### PR TITLE
Child workflow server side retry

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowClient.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClient.java
@@ -103,7 +103,9 @@ import java.util.concurrent.CompletableFuture;
 public interface WorkflowClient {
 
   /** Use this constant as a query type to get a workflow stack trace. */
-  String QUERY_TYPE_STACK_TRCE = "__stack_trace";
+  String QUERY_TYPE_STACK_TRACE = "__stack_trace";
+  /** Replays workflow to the current state and returns empty result or error if replay failed. */
+  String QUERY_TYPE_REPLAY_ONLY = "__replay_only";
 
   /**
    * Creates worker that connects to the local instance of the Cadence Service that listens on a

--- a/src/main/java/com/uber/cadence/common/WorkflowExecutionHistory.java
+++ b/src/main/java/com/uber/cadence/common/WorkflowExecutionHistory.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.common;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.uber.cadence.EventType;
+import com.uber.cadence.HistoryEvent;
+import com.uber.cadence.WorkflowExecution;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.List;
+
+/** Contains workflow execution ids and the history */
+public final class WorkflowExecutionHistory {
+  private final String workflowId;
+  private final String runId;
+  private final List<HistoryEvent> events;
+
+  public WorkflowExecutionHistory(String workflowId, String runId, List<HistoryEvent> events) {
+    this.workflowId = workflowId;
+    this.runId = runId;
+    checkHistory(events);
+    this.events = ImmutableList.copyOf(events);
+  }
+
+  public WorkflowExecutionHistory(WorkflowExecution workflowExecution, List<HistoryEvent> events) {
+    this.workflowId = workflowExecution.getWorkflowId();
+    this.runId = workflowExecution.getRunId();
+    checkHistory(events);
+    this.events = ImmutableList.copyOf(events);
+  }
+
+  public static WorkflowExecutionHistory fromJson(String serialized) {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.registerTypeAdapter(ByteBuffer.class, new ByteBufferJsonDeserializer());
+    Gson gson = gsonBuilder.create();
+    WorkflowExecutionHistory result = gson.fromJson(serialized, WorkflowExecutionHistory.class);
+    checkHistory(result.getEvents());
+    return result;
+  }
+
+  private static void checkHistory(List<HistoryEvent> events) {
+    if (events == null || events.size() == 0) {
+      throw new IllegalArgumentException("Empty history");
+    }
+    HistoryEvent startedEvent = events.get(0);
+    if (startedEvent.getEventType() != EventType.WorkflowExecutionStarted) {
+      throw new IllegalArgumentException(
+          "First event is not WorkflowExecutionStarted but " + startedEvent);
+    }
+    if (startedEvent.getWorkflowExecutionStartedEventAttributes() == null) {
+      throw new IllegalArgumentException("First event is corrupted");
+    }
+  }
+
+  public String toJson() {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    Gson gson = gsonBuilder.create();
+    return gson.toJson(this);
+  }
+
+  public String getWorkflowId() {
+    return workflowId;
+  }
+
+  public String getRunId() {
+    return runId;
+  }
+
+  public WorkflowExecution getWorkflowExecution() {
+    return new WorkflowExecution().setWorkflowId(workflowId).setRunId(runId);
+  }
+
+  public List<HistoryEvent> getEvents() {
+    return events;
+  }
+
+  private static final class ByteBufferJsonDeserializer
+      implements JsonDeserializer<ByteBuffer>, JsonSerializer<ByteBuffer> {
+
+    @Override
+    public JsonElement serialize(ByteBuffer value, Type type, JsonSerializationContext ctx) {
+      if (value.arrayOffset() > 0) {
+        throw new IllegalArgumentException("non zero value array offset: " + value.arrayOffset());
+      }
+      return new JsonPrimitive(Base64.getEncoder().encodeToString(value.array()));
+    }
+
+    @Override
+    public ByteBuffer deserialize(JsonElement e, Type type, JsonDeserializationContext ctx)
+        throws JsonParseException {
+      return ByteBuffer.wrap(Base64.getDecoder().decode(e.getAsString()));
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -96,10 +96,11 @@ public interface DecisionContext extends ReplayAware {
       BiConsumer<byte[], Exception> callback);
 
   /**
-   * Used for backwards compatibility with the code that used local workflow retry when RetryOptions
-   * were specified.
+   * Is the next event in the history is child workflow initiated event and it has attached retry
+   * policy. Used for backwards compatibility with the code that used local workflow retry when
+   * RetryOptions were specified.
    */
-  boolean isChildWorkflowExecutionStartedWithRetryOptions();
+  boolean isServerSideChildWorkflowRetry();
 
   Consumer<Exception> signalWorkflowExecution(
       SignalExternalWorkflowParameters signalParameters, BiConsumer<Void, Exception> callback);

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -95,6 +95,12 @@ public interface DecisionContext extends ReplayAware {
       Consumer<WorkflowExecution> executionCallback,
       BiConsumer<byte[], Exception> callback);
 
+  /**
+   * Used for backwards compatibility with the code that used local workflow retry when RetryOptions
+   * were specified.
+   */
+  boolean isChildWorkflowExecutionStartedWithRetryOptions();
+
   Consumer<Exception> signalWorkflowExecution(
       SignalExternalWorkflowParameters signalParameters, BiConsumer<Void, Exception> callback);
 

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
@@ -168,6 +168,11 @@ final class DecisionContextImpl implements DecisionContext, HistoryEventHandler 
   }
 
   @Override
+  public boolean isChildWorkflowExecutionStartedWithRetryOptions() {
+    return workflowClient.isChildWorkflowExecutionStartedWithRetryOptions();
+  }
+
+  @Override
   public Consumer<Exception> signalWorkflowExecution(
       SignalExternalWorkflowParameters signalParameters, BiConsumer<Void, Exception> callback) {
     return workflowClient.signalWorkflowExecution(signalParameters, callback);

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
@@ -168,7 +168,7 @@ final class DecisionContextImpl implements DecisionContext, HistoryEventHandler 
   }
 
   @Override
-  public boolean isChildWorkflowExecutionStartedWithRetryOptions() {
+  public boolean isServerSideChildWorkflowRetry() {
     return workflowClient.isChildWorkflowExecutionStartedWithRetryOptions();
   }
 

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
@@ -207,11 +207,14 @@ class DecisionsHelper {
     if (!optionalEvent.isPresent()) {
       return true;
     }
+    HistoryEvent event = optionalEvent.get();
+    if (event.getEventType() != EventType.StartChildWorkflowExecutionInitiated) {
+      return false;
+    }
     StartChildWorkflowExecutionInitiatedEventAttributes attr =
-        optionalEvent.get().getStartChildWorkflowExecutionInitiatedEventAttributes();
+        event.getStartChildWorkflowExecutionInitiatedEventAttributes();
     if (attr == null) {
-      throw new NonDeterminisicWorkflowError(
-          "Unknown " + nextDecisionEventId + ". " + NON_DETERMINISTIC_MESSAGE);
+      throw new Error("Corrupted event: " + event);
     }
     return attr.getRetryPolicy() != null;
   }

--- a/src/main/java/com/uber/cadence/internal/replay/StartChildWorkflowExecutionParameters.java
+++ b/src/main/java/com/uber/cadence/internal/replay/StartChildWorkflowExecutionParameters.java
@@ -20,7 +20,9 @@ package com.uber.cadence.internal.replay;
 import com.uber.cadence.ChildPolicy;
 import com.uber.cadence.WorkflowIdReusePolicy;
 import com.uber.cadence.WorkflowType;
+import com.uber.cadence.internal.common.RetryParameters;
 import java.util.Arrays;
+import java.util.Objects;
 
 public final class StartChildWorkflowExecutionParameters {
 
@@ -45,6 +47,8 @@ public final class StartChildWorkflowExecutionParameters {
     private ChildPolicy childPolicy;
 
     private WorkflowIdReusePolicy workflowIdReusePolicy;
+
+    private RetryParameters retryParameters;
 
     public Builder setDomain(String domain) {
       this.domain = domain;
@@ -97,6 +101,11 @@ public final class StartChildWorkflowExecutionParameters {
       return this;
     }
 
+    public Builder setRetryParameters(RetryParameters retryParameters) {
+      this.retryParameters = retryParameters;
+      return this;
+    }
+
     public StartChildWorkflowExecutionParameters build() {
       return new StartChildWorkflowExecutionParameters(
           domain,
@@ -108,7 +117,8 @@ public final class StartChildWorkflowExecutionParameters {
           workflowId,
           workflowType,
           childPolicy,
-          workflowIdReusePolicy);
+          workflowIdReusePolicy,
+          retryParameters);
     }
   }
 
@@ -132,6 +142,8 @@ public final class StartChildWorkflowExecutionParameters {
 
   private final WorkflowIdReusePolicy workflowIdReusePolicy;
 
+  private final RetryParameters retryParameters;
+
   private StartChildWorkflowExecutionParameters(
       String domain,
       byte[] input,
@@ -142,7 +154,8 @@ public final class StartChildWorkflowExecutionParameters {
       String workflowId,
       WorkflowType workflowType,
       ChildPolicy childPolicy,
-      WorkflowIdReusePolicy workflowIdReusePolicy) {
+      WorkflowIdReusePolicy workflowIdReusePolicy,
+      RetryParameters retryParameters) {
     this.domain = domain;
     this.input = input;
     this.control = control;
@@ -153,6 +166,7 @@ public final class StartChildWorkflowExecutionParameters {
     this.workflowType = workflowType;
     this.childPolicy = childPolicy;
     this.workflowIdReusePolicy = workflowIdReusePolicy;
+    this.retryParameters = retryParameters;
   }
 
   public String getDomain() {
@@ -195,6 +209,46 @@ public final class StartChildWorkflowExecutionParameters {
     return workflowIdReusePolicy;
   }
 
+  public RetryParameters getRetryParameters() {
+    return retryParameters;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StartChildWorkflowExecutionParameters that = (StartChildWorkflowExecutionParameters) o;
+    return executionStartToCloseTimeoutSeconds == that.executionStartToCloseTimeoutSeconds
+        && taskStartToCloseTimeoutSeconds == that.taskStartToCloseTimeoutSeconds
+        && Objects.equals(domain, that.domain)
+        && Objects.equals(control, that.control)
+        && Arrays.equals(input, that.input)
+        && Objects.equals(taskList, that.taskList)
+        && Objects.equals(workflowId, that.workflowId)
+        && Objects.equals(workflowType, that.workflowType)
+        && childPolicy == that.childPolicy
+        && workflowIdReusePolicy == that.workflowIdReusePolicy
+        && Objects.equals(retryParameters, that.retryParameters);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            domain,
+            control,
+            executionStartToCloseTimeoutSeconds,
+            taskList,
+            taskStartToCloseTimeoutSeconds,
+            workflowId,
+            workflowType,
+            childPolicy,
+            workflowIdReusePolicy,
+            retryParameters);
+    result = 31 * result + Arrays.hashCode(input);
+    return result;
+  }
+
   @Override
   public String toString() {
     return "StartChildWorkflowExecutionParameters{"
@@ -222,6 +276,8 @@ public final class StartChildWorkflowExecutionParameters {
         + childPolicy
         + ", workflowIdReusePolicy="
         + workflowIdReusePolicy
+        + ", retryParameters="
+        + retryParameters
         + '}';
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -549,6 +549,11 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     }
 
     @Override
+    public boolean isChildWorkflowExecutionStartedWithRetryOptions() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
     public Consumer<Exception> signalWorkflowExecution(
         SignalExternalWorkflowParameters signalParameters, BiConsumer<Void, Exception> callback) {
       throw new UnsupportedOperationException("not implemented");

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -549,7 +549,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     }
 
     @Override
-    public boolean isChildWorkflowExecutionStartedWithRetryOptions() {
+    public boolean isServerSideChildWorkflowRetry() {
       throw new UnsupportedOperationException("not implemented");
     }
 

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -248,6 +248,8 @@ final class SyncDecisionContext implements WorkflowInterceptor {
       byte[] input,
       CompletablePromise<WorkflowExecution> executionResult) {
     RetryOptions retryOptions = options.getRetryOptions();
+    // This condition is for backwards compatibility with the code that
+    // used client side retry before the server side retry existed.
     if (retryOptions != null && !context.isServerSideChildWorkflowRetry()) {
       ChildWorkflowOptions o1 =
           new ChildWorkflowOptions.Builder()

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -248,7 +248,7 @@ final class SyncDecisionContext implements WorkflowInterceptor {
       byte[] input,
       CompletablePromise<WorkflowExecution> executionResult) {
     RetryOptions retryOptions = options.getRetryOptions();
-    if (retryOptions != null && !context.isChildWorkflowExecutionStartedWithRetryOptions()) {
+    if (retryOptions != null && !context.isServerSideChildWorkflowRetry()) {
       ChildWorkflowOptions o1 =
           new ChildWorkflowOptions.Builder()
               .setTaskList(options.getTaskList())

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -248,7 +248,7 @@ final class SyncDecisionContext implements WorkflowInterceptor {
       byte[] input,
       CompletablePromise<WorkflowExecution> executionResult) {
     RetryOptions retryOptions = options.getRetryOptions();
-    if (retryOptions != null /* && !context.isChildWorkflowExecutionStartedWithRetryOptions()*/) {
+    if (retryOptions != null && !context.isChildWorkflowExecutionStartedWithRetryOptions()) {
       ChildWorkflowOptions o1 =
           new ChildWorkflowOptions.Builder()
               .setTaskList(options.getTaskList())

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -430,7 +430,7 @@ final class SyncDecisionContext implements WorkflowInterceptor {
       throw new IllegalArgumentException(
           "No value found for mutableSideEffectId="
               + id
-              + ", during replay it usually indicatesa  different workflow runId than the original one");
+              + ", during replay it usually indicates a different workflow runId than the original one");
     }
     byte[] binaryResult = optionalBytes.get();
     // An optimization that avoids unnecessary deserialization of the result.

--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflow.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflow.java
@@ -123,7 +123,10 @@ class SyncWorkflow implements ReplayWorkflow {
 
   @Override
   public byte[] query(WorkflowQuery query) {
-    if (WorkflowClient.QUERY_TYPE_STACK_TRCE.equals(query.getQueryType())) {
+    if (WorkflowClient.QUERY_TYPE_REPLAY_ONLY.equals(query.getQueryType())) {
+      return new byte[] {};
+    }
+    if (WorkflowClient.QUERY_TYPE_STACK_TRACE.equals(query.getQueryType())) {
       return dataConverter.toData(runner.stackTrace());
     }
     return workflowProc.query(query.getQueryType(), query.getQueryArgs());

--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
@@ -20,6 +20,7 @@ package com.uber.cadence.internal.sync;
 import com.uber.cadence.PollForDecisionTaskResponse;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.converter.DataConverter;
+import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.replay.DeciderCache;
 import com.uber.cadence.internal.replay.ReplayDecisionTaskHandler;
 import com.uber.cadence.internal.worker.DecisionTaskHandler;
@@ -124,6 +125,19 @@ public class SyncWorkflowWorker implements Consumer<PollForDecisionTaskResponse>
     DataConverter dataConverter = options.getDataConverter();
     byte[] serializedArgs = dataConverter.toData(args);
     byte[] result = worker.queryWorkflowExecution(execution, queryType, serializedArgs);
+    return dataConverter.fromData(result, resultClass, resultType);
+  }
+
+  public <R> R queryWorkflowExecution(
+      WorkflowExecutionUtils.SerializedHistory history,
+      String queryType,
+      Class<R> resultClass,
+      Type resultType,
+      Object[] args)
+      throws Exception {
+    DataConverter dataConverter = options.getDataConverter();
+    byte[] serializedArgs = dataConverter.toData(args);
+    byte[] result = worker.queryWorkflowExecution(history, queryType, serializedArgs);
     return dataConverter.fromData(result, resultClass, resultType);
   }
 

--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
@@ -19,8 +19,8 @@ package com.uber.cadence.internal.sync;
 
 import com.uber.cadence.PollForDecisionTaskResponse;
 import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.common.WorkflowExecutionHistory;
 import com.uber.cadence.converter.DataConverter;
-import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.replay.DeciderCache;
 import com.uber.cadence.internal.replay.ReplayDecisionTaskHandler;
 import com.uber.cadence.internal.worker.DecisionTaskHandler;
@@ -129,7 +129,7 @@ public class SyncWorkflowWorker implements Consumer<PollForDecisionTaskResponse>
   }
 
   public <R> R queryWorkflowExecution(
-      WorkflowExecutionUtils.SerializedHistory history,
+      WorkflowExecutionHistory history,
       String queryType,
       Class<R> resultClass,
       Type resultType,

--- a/src/main/java/com/uber/cadence/internal/testservice/RetryState.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/RetryState.java
@@ -103,7 +103,7 @@ final class RetryState {
     return (int) TimeUnit.MILLISECONDS.toSeconds((long) Math.ceil((double) backoffInterval));
   }
 
-  private static RetryPolicy validateRetryPolicy(RetryPolicy policy) throws BadRequestError {
+  static RetryPolicy validateRetryPolicy(RetryPolicy policy) throws BadRequestError {
     if (policy.getInitialIntervalInSeconds() <= 0) {
       throw new BadRequestError("InitialIntervalInSeconds must be greater than 0 on retry policy.");
     }

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -407,7 +407,8 @@ class StateMachines {
             .setTaskList(d.getTaskList())
             .setWorkflowId(d.getWorkflowId())
             .setWorkflowIdReusePolicy(d.getWorkflowIdReusePolicy())
-            .setWorkflowType(d.getWorkflowType());
+            .setWorkflowType(d.getWorkflowType())
+            .setRetryPolicy(d.getRetryPolicy());
     HistoryEvent event =
         new HistoryEvent()
             .setEventType(EventType.StartChildWorkflowExecutionInitiated)
@@ -426,7 +427,8 @@ class StateMachines {
                   .setTaskList(d.getTaskList())
                   .setWorkflowId(d.getWorkflowId())
                   .setWorkflowIdReusePolicy(d.getWorkflowIdReusePolicy())
-                  .setWorkflowType(d.getWorkflowType());
+                  .setWorkflowType(d.getWorkflowType())
+                  .setRetryPolicy(d.getRetryPolicy());
           if (d.isSetInput()) {
             startChild.setInput(d.getInput());
           }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -518,16 +518,49 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       StartChildWorkflowExecutionDecisionAttributes a,
       long decisionTaskCompletedId)
       throws BadRequestError, InternalServiceError {
-    validateStartChildWorkflow(a);
+    validateStartChildExecutionAttributes(a);
     StateMachine<ChildWorkflowData> child = StateMachines.newChildWorkflowStateMachine(service);
     childWorkflows.put(ctx.getNextEventId(), child);
     child.action(StateMachines.Action.INITIATE, ctx, a, decisionTaskCompletedId);
     ctx.lockTimer();
   }
 
-  // TODO
-  private void validateStartChildWorkflow(StartChildWorkflowExecutionDecisionAttributes a)
-      throws BadRequestError {
+  /** Clone of the validateStartChildExecutionAttributes from historyEngine.go */
+  private void validateStartChildExecutionAttributes(
+      StartChildWorkflowExecutionDecisionAttributes a) throws BadRequestError {
+    if (a == null) {
+      throw new BadRequestError(
+          "StartChildWorkflowExecutionDecisionAttributes is not set on decision.");
+    }
+
+    if (a.getWorkflowId().isEmpty()) {
+      throw new BadRequestError("Required field WorkflowID is not set on decision.");
+    }
+
+    if (a.getWorkflowType() == null || a.getWorkflowType().getName().isEmpty()) {
+      throw new BadRequestError("Required field WorkflowType is not set on decision.");
+    }
+
+    if (a.getChildPolicy() == null) {
+      throw new BadRequestError("Required field ChildPolicy is not set on decision.");
+    }
+
+    // Inherit tasklist from parent workflow execution if not provided on decision
+    if (a.getTaskList() == null || a.getTaskList().getName().isEmpty()) {
+      a.setTaskList(startRequest.getTaskList());
+    }
+
+    // Inherit workflow timeout from parent workflow execution if not provided on decision
+    if (a.getExecutionStartToCloseTimeoutSeconds() <= 0) {
+      a.setExecutionStartToCloseTimeoutSeconds(
+          startRequest.getExecutionStartToCloseTimeoutSeconds());
+    }
+
+    // Inherit decision task timeout from parent workflow execution if not provided on decision
+    if (a.getTaskStartToCloseTimeoutSeconds() <= 0) {
+      a.setTaskStartToCloseTimeoutSeconds(startRequest.getTaskStartToCloseTimeoutSeconds());
+    }
+
     RetryPolicy retryPolicy = a.getRetryPolicy();
     if (retryPolicy != null) {
       RetryState.validateRetryPolicy(retryPolicy);

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
@@ -130,11 +130,9 @@ public final class WorkflowWorker
     HistoryEvent startedEvent = events.get(0);
     WorkflowExecutionStartedEventAttributes started =
         startedEvent.getWorkflowExecutionStartedEventAttributes();
-    WorkflowExecution execution =
-        new WorkflowExecution().setRunId("runId").setWorkflowId("workflowId");
     PollForDecisionTaskResponse task;
     task = new PollForDecisionTaskResponse();
-    task.setWorkflowExecution(execution);
+    task.setWorkflowExecution(history.getWorkflowExecution());
     task.setStartedEventId(Long.MAX_VALUE);
     task.setPreviousStartedEventId(Long.MAX_VALUE);
     task.setNextPageToken(nextPageToken);
@@ -154,7 +152,7 @@ public final class WorkflowWorker
       if (r.getErrorMessage() != null) {
         throw new RuntimeException(
             "query failure for "
-                + execution
+                + history.getWorkflowExecution()
                 + ", queryType="
                 + queryType
                 + ", args="

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
@@ -126,10 +126,6 @@ public final class WorkflowWorker
   private byte[] queryWorkflowExecution(
       String queryType, byte[] args, WorkflowExecutionHistory history, byte[] nextPageToken)
       throws Exception {
-    List<HistoryEvent> events = history.getEvents();
-    HistoryEvent startedEvent = events.get(0);
-    WorkflowExecutionStartedEventAttributes started =
-        startedEvent.getWorkflowExecutionStartedEventAttributes();
     PollForDecisionTaskResponse task;
     task = new PollForDecisionTaskResponse();
     task.setWorkflowExecution(history.getWorkflowExecution());
@@ -139,6 +135,10 @@ public final class WorkflowWorker
     WorkflowQuery query = new WorkflowQuery();
     query.setQueryType(queryType).setQueryArgs(args);
     task.setQuery(query);
+    List<HistoryEvent> events = history.getEvents();
+    HistoryEvent startedEvent = events.get(0);
+    WorkflowExecutionStartedEventAttributes started =
+        startedEvent.getWorkflowExecutionStartedEventAttributes();
     if (started == null) {
       throw new IllegalStateException(
           "First event of the history is not  WorkflowExecutionStarted: " + startedEvent);

--- a/src/main/java/com/uber/cadence/testing/WorkflowReplayer.java
+++ b/src/main/java/com/uber/cadence/testing/WorkflowReplayer.java
@@ -25,8 +25,17 @@ import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.worker.Worker;
 import java.io.File;
 
+/** Replays a workflow given its history. Useful for backwards compatibility testing. */
 public final class WorkflowReplayer {
 
+  /**
+   * Replays workflow from a resource that contains a json serialized history.
+   *
+   * @param resourceName name of the resource
+   * @param workflowClass workflow implementation class to replay
+   * @param moreWorkflowClasses optional additional workflow implementation classes
+   * @throws Exception if replay failed for any reason.
+   */
   public static void replayWorkflowExecutionFromResource(
       String resourceName, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
       throws Exception {
@@ -34,12 +43,40 @@ public final class WorkflowReplayer {
     replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
   }
 
+  /**
+   * Replays workflow from a file
+   *
+   * @param historyFile file that contains a json serialized history.
+   * @param workflowClass s workflow implementation class to replay
+   * @param moreWorkflowClasses optional additional workflow implementation classes
+   * @throws Exception if replay failed for any reason.
+   */
   public static void replayWorkflowExecution(
       File historyFile, Class<?> workflowClass, Class<?>... moreWorkflowClasses) throws Exception {
     WorkflowExecutionHistory history = WorkflowExecutionUtils.readHistory(historyFile);
     replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
   }
 
+  /**
+   * Replays workflow from a json serialized history. The json should be in the format:
+   *
+   * <pre>
+   * {
+   *   "workflowId": "...",
+   *   "runId": "...",
+   *   "events": [
+   *     ...
+   *   ]
+   * }
+   * </pre>
+   *
+   * RunId <b>must</b> match the one used to generate the serialized history.
+   *
+   * @param jsonSerializedHistory string that contains the json serialized history.
+   * @param workflowClass s workflow implementation class to replay
+   * @param moreWorkflowClasses optional additional workflow implementation classes
+   * @throws Exception if replay failed for any reason.
+   */
   public static void replayWorkflowExecution(
       String jsonSerializedHistory, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
       throws Exception {
@@ -47,6 +84,15 @@ public final class WorkflowReplayer {
     replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
   }
 
+  /**
+   * Replays workflow from a {@link WorkflowExecutionHistory}. RunId <b>must</b> match the one used
+   * to generate the serialized history.
+   *
+   * @param history object that contains the workflow ids and the events.
+   * @param workflowClass s workflow implementation class to replay
+   * @param moreWorkflowClasses optional additional workflow implementation classes
+   * @throws Exception if replay failed for any reason.
+   */
   public static void replayWorkflowExecution(
       WorkflowExecutionHistory history, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
       throws Exception {

--- a/src/main/java/com/uber/cadence/testing/WorkflowReplayer.java
+++ b/src/main/java/com/uber/cadence/testing/WorkflowReplayer.java
@@ -20,6 +20,7 @@ package com.uber.cadence.testing;
 import com.google.common.collect.ObjectArrays;
 import com.uber.cadence.TaskList;
 import com.uber.cadence.WorkflowExecutionStartedEventAttributes;
+import com.uber.cadence.common.WorkflowExecutionHistory;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.worker.Worker;
 import java.io.File;
@@ -29,30 +30,25 @@ public final class WorkflowReplayer {
   public static void replayWorkflowExecutionFromResource(
       String resourceName, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
       throws Exception {
-    WorkflowExecutionUtils.SerializedHistory history =
-        WorkflowExecutionUtils.readHistoryFromResource(resourceName);
+    WorkflowExecutionHistory history = WorkflowExecutionUtils.readHistoryFromResource(resourceName);
     replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
   }
 
   public static void replayWorkflowExecution(
       File historyFile, Class<?> workflowClass, Class<?>... moreWorkflowClasses) throws Exception {
-    WorkflowExecutionUtils.SerializedHistory history =
-        WorkflowExecutionUtils.readHistory(historyFile);
+    WorkflowExecutionHistory history = WorkflowExecutionUtils.readHistory(historyFile);
     replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
   }
 
   public static void replayWorkflowExecution(
       String jsonSerializedHistory, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
       throws Exception {
-    WorkflowExecutionUtils.SerializedHistory history =
-        WorkflowExecutionUtils.deserializeHistory(jsonSerializedHistory);
+    WorkflowExecutionHistory history = WorkflowExecutionHistory.fromJson(jsonSerializedHistory);
     replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
   }
 
   public static void replayWorkflowExecution(
-      WorkflowExecutionUtils.SerializedHistory history,
-      Class<?> workflowClass,
-      Class<?>... moreWorkflowClasses)
+      WorkflowExecutionHistory history, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
       throws Exception {
     WorkflowExecutionStartedEventAttributes attr =
         history.getEvents().get(0).getWorkflowExecutionStartedEventAttributes();

--- a/src/main/java/com/uber/cadence/testing/WorkflowReplayer.java
+++ b/src/main/java/com/uber/cadence/testing/WorkflowReplayer.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.testing;
+
+import com.google.common.collect.ObjectArrays;
+import com.uber.cadence.TaskList;
+import com.uber.cadence.WorkflowExecutionStartedEventAttributes;
+import com.uber.cadence.internal.common.WorkflowExecutionUtils;
+import com.uber.cadence.worker.Worker;
+import java.io.File;
+
+public final class WorkflowReplayer {
+
+  public static void replayWorkflowExecutionFromResource(
+      String resourceName, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
+      throws Exception {
+    WorkflowExecutionUtils.SerializedHistory history =
+        WorkflowExecutionUtils.readHistoryFromResource(resourceName);
+    replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
+  }
+
+  public static void replayWorkflowExecution(
+      File historyFile, Class<?> workflowClass, Class<?>... moreWorkflowClasses) throws Exception {
+    WorkflowExecutionUtils.SerializedHistory history =
+        WorkflowExecutionUtils.readHistory(historyFile);
+    replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
+  }
+
+  public static void replayWorkflowExecution(
+      String jsonSerializedHistory, Class<?> workflowClass, Class<?>... moreWorkflowClasses)
+      throws Exception {
+    WorkflowExecutionUtils.SerializedHistory history =
+        WorkflowExecutionUtils.deserializeHistory(jsonSerializedHistory);
+    replayWorkflowExecution(history, workflowClass, moreWorkflowClasses);
+  }
+
+  public static void replayWorkflowExecution(
+      WorkflowExecutionUtils.SerializedHistory history,
+      Class<?> workflowClass,
+      Class<?>... moreWorkflowClasses)
+      throws Exception {
+    WorkflowExecutionStartedEventAttributes attr =
+        history.getEvents().get(0).getWorkflowExecutionStartedEventAttributes();
+    TaskList taskList = attr.getTaskList();
+    TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
+    Worker worker = testEnv.newWorker(taskList.getName());
+    worker.registerWorkflowImplementationTypes(
+        ObjectArrays.concat(moreWorkflowClasses, workflowClass));
+    worker.replayWorkflowExecution(history);
+  }
+}

--- a/src/main/java/com/uber/cadence/worker/Worker.java
+++ b/src/main/java/com/uber/cadence/worker/Worker.java
@@ -22,9 +22,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.uber.cadence.PollForDecisionTaskResponse;
-import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.converter.DataConverter;
+import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.NoopScope;
 import com.uber.cadence.internal.replay.DeciderCache;
@@ -42,7 +42,6 @@ import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.WorkflowMethod;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
-import java.lang.reflect.Type;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -277,58 +276,33 @@ public final class Worker {
   }
 
   /**
-   * This is an utility method to query a workflow execution using this particular instance of a
-   * worker. It gets a history from a Cadence service, replays a workflow code and then runs the
-   * query. This method is useful to troubleshoot workflows by running them in a debugger. To work
-   * the workflow implementation type must be registered with this worker. In most cases using
-   * {@link WorkflowClient} to query workflows is preferable, as it doesn't require workflow
-   * implementation code to be available. There is no need to call {@link #start()} to be able to
-   * call this method.
+   * This is an utility method to replay a workflow execution using this particular instance of a
+   * worker. This method is useful to troubleshoot workflows by running them in a debugger. To work
+   * the workflow implementation type must be registered with this worker. There is no need to call
+   * {@link #start()} to be able to call this method.
    *
-   * @param execution workflow execution to replay and then query locally
-   * @param queryType query type to execute
-   * @param returnType return type of the query result
-   * @param args query arguments
-   * @param <R> type of the query result
-   * @return query result
+   * @param history workflow execution history to replay
    * @throws Exception if replay failed for any reason
    */
-  public <R> R queryWorkflowExecution(
-      WorkflowExecution execution, String queryType, Class<R> returnType, Object... args)
+  public void replayWorkflowExecution(WorkflowExecutionUtils.SerializedHistory history)
       throws Exception {
-    return queryWorkflowExecution(execution, queryType, returnType, returnType, args);
+    workflowWorker.queryWorkflowExecution(
+        history, WorkflowClient.QUERY_TYPE_STACK_TRCE, String.class, String.class, new Object[] {});
   }
 
   /**
-   * This is an utility method to query a workflow execution using this particular instance of a
-   * worker. It gets a history from a Cadence service, replays a workflow code and then runs the
-   * query. This method is useful to troubleshoot workflows by running them in a debugger. To work
-   * the workflow implementation type must be registered with this worker. In most cases using
-   * {@link WorkflowClient} to query workflows is preferable, as it doesn't require workflow
-   * implementation code to be available. There is no need to call {@link #start()} to be able to
-   * call this method.
+   * This is an utility method to replay a workflow execution using this particular instance of a
+   * worker. This method is useful to troubleshoot workflows by running them in a debugger. To work
+   * the workflow implementation type must be registered with this worker. There is no need to call
+   * {@link #start()} to be able to call this method.
    *
-   * @param execution workflow execution to replay and then query locally
-   * @param queryType query type to execute
-   * @param resultClass return class of the query result
-   * @param resultType return type of the query result. Useful when resultClass is a generic type.
-   * @param args query arguments
-   * @param <R> type of the query result
-   * @return query result
+   * @param jsonSerializedHistory workflow execution history in JSON format to replay
    * @throws Exception if replay failed for any reason
    */
-  public <R> R queryWorkflowExecution(
-      WorkflowExecution execution,
-      String queryType,
-      Class<R> resultClass,
-      Type resultType,
-      Object... args)
-      throws Exception {
-    if (workflowWorker == null) {
-      throw new IllegalStateException("disableWorkflowWorker is set in worker options");
-    }
-    return workflowWorker.queryWorkflowExecution(
-        execution, queryType, resultClass, resultType, args);
+  public void replayWorkflowExecution(String jsonSerializedHistory) throws Exception {
+    WorkflowExecutionUtils.SerializedHistory history =
+        WorkflowExecutionUtils.deserializeHistory(jsonSerializedHistory);
+    replayWorkflowExecution(history);
   }
 
   public String getTaskList() {

--- a/src/main/java/com/uber/cadence/worker/Worker.java
+++ b/src/main/java/com/uber/cadence/worker/Worker.java
@@ -286,7 +286,11 @@ public final class Worker {
    */
   public void replayWorkflowExecution(WorkflowExecutionHistory history) throws Exception {
     workflowWorker.queryWorkflowExecution(
-        history, WorkflowClient.QUERY_TYPE_STACK_TRCE, String.class, String.class, new Object[] {});
+        history,
+        WorkflowClient.QUERY_TYPE_REPLAY_ONLY,
+        String.class,
+        String.class,
+        new Object[] {});
   }
 
   /**

--- a/src/main/java/com/uber/cadence/worker/Worker.java
+++ b/src/main/java/com/uber/cadence/worker/Worker.java
@@ -23,8 +23,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.uber.cadence.PollForDecisionTaskResponse;
 import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.common.WorkflowExecutionHistory;
 import com.uber.cadence.converter.DataConverter;
-import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.NoopScope;
 import com.uber.cadence.internal.replay.DeciderCache;
@@ -284,8 +284,7 @@ public final class Worker {
    * @param history workflow execution history to replay
    * @throws Exception if replay failed for any reason
    */
-  public void replayWorkflowExecution(WorkflowExecutionUtils.SerializedHistory history)
-      throws Exception {
+  public void replayWorkflowExecution(WorkflowExecutionHistory history) throws Exception {
     workflowWorker.queryWorkflowExecution(
         history, WorkflowClient.QUERY_TYPE_STACK_TRCE, String.class, String.class, new Object[] {});
   }
@@ -300,8 +299,7 @@ public final class Worker {
    * @throws Exception if replay failed for any reason
    */
   public void replayWorkflowExecution(String jsonSerializedHistory) throws Exception {
-    WorkflowExecutionUtils.SerializedHistory history =
-        WorkflowExecutionUtils.deserializeHistory(jsonSerializedHistory);
+    WorkflowExecutionHistory history = WorkflowExecutionHistory.fromJson(jsonSerializedHistory);
     replayWorkflowExecution(history);
   }
 

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -125,7 +125,7 @@ public class WorkflowTest {
 
   @Rule
   public Timeout globalTimeout =
-      Timeout.seconds(DEBUGGER_TIMEOUTS ? 500 : skipDockerService ? 20 : 30);
+      Timeout.seconds(DEBUGGER_TIMEOUTS ? 500 : skipDockerService ? 5 : 30);
 
   @Rule
   public TestWatcher watchman =

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -98,7 +98,7 @@ public class WorkflowTest {
    * When set to true increases test, activity and workflow timeouts to large values to support
    * stepping through code in a debugger without timing out.
    */
-  private static final boolean DEBUGGER_TIMEOUTS = true;
+  private static final boolean DEBUGGER_TIMEOUTS = false;
 
   public static final String ANNOTATION_TASK_LIST = "WorkflowTest-testExecute[Docker]";
 

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -659,12 +659,12 @@ public class WorkflowTest {
             "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
     WorkflowExecution execution = workflowStub.start(taskList);
     sleep(Duration.ofMillis(500));
-    String stackTrace = workflowStub.query(WorkflowClient.QUERY_TYPE_STACK_TRCE, String.class);
+    String stackTrace = workflowStub.query(WorkflowClient.QUERY_TYPE_STACK_TRACE, String.class);
     assertTrue(stackTrace, stackTrace.contains("WorkflowTest$TestSyncWorkflowImpl.execute"));
     assertTrue(stackTrace, stackTrace.contains("activityWithDelay"));
     // Test stub created from workflow execution.
     workflowStub = workflowClient.newUntypedWorkflowStub(execution, workflowStub.getWorkflowType());
-    stackTrace = workflowStub.query(WorkflowClient.QUERY_TYPE_STACK_TRCE, String.class);
+    stackTrace = workflowStub.query(WorkflowClient.QUERY_TYPE_STACK_TRACE, String.class);
     assertTrue(stackTrace, stackTrace.contains("WorkflowTest$TestSyncWorkflowImpl.execute"));
     assertTrue(stackTrace, stackTrace.contains("activityWithDelay"));
     String result = workflowStub.getResult(String.class);
@@ -2349,6 +2349,9 @@ public class WorkflowTest {
    */
   @Test
   public void testChildWorkflowRetryReplay() throws Exception {
+    if (!testName.getMethodName().equals("testChildWorkflowRetryReplay[Docker Sticky OFF]")) {
+      return;
+    }
     WorkflowReplayer.replayWorkflowExecutionFromResource(
         "testChildWorkflowRetryHistory.json", TestChildWorkflowRetryWorkflow.class);
   }

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -126,7 +126,7 @@ public class WorkflowTest {
 
   @Rule
   public Timeout globalTimeout =
-      Timeout.seconds(DEBUGGER_TIMEOUTS ? 500 : skipDockerService ? 5 : 30);
+      Timeout.seconds(DEBUGGER_TIMEOUTS ? 500 : skipDockerService ? 15 : 30);
 
   @Rule
   public TestWatcher watchman =

--- a/src/test/resources/testChildWorkflowRetryHistory.json
+++ b/src/test/resources/testChildWorkflowRetryHistory.json
@@ -1,0 +1,602 @@
+{
+"workflowId": "8f659aba-7b3d-47c8-a242-43e7047fa8f1",
+"runId": "39e72b76-9301-42d2-b7f4-e77399e39382",
+"history": [
+  {
+    "eventId": 1,
+    "timestamp": 1542765094920643200,
+    "eventType": "WorkflowExecutionStarted",
+    "version": -24,
+    "workflowExecutionStartedEventAttributes": {
+      "workflowType": {
+        "name": "TestWorkflow1::execute"
+      },
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "executionStartToCloseTimeoutSeconds": 20,
+      "taskStartToCloseTimeoutSeconds": 2,
+      "identity": ""
+    }
+  },
+  {
+    "eventId": 2,
+    "timestamp": 1542765094920696900,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 3,
+    "timestamp": 1542765094942935700,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 2,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "53bfb340-59e9-4dda-ad31-98e4dec021e4"
+    }
+  },
+  {
+    "eventId": 4,
+    "timestamp": 1542765095058754700,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 2,
+      "startedEventId": 3,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 5,
+    "timestamp": 1542765095058875400,
+    "eventType": "MarkerRecorded",
+    "version": -24,
+    "markerRecordedEventAttributes": {
+      "markerName": "MutableSideEffect",
+      "details": "eyJpZCI6IjY1N2ViMjVmLTUzNjktM2JhOS1hODMwLWFjNjk4YWI0MzZjMyIsImV2ZW50SWQiOjUsImRhdGEiOlsxMjMsMzQsMTA1LDExMCwxMDUsMTE2LDEwNSw5NywxMDgsNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsOTgsOTcsOTksMTA3LDExMSwxMDIsMTAyLDY3LDExMSwxMDEsMTAyLDEwMiwxMDUsOTksMTA1LDEwMSwxMTAsMTE2LDM0LDU4LDUwLDQ2LDQ4LDQ0LDM0LDEwMSwxMjAsMTEyLDEwNSwxMTQsOTcsMTE2LDEwNSwxMTEsMTEwLDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw1Niw1NCw1Miw0OCw0OCw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDEwOSw5NywxMjAsMTA1LDEwOSwxMTcsMTA5LDY1LDExNiwxMTYsMTAxLDEwOSwxMTIsMTE2LDExNSwzNCw1OCw1MSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw3MywxMTAsMTE2LDEwMSwxMTQsMTE4LDk3LDEwOCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNDksNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDAsMTExLDc4LDExMSwxMTYsODIsMTAxLDExNiwxMTQsMTIxLDM0LDU4LDExMCwxMTcsMTA4LDEwOCwxMjVdLCJhY2Nlc3NDb3VudCI6MH0=",
+      "decisionTaskCompletedEventId": 4
+    }
+  },
+  {
+    "eventId": 6,
+    "timestamp": 1542765095058945500,
+    "eventType": "StartChildWorkflowExecutionInitiated",
+    "version": -24,
+    "startChildWorkflowExecutionInitiatedEventAttributes": {
+      "domain": "UnitTest",
+      "workflowId": "6e72d25c-f4c6-3bc2-abf6-feaad35b8dfb",
+      "workflowType": {
+        "name": "ITestChild::execute"
+      },
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "executionStartToCloseTimeoutSeconds": 500,
+      "taskStartToCloseTimeoutSeconds": 2,
+      "childPolicy": "TERMINATE",
+      "decisionTaskCompletedEventId": 4,
+      "workflowIdReusePolicy": "AllowDuplicateFailedOnly"
+    }
+  },
+  {
+    "eventId": 7,
+    "timestamp": 1542765095080350200,
+    "eventType": "ChildWorkflowExecutionStarted",
+    "version": -24,
+    "childWorkflowExecutionStartedEventAttributes": {
+      "domain": "UnitTest",
+      "initiatedEventId": 6,
+      "workflowExecution": {
+        "workflowId": "6e72d25c-f4c6-3bc2-abf6-feaad35b8dfb",
+        "runId": "7e222099-98b1-410a-bf59-8df80e6ea26a"
+      },
+      "workflowType": {
+        "name": "ITestChild::execute"
+      }
+    }
+  },
+  {
+    "eventId": 8,
+    "timestamp": 1542765095080377200,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 9,
+    "timestamp": 1542765095103455700,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 8,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "3ed0820b-d7a2-4168-8324-4f31397b313c"
+    }
+  },
+  {
+    "eventId": 10,
+    "timestamp": 1542765095132213500,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 8,
+      "startedEventId": 9,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 11,
+    "timestamp": 1542765095329878200,
+    "eventType": "ChildWorkflowExecutionFailed",
+    "version": -24,
+    "childWorkflowExecutionFailedEventAttributes": {
+      "reason": "java.lang.UnsupportedOperationException",
+      "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUiLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkQW5ncnlDaGlsZC5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIzMDIpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9",
+      "domain": "UnitTest",
+      "workflowExecution": {
+        "workflowId": "6e72d25c-f4c6-3bc2-abf6-feaad35b8dfb",
+        "runId": "7e222099-98b1-410a-bf59-8df80e6ea26a"
+      },
+      "workflowType": {
+        "name": "ITestChild::execute"
+      },
+      "initiatedEventId": 6,
+      "startedEventId": 7
+    }
+  },
+  {
+    "eventId": 12,
+    "timestamp": 1542765095329890500,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 13,
+    "timestamp": 1542765095397502400,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 12,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "18512bad-33b0-42cb-a27a-c553a79c6a0b"
+    }
+  },
+  {
+    "eventId": 14,
+    "timestamp": 1542765095437980500,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 12,
+      "startedEventId": 13,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 15,
+    "timestamp": 1542765095437996700,
+    "eventType": "TimerStarted",
+    "version": -24,
+    "timerStartedEventAttributes": {
+      "timerId": "2",
+      "startToFireTimeoutSeconds": 1,
+      "decisionTaskCompletedEventId": 14
+    }
+  },
+  {
+    "eventId": 16,
+    "timestamp": 1542765096441932600,
+    "eventType": "TimerFired",
+    "version": -24,
+    "timerFiredEventAttributes": {
+      "timerId": "2",
+      "startedEventId": 15
+    }
+  },
+  {
+    "eventId": 17,
+    "timestamp": 1542765096442007900,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 18,
+    "timestamp": 1542765096458707700,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 17,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "98d30e80-db84-44b8-a15b-9ddd5cb8a0e8"
+    }
+  },
+  {
+    "eventId": 19,
+    "timestamp": 1542765096486315200,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 17,
+      "startedEventId": 18,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 20,
+    "timestamp": 1542765096486330200,
+    "eventType": "MarkerRecorded",
+    "version": -24,
+    "markerRecordedEventAttributes": {
+      "markerName": "MutableSideEffect",
+      "details": "eyJpZCI6IjY1N2ViMjVmLTUzNjktM2JhOS1hODMwLWFjNjk4YWI0MzZjMyIsImV2ZW50SWQiOjIwLCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw1MCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNTYsNTQsNTIsNDgsNDgsNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw2NSwxMTYsMTE2LDEwMSwxMDksMTEyLDExNiwxMTUsMzQsNTgsNTEsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsMTAwLDExMSw3OCwxMTEsMTE2LDgyLDEwMSwxMTYsMTE0LDEyMSwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsMTI1XSwiYWNjZXNzQ291bnQiOjF9",
+      "decisionTaskCompletedEventId": 19
+    }
+  },
+  {
+    "eventId": 21,
+    "timestamp": 1542765096486402200,
+    "eventType": "StartChildWorkflowExecutionInitiated",
+    "version": -24,
+    "startChildWorkflowExecutionInitiatedEventAttributes": {
+      "domain": "UnitTest",
+      "workflowId": "fc1cb522-dd1c-3138-b5da-6c838c7f30f3",
+      "workflowType": {
+        "name": "ITestChild::execute"
+      },
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "executionStartToCloseTimeoutSeconds": 500,
+      "taskStartToCloseTimeoutSeconds": 2,
+      "childPolicy": "TERMINATE",
+      "decisionTaskCompletedEventId": 19,
+      "workflowIdReusePolicy": "AllowDuplicateFailedOnly"
+    }
+  },
+  {
+    "eventId": 22,
+    "timestamp": 1542765096509906300,
+    "eventType": "ChildWorkflowExecutionStarted",
+    "version": -24,
+    "childWorkflowExecutionStartedEventAttributes": {
+      "domain": "UnitTest",
+      "initiatedEventId": 21,
+      "workflowExecution": {
+        "workflowId": "fc1cb522-dd1c-3138-b5da-6c838c7f30f3",
+        "runId": "8b592bc3-010c-4a37-81bf-03c8fe831669"
+      },
+      "workflowType": {
+        "name": "ITestChild::execute"
+      }
+    }
+  },
+  {
+    "eventId": 23,
+    "timestamp": 1542765096509924200,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 24,
+    "timestamp": 1542765096565318500,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 23,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "d4d9844a-1b99-406c-9734-b2be8b13aa76"
+    }
+  },
+  {
+    "eventId": 25,
+    "timestamp": 1542765096588464900,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 23,
+      "startedEventId": 24,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 26,
+    "timestamp": 1542765096782348300,
+    "eventType": "ChildWorkflowExecutionFailed",
+    "version": -24,
+    "childWorkflowExecutionFailedEventAttributes": {
+      "reason": "java.lang.UnsupportedOperationException",
+      "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUiLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkQW5ncnlDaGlsZC5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIzMDIpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9",
+      "domain": "UnitTest",
+      "workflowExecution": {
+        "workflowId": "fc1cb522-dd1c-3138-b5da-6c838c7f30f3",
+        "runId": "8b592bc3-010c-4a37-81bf-03c8fe831669"
+      },
+      "workflowType": {
+        "name": "ITestChild::execute"
+      },
+      "initiatedEventId": 21,
+      "startedEventId": 22
+    }
+  },
+  {
+    "eventId": 27,
+    "timestamp": 1542765096782370200,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 28,
+    "timestamp": 1542765096798051100,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 27,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "d6669de6-f3d4-4da4-b534-5ba7681b5bcf"
+    }
+  },
+  {
+    "eventId": 29,
+    "timestamp": 1542765096822430200,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 27,
+      "startedEventId": 28,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 30,
+    "timestamp": 1542765096822453600,
+    "eventType": "TimerStarted",
+    "version": -24,
+    "timerStartedEventAttributes": {
+      "timerId": "4",
+      "startToFireTimeoutSeconds": 1,
+      "decisionTaskCompletedEventId": 29
+    }
+  },
+  {
+    "eventId": 31,
+    "timestamp": 1542765097829652100,
+    "eventType": "TimerFired",
+    "version": -24,
+    "timerFiredEventAttributes": {
+      "timerId": "4",
+      "startedEventId": 30
+    }
+  },
+  {
+    "eventId": 32,
+    "timestamp": 1542765097829679200,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 33,
+    "timestamp": 1542765097851053700,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 32,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "170d3e1a-a601-41f7-a51b-937017e4a544"
+    }
+  },
+  {
+    "eventId": 34,
+    "timestamp": 1542765097878183200,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 32,
+      "startedEventId": 33,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 35,
+    "timestamp": 1542765097878198500,
+    "eventType": "MarkerRecorded",
+    "version": -24,
+    "markerRecordedEventAttributes": {
+      "markerName": "MutableSideEffect",
+      "details": "eyJpZCI6IjY1N2ViMjVmLTUzNjktM2JhOS1hODMwLWFjNjk4YWI0MzZjMyIsImV2ZW50SWQiOjM1LCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw1MCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNTYsNTQsNTIsNDgsNDgsNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw2NSwxMTYsMTE2LDEwMSwxMDksMTEyLDExNiwxMTUsMzQsNTgsNTEsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsMTAwLDExMSw3OCwxMTEsMTE2LDgyLDEwMSwxMTYsMTE0LDEyMSwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsMTI1XSwiYWNjZXNzQ291bnQiOjF9",
+      "decisionTaskCompletedEventId": 34
+    }
+  },
+  {
+    "eventId": 36,
+    "timestamp": 1542765097878391300,
+    "eventType": "StartChildWorkflowExecutionInitiated",
+    "version": -24,
+    "startChildWorkflowExecutionInitiatedEventAttributes": {
+      "domain": "UnitTest",
+      "workflowId": "0fdfacf9-5e9b-3255-8274-671e111f9d0f",
+      "workflowType": {
+        "name": "ITestChild::execute"
+      },
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "executionStartToCloseTimeoutSeconds": 500,
+      "taskStartToCloseTimeoutSeconds": 2,
+      "childPolicy": "TERMINATE",
+      "decisionTaskCompletedEventId": 34,
+      "workflowIdReusePolicy": "AllowDuplicateFailedOnly"
+    }
+  },
+  {
+    "eventId": 37,
+    "timestamp": 1542765097904968100,
+    "eventType": "ChildWorkflowExecutionStarted",
+    "version": -24,
+    "childWorkflowExecutionStartedEventAttributes": {
+      "domain": "UnitTest",
+      "initiatedEventId": 36,
+      "workflowExecution": {
+        "workflowId": "0fdfacf9-5e9b-3255-8274-671e111f9d0f",
+        "runId": "52996246-7da2-4b31-b6a9-14e51ff1fe95"
+      },
+      "workflowType": {
+        "name": "ITestChild::execute"
+      }
+    }
+  },
+  {
+    "eventId": 38,
+    "timestamp": 1542765097904988300,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 39,
+    "timestamp": 1542765097959083200,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 38,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "583dcd8f-c6c6-49f7-b1c6-9e8f5d608fb9"
+    }
+  },
+  {
+    "eventId": 40,
+    "timestamp": 1542765097984991700,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 38,
+      "startedEventId": 39,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 41,
+    "timestamp": 1542765098077788300,
+    "eventType": "ChildWorkflowExecutionFailed",
+    "version": -24,
+    "childWorkflowExecutionFailedEventAttributes": {
+      "reason": "java.lang.UnsupportedOperationException",
+      "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUiLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkQW5ncnlDaGlsZC5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIzMDIpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9",
+      "domain": "UnitTest",
+      "workflowExecution": {
+        "workflowId": "0fdfacf9-5e9b-3255-8274-671e111f9d0f",
+        "runId": "52996246-7da2-4b31-b6a9-14e51ff1fe95"
+      },
+      "workflowType": {
+        "name": "ITestChild::execute"
+      },
+      "initiatedEventId": 36,
+      "startedEventId": 37
+    }
+  },
+  {
+    "eventId": 42,
+    "timestamp": 1542765098077800400,
+    "eventType": "DecisionTaskScheduled",
+    "version": -24,
+    "decisionTaskScheduledEventAttributes": {
+      "taskList": {
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+      },
+      "startToCloseTimeoutSeconds": 2,
+      "attempt": 0
+    }
+  },
+  {
+    "eventId": 43,
+    "timestamp": 1542765098094231500,
+    "eventType": "DecisionTaskStarted",
+    "version": -24,
+    "decisionTaskStartedEventAttributes": {
+      "scheduledEventId": 42,
+      "identity": "33081@maxim-C02XD0AAJGH6",
+      "requestId": "3e196833-18bf-43a6-bb24-b93dde0d7ea9"
+    }
+  },
+  {
+    "eventId": 44,
+    "timestamp": 1542765098123260700,
+    "eventType": "DecisionTaskCompleted",
+    "version": -24,
+    "decisionTaskCompletedEventAttributes": {
+      "scheduledEventId": 42,
+      "startedEventId": 43,
+      "identity": "33081@maxim-C02XD0AAJGH6"
+    }
+  },
+  {
+    "eventId": 45,
+    "timestamp": 1542765098123275300,
+    "eventType": "WorkflowExecutionFailed",
+    "version": -24,
+    "workflowExecutionFailedEventAttributes": {
+      "reason": "com.uber.cadence.workflow.ChildWorkflowFailureException",
+      "details": "eyJ3b3JrZmxvd0V4ZWN1dGlvbiI6eyJ3b3JrZmxvd0lkIjoiMGZkZmFjZjktNWU5Yi0zMjU1LTgyNzQtNjcxZTExMWY5ZDBmIiwicnVuSWQiOiI1Mjk5NjI0Ni03ZGEyLTRiMzEtYjZhOS0xNGU1MWZmMWZlOTUifSwid29ya2Zsb3dUeXBlIjp7Im5hbWUiOiJJVGVzdENoaWxkOjpleGVjdXRlIn0sImV2ZW50SWQiOjQxLCJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUgV29ya2Zsb3dUeXBlXHUwMDNkXCJJVGVzdENoaWxkOjpleGVjdXRlXCIsIElEXHUwMDNkXCIwZmRmYWNmOS01ZTliLTMyNTUtODI3NC02NzFlMTExZjlkMGZcIiwgUnVuSURcdTAwM2RcIjUyOTk2MjQ2LTdkYTItNGIzMS1iNmE5LTE0ZTUxZmYxZmU5NSwgRXZlbnRJRFx1MDAzZDQxIiwiY2F1c2UiOnsiZGV0YWlsTWVzc2FnZSI6InNpbXVsYXRlZCBmYWlsdXJlIiwic3RhY2tUcmFjZSI6ImNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuV29ya2Zsb3dUZXN0JEFuZ3J5Q2hpbGQuZXhlY3V0ZShXb3JrZmxvd1Rlc3QuamF2YToyMzAyKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZTAoTmF0aXZlIE1ldGhvZDowKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9LCJzdGFja1RyYWNlIjoiamF2YS5sYW5nLlRocmVhZC5nZXRTdGFja1RyYWNlKFRocmVhZC5qYXZhOjE1NTkpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2hpbGRXb3JrZmxvd1N0dWJJbXBsLmV4ZWN1dGUoQ2hpbGRXb3JrZmxvd1N0dWJJbXBsLmphdmE6ODEpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2hpbGRXb3JrZmxvd0ludm9jYXRpb25IYW5kbGVyLmludm9rZShDaGlsZFdvcmtmbG93SW52b2NhdGlvbkhhbmRsZXIuamF2YTo3MylcbmNvbS5zdW4ucHJveHkuJFByb3h5MTYuZXhlY3V0ZShVbmtub3duIFNvdXJjZSlcbmNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuV29ya2Zsb3dUZXN0JFRlc3RDaGlsZFdvcmtmbG93UmV0cnlXb3JrZmxvdy5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIyNjkpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuQ2hpbGRXb3JrZmxvd0ZhaWx1cmVFeGNlcHRpb24ifQ==",
+      "decisionTaskCompletedEventId": 44
+    }
+  }
+]
+}

--- a/src/test/resources/testChildWorkflowRetryHistory.json
+++ b/src/test/resources/testChildWorkflowRetryHistory.json
@@ -1,10 +1,10 @@
 {
-"workflowId": "8f659aba-7b3d-47c8-a242-43e7047fa8f1",
-"runId": "39e72b76-9301-42d2-b7f4-e77399e39382",
-"history": [
+"workflowId": "d25264df-f4aa-417f-aa52-49b89350a748",
+"runId": "a13822f0-716a-4963-8f1f-596f2f112bbd",
+"events": [
   {
     "eventId": 1,
-    "timestamp": 1542765094920643200,
+    "timestamp": 1543270623934974500,
     "eventType": "WorkflowExecutionStarted",
     "version": -24,
     "workflowExecutionStartedEventAttributes": {
@@ -12,9 +12,9 @@
         "name": "TestWorkflow1::execute"
       },
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
       },
-      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT05dLTdmMTY0MmE5LTkwOTItNGFiMS05ODIwLWZmZGY5ZWVjOTVjZSI=",
       "executionStartToCloseTimeoutSeconds": 20,
       "taskStartToCloseTimeoutSeconds": 2,
       "identity": ""
@@ -22,12 +22,12 @@
   },
   {
     "eventId": 2,
-    "timestamp": 1542765094920696900,
+    "timestamp": 1543270623934990700,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -35,52 +35,52 @@
   },
   {
     "eventId": 3,
-    "timestamp": 1542765094942935700,
+    "timestamp": 1543270623954164300,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 2,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "53bfb340-59e9-4dda-ad31-98e4dec021e4"
+      "identity": "52243@maxim-C02XD0AAJGH6",
+      "requestId": "0cb6ed17-a68a-48da-b965-a42e492bab2c"
     }
   },
   {
     "eventId": 4,
-    "timestamp": 1542765095058754700,
+    "timestamp": 1543270623978757800,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 2,
       "startedEventId": 3,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 5,
-    "timestamp": 1542765095058875400,
+    "timestamp": 1543270623978796600,
     "eventType": "MarkerRecorded",
     "version": -24,
     "markerRecordedEventAttributes": {
       "markerName": "MutableSideEffect",
-      "details": "eyJpZCI6IjY1N2ViMjVmLTUzNjktM2JhOS1hODMwLWFjNjk4YWI0MzZjMyIsImV2ZW50SWQiOjUsImRhdGEiOlsxMjMsMzQsMTA1LDExMCwxMDUsMTE2LDEwNSw5NywxMDgsNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsOTgsOTcsOTksMTA3LDExMSwxMDIsMTAyLDY3LDExMSwxMDEsMTAyLDEwMiwxMDUsOTksMTA1LDEwMSwxMTAsMTE2LDM0LDU4LDUwLDQ2LDQ4LDQ0LDM0LDEwMSwxMjAsMTEyLDEwNSwxMTQsOTcsMTE2LDEwNSwxMTEsMTEwLDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw1Niw1NCw1Miw0OCw0OCw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDEwOSw5NywxMjAsMTA1LDEwOSwxMTcsMTA5LDY1LDExNiwxMTYsMTAxLDEwOSwxMTIsMTE2LDExNSwzNCw1OCw1MSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw3MywxMTAsMTE2LDEwMSwxMTQsMTE4LDk3LDEwOCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNDksNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDAsMTExLDc4LDExMSwxMTYsODIsMTAxLDExNiwxMTQsMTIxLDM0LDU4LDExMCwxMTcsMTA4LDEwOCwxMjVdLCJhY2Nlc3NDb3VudCI6MH0=",
+      "details": "eyJpZCI6IjEyZWVkMTNhLWVlNTYtMzE0OC05NDFhLWE5OThkMTJmZTEzMiIsImV2ZW50SWQiOjUsImRhdGEiOlsxMjMsMzQsMTA1LDExMCwxMDUsMTE2LDEwNSw5NywxMDgsNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsOTgsOTcsOTksMTA3LDExMSwxMDIsMTAyLDY3LDExMSwxMDEsMTAyLDEwMiwxMDUsOTksMTA1LDEwMSwxMTAsMTE2LDM0LDU4LDUwLDQ2LDQ4LDQ0LDM0LDEwMSwxMjAsMTEyLDEwNSwxMTQsOTcsMTE2LDEwNSwxMTEsMTEwLDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw1Niw1NCw1Miw0OCw0OCw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDEwOSw5NywxMjAsMTA1LDEwOSwxMTcsMTA5LDY1LDExNiwxMTYsMTAxLDEwOSwxMTIsMTE2LDExNSwzNCw1OCw1MSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw3MywxMTAsMTE2LDEwMSwxMTQsMTE4LDk3LDEwOCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNDksNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDAsMTExLDc4LDExMSwxMTYsODIsMTAxLDExNiwxMTQsMTIxLDM0LDU4LDExMCwxMTcsMTA4LDEwOCwxMjVdLCJhY2Nlc3NDb3VudCI6MH0=",
       "decisionTaskCompletedEventId": 4
     }
   },
   {
     "eventId": 6,
-    "timestamp": 1542765095058945500,
+    "timestamp": 1543270623979014700,
     "eventType": "StartChildWorkflowExecutionInitiated",
     "version": -24,
     "startChildWorkflowExecutionInitiatedEventAttributes": {
       "domain": "UnitTest",
-      "workflowId": "6e72d25c-f4c6-3bc2-abf6-feaad35b8dfb",
+      "workflowId": "c766b1bc-a4a2-369f-93f4-15be09faf4bb",
       "workflowType": {
         "name": "ITestChild::execute"
       },
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
       },
-      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT05dLTdmMTY0MmE5LTkwOTItNGFiMS05ODIwLWZmZGY5ZWVjOTVjZSI=",
       "executionStartToCloseTimeoutSeconds": 500,
       "taskStartToCloseTimeoutSeconds": 2,
       "childPolicy": "TERMINATE",
@@ -90,15 +90,15 @@
   },
   {
     "eventId": 7,
-    "timestamp": 1542765095080350200,
+    "timestamp": 1543270624000446500,
     "eventType": "ChildWorkflowExecutionStarted",
     "version": -24,
     "childWorkflowExecutionStartedEventAttributes": {
       "domain": "UnitTest",
       "initiatedEventId": 6,
       "workflowExecution": {
-        "workflowId": "6e72d25c-f4c6-3bc2-abf6-feaad35b8dfb",
-        "runId": "7e222099-98b1-410a-bf59-8df80e6ea26a"
+        "workflowId": "c766b1bc-a4a2-369f-93f4-15be09faf4bb",
+        "runId": "102e3eee-510c-4b3a-9770-75183a250fe2"
       },
       "workflowType": {
         "name": "ITestChild::execute"
@@ -107,12 +107,12 @@
   },
   {
     "eventId": 8,
-    "timestamp": 1542765095080377200,
+    "timestamp": 1543270624000465900,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -120,29 +120,29 @@
   },
   {
     "eventId": 9,
-    "timestamp": 1542765095103455700,
+    "timestamp": 1543270624059781700,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 8,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "3ed0820b-d7a2-4168-8324-4f31397b313c"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "18cb3e5a-1f5d-4bef-93e0-890bb075733f"
     }
   },
   {
     "eventId": 10,
-    "timestamp": 1542765095132213500,
+    "timestamp": 1543270624088964400,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 8,
       "startedEventId": 9,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 11,
-    "timestamp": 1542765095329878200,
+    "timestamp": 1543270624271791400,
     "eventType": "ChildWorkflowExecutionFailed",
     "version": -24,
     "childWorkflowExecutionFailedEventAttributes": {
@@ -150,8 +150,8 @@
       "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUiLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkQW5ncnlDaGlsZC5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIzMDIpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9",
       "domain": "UnitTest",
       "workflowExecution": {
-        "workflowId": "6e72d25c-f4c6-3bc2-abf6-feaad35b8dfb",
-        "runId": "7e222099-98b1-410a-bf59-8df80e6ea26a"
+        "workflowId": "c766b1bc-a4a2-369f-93f4-15be09faf4bb",
+        "runId": "102e3eee-510c-4b3a-9770-75183a250fe2"
       },
       "workflowType": {
         "name": "ITestChild::execute"
@@ -162,12 +162,12 @@
   },
   {
     "eventId": 12,
-    "timestamp": 1542765095329890500,
+    "timestamp": 1543270624271812700,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -175,29 +175,29 @@
   },
   {
     "eventId": 13,
-    "timestamp": 1542765095397502400,
+    "timestamp": 1543270624289186800,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 12,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "18512bad-33b0-42cb-a27a-c553a79c6a0b"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "4ef4f1cc-8a3e-478b-87fa-839b985e7c92"
     }
   },
   {
     "eventId": 14,
-    "timestamp": 1542765095437980500,
+    "timestamp": 1543270624307245200,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 12,
       "startedEventId": 13,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 15,
-    "timestamp": 1542765095437996700,
+    "timestamp": 1543270624307271300,
     "eventType": "TimerStarted",
     "version": -24,
     "timerStartedEventAttributes": {
@@ -208,7 +208,7 @@
   },
   {
     "eventId": 16,
-    "timestamp": 1542765096441932600,
+    "timestamp": 1543270625314258700,
     "eventType": "TimerFired",
     "version": -24,
     "timerFiredEventAttributes": {
@@ -218,12 +218,12 @@
   },
   {
     "eventId": 17,
-    "timestamp": 1542765096442007900,
+    "timestamp": 1543270625314290600,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -231,52 +231,52 @@
   },
   {
     "eventId": 18,
-    "timestamp": 1542765096458707700,
+    "timestamp": 1543270625332238000,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 17,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "98d30e80-db84-44b8-a15b-9ddd5cb8a0e8"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "331dbe14-6523-4491-be3a-09c116923be0"
     }
   },
   {
     "eventId": 19,
-    "timestamp": 1542765096486315200,
+    "timestamp": 1543270625356269500,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 17,
       "startedEventId": 18,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 20,
-    "timestamp": 1542765096486330200,
+    "timestamp": 1543270625356283500,
     "eventType": "MarkerRecorded",
     "version": -24,
     "markerRecordedEventAttributes": {
       "markerName": "MutableSideEffect",
-      "details": "eyJpZCI6IjY1N2ViMjVmLTUzNjktM2JhOS1hODMwLWFjNjk4YWI0MzZjMyIsImV2ZW50SWQiOjIwLCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw1MCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNTYsNTQsNTIsNDgsNDgsNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw2NSwxMTYsMTE2LDEwMSwxMDksMTEyLDExNiwxMTUsMzQsNTgsNTEsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsMTAwLDExMSw3OCwxMTEsMTE2LDgyLDEwMSwxMTYsMTE0LDEyMSwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsMTI1XSwiYWNjZXNzQ291bnQiOjF9",
+      "details": "eyJpZCI6IjEyZWVkMTNhLWVlNTYtMzE0OC05NDFhLWE5OThkMTJmZTEzMiIsImV2ZW50SWQiOjIwLCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw1MCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNTYsNTQsNTIsNDgsNDgsNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw2NSwxMTYsMTE2LDEwMSwxMDksMTEyLDExNiwxMTUsMzQsNTgsNTEsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsMTAwLDExMSw3OCwxMTEsMTE2LDgyLDEwMSwxMTYsMTE0LDEyMSwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsMTI1XSwiYWNjZXNzQ291bnQiOjF9",
       "decisionTaskCompletedEventId": 19
     }
   },
   {
     "eventId": 21,
-    "timestamp": 1542765096486402200,
+    "timestamp": 1543270625356528800,
     "eventType": "StartChildWorkflowExecutionInitiated",
     "version": -24,
     "startChildWorkflowExecutionInitiatedEventAttributes": {
       "domain": "UnitTest",
-      "workflowId": "fc1cb522-dd1c-3138-b5da-6c838c7f30f3",
+      "workflowId": "ae895176-b277-32c0-a73c-00d437f99e69",
       "workflowType": {
         "name": "ITestChild::execute"
       },
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
       },
-      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT05dLTdmMTY0MmE5LTkwOTItNGFiMS05ODIwLWZmZGY5ZWVjOTVjZSI=",
       "executionStartToCloseTimeoutSeconds": 500,
       "taskStartToCloseTimeoutSeconds": 2,
       "childPolicy": "TERMINATE",
@@ -286,15 +286,15 @@
   },
   {
     "eventId": 22,
-    "timestamp": 1542765096509906300,
+    "timestamp": 1543270625381061500,
     "eventType": "ChildWorkflowExecutionStarted",
     "version": -24,
     "childWorkflowExecutionStartedEventAttributes": {
       "domain": "UnitTest",
       "initiatedEventId": 21,
       "workflowExecution": {
-        "workflowId": "fc1cb522-dd1c-3138-b5da-6c838c7f30f3",
-        "runId": "8b592bc3-010c-4a37-81bf-03c8fe831669"
+        "workflowId": "ae895176-b277-32c0-a73c-00d437f99e69",
+        "runId": "bfc14ce9-57fd-4345-a1d0-96b34ce85694"
       },
       "workflowType": {
         "name": "ITestChild::execute"
@@ -303,12 +303,12 @@
   },
   {
     "eventId": 23,
-    "timestamp": 1542765096509924200,
+    "timestamp": 1543270625381079800,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -316,29 +316,29 @@
   },
   {
     "eventId": 24,
-    "timestamp": 1542765096565318500,
+    "timestamp": 1543270625437049500,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 23,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "d4d9844a-1b99-406c-9734-b2be8b13aa76"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "859f126c-3cf5-46cc-a765-f8eb34c3350e"
     }
   },
   {
     "eventId": 25,
-    "timestamp": 1542765096588464900,
+    "timestamp": 1543270625456856100,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 23,
       "startedEventId": 24,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 26,
-    "timestamp": 1542765096782348300,
+    "timestamp": 1543270625556390600,
     "eventType": "ChildWorkflowExecutionFailed",
     "version": -24,
     "childWorkflowExecutionFailedEventAttributes": {
@@ -346,8 +346,8 @@
       "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUiLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkQW5ncnlDaGlsZC5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIzMDIpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9",
       "domain": "UnitTest",
       "workflowExecution": {
-        "workflowId": "fc1cb522-dd1c-3138-b5da-6c838c7f30f3",
-        "runId": "8b592bc3-010c-4a37-81bf-03c8fe831669"
+        "workflowId": "ae895176-b277-32c0-a73c-00d437f99e69",
+        "runId": "bfc14ce9-57fd-4345-a1d0-96b34ce85694"
       },
       "workflowType": {
         "name": "ITestChild::execute"
@@ -358,12 +358,12 @@
   },
   {
     "eventId": 27,
-    "timestamp": 1542765096782370200,
+    "timestamp": 1543270625556403300,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -371,29 +371,29 @@
   },
   {
     "eventId": 28,
-    "timestamp": 1542765096798051100,
+    "timestamp": 1543270625570160900,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 27,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "d6669de6-f3d4-4da4-b534-5ba7681b5bcf"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "744b0f0e-4ebc-48a4-af2c-54a8efa3b579"
     }
   },
   {
     "eventId": 29,
-    "timestamp": 1542765096822430200,
+    "timestamp": 1543270625586495800,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 27,
       "startedEventId": 28,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 30,
-    "timestamp": 1542765096822453600,
+    "timestamp": 1543270625586513400,
     "eventType": "TimerStarted",
     "version": -24,
     "timerStartedEventAttributes": {
@@ -404,7 +404,7 @@
   },
   {
     "eventId": 31,
-    "timestamp": 1542765097829652100,
+    "timestamp": 1543270626592614700,
     "eventType": "TimerFired",
     "version": -24,
     "timerFiredEventAttributes": {
@@ -414,12 +414,12 @@
   },
   {
     "eventId": 32,
-    "timestamp": 1542765097829679200,
+    "timestamp": 1543270626592643600,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -427,52 +427,52 @@
   },
   {
     "eventId": 33,
-    "timestamp": 1542765097851053700,
+    "timestamp": 1543270626609174900,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 32,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "170d3e1a-a601-41f7-a51b-937017e4a544"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "c94ad251-bceb-4db1-a583-d05336bd8efa"
     }
   },
   {
     "eventId": 34,
-    "timestamp": 1542765097878183200,
+    "timestamp": 1543270626628887300,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 32,
       "startedEventId": 33,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 35,
-    "timestamp": 1542765097878198500,
+    "timestamp": 1543270626628900400,
     "eventType": "MarkerRecorded",
     "version": -24,
     "markerRecordedEventAttributes": {
       "markerName": "MutableSideEffect",
-      "details": "eyJpZCI6IjY1N2ViMjVmLTUzNjktM2JhOS1hODMwLWFjNjk4YWI0MzZjMyIsImV2ZW50SWQiOjM1LCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw1MCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNTYsNTQsNTIsNDgsNDgsNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw2NSwxMTYsMTE2LDEwMSwxMDksMTEyLDExNiwxMTUsMzQsNTgsNTEsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsMTAwLDExMSw3OCwxMTEsMTE2LDgyLDEwMSwxMTYsMTE0LDEyMSwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsMTI1XSwiYWNjZXNzQ291bnQiOjF9",
+      "details": "eyJpZCI6IjEyZWVkMTNhLWVlNTYtMzE0OC05NDFhLWE5OThkMTJmZTEzMiIsImV2ZW50SWQiOjM1LCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw1MCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMjMsMzQsMTE1LDEwMSw5OSwxMTEsMTEwLDEwMCwxMTUsMzQsNTgsNTYsNTQsNTIsNDgsNDgsNDQsMzQsMTEwLDk3LDExMCwxMTEsMTE1LDM0LDU4LDQ4LDEyNSw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw2NSwxMTYsMTE2LDEwMSwxMDksMTEyLDExNiwxMTUsMzQsNTgsNTEsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsMTAwLDExMSw3OCwxMTEsMTE2LDgyLDEwMSwxMTYsMTE0LDEyMSwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsMTI1XSwiYWNjZXNzQ291bnQiOjF9",
       "decisionTaskCompletedEventId": 34
     }
   },
   {
     "eventId": 36,
-    "timestamp": 1542765097878391300,
+    "timestamp": 1543270626629244200,
     "eventType": "StartChildWorkflowExecutionInitiated",
     "version": -24,
     "startChildWorkflowExecutionInitiatedEventAttributes": {
       "domain": "UnitTest",
-      "workflowId": "0fdfacf9-5e9b-3255-8274-671e111f9d0f",
+      "workflowId": "6fb308b0-2d80-3efe-8334-6fe812a2debe",
       "workflowType": {
         "name": "ITestChild::execute"
       },
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky ON]-7f1642a9-9092-4ab1-9820-ffdf9eec95ce"
       },
-      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT0ZGXS1jMmRjMzRjYi00YzkwLTQzYjMtOTg1Ni03MGYwNjg2MDk2MGIi",
+      "input": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5W0RvY2tlciBTdGlja3kgT05dLTdmMTY0MmE5LTkwOTItNGFiMS05ODIwLWZmZGY5ZWVjOTVjZSI=",
       "executionStartToCloseTimeoutSeconds": 500,
       "taskStartToCloseTimeoutSeconds": 2,
       "childPolicy": "TERMINATE",
@@ -482,15 +482,15 @@
   },
   {
     "eventId": 37,
-    "timestamp": 1542765097904968100,
+    "timestamp": 1543270626651736900,
     "eventType": "ChildWorkflowExecutionStarted",
     "version": -24,
     "childWorkflowExecutionStartedEventAttributes": {
       "domain": "UnitTest",
       "initiatedEventId": 36,
       "workflowExecution": {
-        "workflowId": "0fdfacf9-5e9b-3255-8274-671e111f9d0f",
-        "runId": "52996246-7da2-4b31-b6a9-14e51ff1fe95"
+        "workflowId": "6fb308b0-2d80-3efe-8334-6fe812a2debe",
+        "runId": "421fd6ab-a552-47a1-881f-1bbc3650412e"
       },
       "workflowType": {
         "name": "ITestChild::execute"
@@ -499,12 +499,12 @@
   },
   {
     "eventId": 38,
-    "timestamp": 1542765097904988300,
+    "timestamp": 1543270626651748600,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -512,29 +512,29 @@
   },
   {
     "eventId": 39,
-    "timestamp": 1542765097959083200,
+    "timestamp": 1543270626718323100,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 38,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "583dcd8f-c6c6-49f7-b1c6-9e8f5d608fb9"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "f5f32e59-e676-41d6-b41b-32dc33e8e57a"
     }
   },
   {
     "eventId": 40,
-    "timestamp": 1542765097984991700,
+    "timestamp": 1543270626736009500,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 38,
       "startedEventId": 39,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 41,
-    "timestamp": 1542765098077788300,
+    "timestamp": 1543270626825884900,
     "eventType": "ChildWorkflowExecutionFailed",
     "version": -24,
     "childWorkflowExecutionFailedEventAttributes": {
@@ -542,8 +542,8 @@
       "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUiLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkQW5ncnlDaGlsZC5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIzMDIpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9",
       "domain": "UnitTest",
       "workflowExecution": {
-        "workflowId": "0fdfacf9-5e9b-3255-8274-671e111f9d0f",
-        "runId": "52996246-7da2-4b31-b6a9-14e51ff1fe95"
+        "workflowId": "6fb308b0-2d80-3efe-8334-6fe812a2debe",
+        "runId": "421fd6ab-a552-47a1-881f-1bbc3650412e"
       },
       "workflowType": {
         "name": "ITestChild::execute"
@@ -554,12 +554,12 @@
   },
   {
     "eventId": 42,
-    "timestamp": 1542765098077800400,
+    "timestamp": 1543270626825897600,
     "eventType": "DecisionTaskScheduled",
     "version": -24,
     "decisionTaskScheduledEventAttributes": {
       "taskList": {
-        "name": "WorkflowTest-testChildWorkflowRetry[Docker Sticky OFF]-c2dc34cb-4c90-43b3-9856-70f06860960b"
+        "name": "maxim-C02XD0AAJGH6:984c16ef-ec31-4cdc-9450-6e273593806a"
       },
       "startToCloseTimeoutSeconds": 2,
       "attempt": 0
@@ -567,34 +567,34 @@
   },
   {
     "eventId": 43,
-    "timestamp": 1542765098094231500,
+    "timestamp": 1543270626838601800,
     "eventType": "DecisionTaskStarted",
     "version": -24,
     "decisionTaskStartedEventAttributes": {
       "scheduledEventId": 42,
-      "identity": "33081@maxim-C02XD0AAJGH6",
-      "requestId": "3e196833-18bf-43a6-bb24-b93dde0d7ea9"
+      "identity": "984c16ef-ec31-4cdc-9450-6e273593806a",
+      "requestId": "09de8166-8166-4aec-87fb-2bfa8eb9203a"
     }
   },
   {
     "eventId": 44,
-    "timestamp": 1542765098123260700,
+    "timestamp": 1543270626858104700,
     "eventType": "DecisionTaskCompleted",
     "version": -24,
     "decisionTaskCompletedEventAttributes": {
       "scheduledEventId": 42,
       "startedEventId": 43,
-      "identity": "33081@maxim-C02XD0AAJGH6"
+      "identity": "52243@maxim-C02XD0AAJGH6"
     }
   },
   {
     "eventId": 45,
-    "timestamp": 1542765098123275300,
+    "timestamp": 1543270626858125400,
     "eventType": "WorkflowExecutionFailed",
     "version": -24,
     "workflowExecutionFailedEventAttributes": {
       "reason": "com.uber.cadence.workflow.ChildWorkflowFailureException",
-      "details": "eyJ3b3JrZmxvd0V4ZWN1dGlvbiI6eyJ3b3JrZmxvd0lkIjoiMGZkZmFjZjktNWU5Yi0zMjU1LTgyNzQtNjcxZTExMWY5ZDBmIiwicnVuSWQiOiI1Mjk5NjI0Ni03ZGEyLTRiMzEtYjZhOS0xNGU1MWZmMWZlOTUifSwid29ya2Zsb3dUeXBlIjp7Im5hbWUiOiJJVGVzdENoaWxkOjpleGVjdXRlIn0sImV2ZW50SWQiOjQxLCJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUgV29ya2Zsb3dUeXBlXHUwMDNkXCJJVGVzdENoaWxkOjpleGVjdXRlXCIsIElEXHUwMDNkXCIwZmRmYWNmOS01ZTliLTMyNTUtODI3NC02NzFlMTExZjlkMGZcIiwgUnVuSURcdTAwM2RcIjUyOTk2MjQ2LTdkYTItNGIzMS1iNmE5LTE0ZTUxZmYxZmU5NSwgRXZlbnRJRFx1MDAzZDQxIiwiY2F1c2UiOnsiZGV0YWlsTWVzc2FnZSI6InNpbXVsYXRlZCBmYWlsdXJlIiwic3RhY2tUcmFjZSI6ImNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuV29ya2Zsb3dUZXN0JEFuZ3J5Q2hpbGQuZXhlY3V0ZShXb3JrZmxvd1Rlc3QuamF2YToyMzAyKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZTAoTmF0aXZlIE1ldGhvZDowKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9LCJzdGFja1RyYWNlIjoiamF2YS5sYW5nLlRocmVhZC5nZXRTdGFja1RyYWNlKFRocmVhZC5qYXZhOjE1NTkpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2hpbGRXb3JrZmxvd1N0dWJJbXBsLmV4ZWN1dGUoQ2hpbGRXb3JrZmxvd1N0dWJJbXBsLmphdmE6ODEpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2hpbGRXb3JrZmxvd0ludm9jYXRpb25IYW5kbGVyLmludm9rZShDaGlsZFdvcmtmbG93SW52b2NhdGlvbkhhbmRsZXIuamF2YTo3MylcbmNvbS5zdW4ucHJveHkuJFByb3h5MTYuZXhlY3V0ZShVbmtub3duIFNvdXJjZSlcbmNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuV29ya2Zsb3dUZXN0JFRlc3RDaGlsZFdvcmtmbG93UmV0cnlXb3JrZmxvdy5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIyNjkpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuQ2hpbGRXb3JrZmxvd0ZhaWx1cmVFeGNlcHRpb24ifQ==",
+      "details": "eyJ3b3JrZmxvd0V4ZWN1dGlvbiI6eyJ3b3JrZmxvd0lkIjoiNmZiMzA4YjAtMmQ4MC0zZWZlLTgzMzQtNmZlODEyYTJkZWJlIiwicnVuSWQiOiI0MjFmZDZhYi1hNTUyLTQ3YTEtODgxZi0xYmJjMzY1MDQxMmUifSwid29ya2Zsb3dUeXBlIjp7Im5hbWUiOiJJVGVzdENoaWxkOjpleGVjdXRlIn0sImV2ZW50SWQiOjQxLCJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIGZhaWx1cmUgV29ya2Zsb3dUeXBlXHUwMDNkXCJJVGVzdENoaWxkOjpleGVjdXRlXCIsIElEXHUwMDNkXCI2ZmIzMDhiMC0yZDgwLTNlZmUtODMzNC02ZmU4MTJhMmRlYmVcIiwgUnVuSURcdTAwM2RcIjQyMWZkNmFiLWE1NTItNDdhMS04ODFmLTFiYmMzNjUwNDEyZSwgRXZlbnRJRFx1MDAzZDQxIiwiY2F1c2UiOnsiZGV0YWlsTWVzc2FnZSI6InNpbXVsYXRlZCBmYWlsdXJlIiwic3RhY2tUcmFjZSI6ImNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuV29ya2Zsb3dUZXN0JEFuZ3J5Q2hpbGQuZXhlY3V0ZShXb3JrZmxvd1Rlc3QuamF2YToyMzAyKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZTAoTmF0aXZlIE1ldGhvZDowKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImphdmEubGFuZy5VbnN1cHBvcnRlZE9wZXJhdGlvbkV4Y2VwdGlvbiJ9LCJzdGFja1RyYWNlIjoiamF2YS5sYW5nLlRocmVhZC5nZXRTdGFja1RyYWNlKFRocmVhZC5qYXZhOjE1NTkpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2hpbGRXb3JrZmxvd1N0dWJJbXBsLmV4ZWN1dGUoQ2hpbGRXb3JrZmxvd1N0dWJJbXBsLmphdmE6ODEpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2hpbGRXb3JrZmxvd0ludm9jYXRpb25IYW5kbGVyLmludm9rZShDaGlsZFdvcmtmbG93SW52b2NhdGlvbkhhbmRsZXIuamF2YTo3MylcbmNvbS5zdW4ucHJveHkuJFByb3h5MTYuZXhlY3V0ZShVbmtub3duIFNvdXJjZSlcbmNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuV29ya2Zsb3dUZXN0JFRlc3RDaGlsZFdvcmtmbG93UmV0cnlXb3JrZmxvdy5leGVjdXRlKFdvcmtmbG93VGVzdC5qYXZhOjIyNjkpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlMChOYXRpdmUgTWV0aG9kKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeSRQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbi5leGVjdXRlKFBPSk9Xb3JrZmxvd0ltcGxlbWVudGF0aW9uRmFjdG9yeS5qYXZhOjIxMylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1J1bm5hYmxlLnJ1bihXb3JrZmxvd1J1bm5hYmxlLmphdmE6NDYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLnJ1bihDYW5jZWxsYXRpb25TY29wZUltcGwuamF2YTo5MylcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Xb3JrZmxvd1RocmVhZEltcGwkUnVubmFibGVXcmFwcGVyLnJ1bihXb3JrZmxvd1RocmVhZEltcGwuamF2YTo4MylcbmphdmEudXRpbC5jb25jdXJyZW50LkV4ZWN1dG9ycyRSdW5uYWJsZUFkYXB0ZXIuY2FsbChFeGVjdXRvcnMuamF2YTo1MTEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5GdXR1cmVUYXNrLnJ1bihGdXR1cmVUYXNrLmphdmE6MjY2KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yLnJ1bldvcmtlcihUaHJlYWRQb29sRXhlY3V0b3IuamF2YToxMTQ5KVxuamF2YS51dGlsLmNvbmN1cnJlbnQuVGhyZWFkUG9vbEV4ZWN1dG9yJFdvcmtlci5ydW4oVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6NjI0KVxuamF2YS5sYW5nLlRocmVhZC5ydW4oVGhyZWFkLmphdmE6NzQ4KVxuIiwic3VwcHJlc3NlZEV4Y2VwdGlvbnMiOltdLCJjbGFzcyI6ImNvbS51YmVyLmNhZGVuY2Uud29ya2Zsb3cuQ2hpbGRXb3JrZmxvd0ZhaWx1cmVFeGNlcHRpb24ifQ==",
       "decisionTaskCompletedEventId": 44
     }
   }


### PR DESCRIPTION
Any child workflow that used RetryOptions after this change is going to use the server side retry instead of the client side one. The change is backwards compatible.

Also added an ability to replay workflows from a JSON file or resource to test backwards compatibility.