### PR TITLE
Added support for activity server side retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ test {
         events "passed", "skipped", "failed"
         exceptionFormat "full"
         // Uncomment the following line if you want to see test logs in gradlew run.
-        // showStandardStreams true
+        showStandardStreams true
     }
 }
 

--- a/src/main/java/com/uber/cadence/activity/Activity.java
+++ b/src/main/java/com/uber/cadence/activity/Activity.java
@@ -22,6 +22,7 @@ import com.uber.cadence.internal.sync.WorkflowInternal;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.workflow.ActivityException;
 import com.uber.cadence.workflow.ActivityTimeoutException;
+import java.lang.reflect.Type;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -236,6 +237,24 @@ public final class Activity {
    */
   public static void heartbeat(Object details) throws CancellationException {
     ActivityInternal.recordActivityHeartbeat(details);
+  }
+
+  /**
+   * Extracts heartbeat details from last failed attempt. This is used in combination with retry
+   * policy. An activity could be scheduled with an optional retry policy on ActivityOptions. If the
+   * activity failed then server would attempt to dispatch another activity task to retry according
+   * to the retry policy. If there was heartbeat details reported by activity from the failed
+   * attempt, the details would be delivered along with the activity task for retry attempt.
+   * Activity could extract the details by {@link #getHeartbeatDetails(Class)}() and resume from the
+   * progress.
+   */
+  public <V> V getHeartbeatDetails(Class<V> detailsClass) {
+    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsClass);
+  }
+
+  /** Similar to {@link #getHeartbeatDetails(Class)}. Use when details is a generic type. */
+  public <V> V getDetails(Class<V> detailsClass, Type detailsType) {
+    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsType);
   }
 
   /**

--- a/src/main/java/com/uber/cadence/activity/Activity.java
+++ b/src/main/java/com/uber/cadence/activity/Activity.java
@@ -262,7 +262,7 @@ public final class Activity {
    * @param detailsClass type of the heartbeat details
    * @param detailsType type including generic information of the heartbeat details.
    */
-  public static <V> Optional<V> getDetails(Class<V> detailsClass, Type detailsType) {
+  public static <V> Optional<V> getHeartbeatDetails(Class<V> detailsClass, Type detailsType) {
     return ActivityInternal.getHeartbeatDetails(detailsClass, detailsType);
   }
 

--- a/src/main/java/com/uber/cadence/activity/Activity.java
+++ b/src/main/java/com/uber/cadence/activity/Activity.java
@@ -245,16 +245,25 @@ public final class Activity {
    * activity failed then server would attempt to dispatch another activity task to retry according
    * to the retry policy. If there was heartbeat details reported by activity from the failed
    * attempt, the details would be delivered along with the activity task for retry attempt.
-   * Activity could extract the details by {@link #getHeartbeatDetails(Class)}() and resume from the
-   * progress.
+   * Activity could extract the details by {@link #getHeartbeatDetails(Class, Object)}() and resume
+   * from the progress.
+   *
+   * @param detailsClass type of the heartbeat details
+   * @param defaultValue value ot return if no heartbeat was ever emitted
    */
-  public <V> V getHeartbeatDetails(Class<V> detailsClass) {
-    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsClass);
+  public static <V> V getHeartbeatDetails(Class<V> detailsClass, V defaultValue) {
+    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsClass, defaultValue);
   }
 
-  /** Similar to {@link #getHeartbeatDetails(Class)}. Use when details is a generic type. */
-  public <V> V getDetails(Class<V> detailsClass, Type detailsType) {
-    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsType);
+  /**
+   * Similar to {@link #getHeartbeatDetails(Class, Object)}. Use when details is a generic type.
+   *
+   * @param detailsClass type of the heartbeat details
+   * @param detailsType type including generic information of the heartbeat details.
+   * @param defaultValue value ot return if no heartbeat was ever emitted
+   */
+  public static <V> V getDetails(Class<V> detailsClass, Type detailsType, V defaultValue) {
+    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsType, defaultValue);
   }
 
   /**

--- a/src/main/java/com/uber/cadence/activity/Activity.java
+++ b/src/main/java/com/uber/cadence/activity/Activity.java
@@ -23,6 +23,7 @@ import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.workflow.ActivityException;
 import com.uber.cadence.workflow.ActivityTimeoutException;
 import java.lang.reflect.Type;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -246,25 +247,23 @@ public final class Activity {
    * the server would attempt to dispatch another activity task to retry according to the retry
    * options. If there was heartbeat details reported by the activity from the failed attempt, the
    * details would be delivered along with the activity task for the retry attempt. The activity
-   * could extract the details by {@link #getHeartbeatDetails(Class, Object)}() and resume from the
+   * could extract the details by {@link #getHeartbeatDetails(Class)}() and resume from the
    * progress.
    *
    * @param detailsClass type of the heartbeat details
-   * @param defaultValue value to return if no heartbeat was ever emitted
    */
-  public static <V> V getHeartbeatDetails(Class<V> detailsClass, V defaultValue) {
-    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsClass, defaultValue);
+  public static <V> Optional<V> getHeartbeatDetails(Class<V> detailsClass) {
+    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsClass);
   }
 
   /**
-   * Similar to {@link #getHeartbeatDetails(Class, Object)}. Use when details is of a generic type.
+   * Similar to {@link #getHeartbeatDetails(Class)}. Use when details is of a generic type.
    *
    * @param detailsClass type of the heartbeat details
    * @param detailsType type including generic information of the heartbeat details.
-   * @param defaultValue value ot return if no heartbeat was ever emitted
    */
-  public static <V> V getDetails(Class<V> detailsClass, Type detailsType, V defaultValue) {
-    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsType, defaultValue);
+  public static <V> Optional<V> getDetails(Class<V> detailsClass, Type detailsType) {
+    return ActivityInternal.getHeartbeatDetails(detailsClass, detailsType);
   }
 
   /**

--- a/src/main/java/com/uber/cadence/activity/Activity.java
+++ b/src/main/java/com/uber/cadence/activity/Activity.java
@@ -240,23 +240,24 @@ public final class Activity {
   }
 
   /**
-   * Extracts heartbeat details from last failed attempt. This is used in combination with retry
-   * policy. An activity could be scheduled with an optional retry policy on ActivityOptions. If the
-   * activity failed then server would attempt to dispatch another activity task to retry according
-   * to the retry policy. If there was heartbeat details reported by activity from the failed
-   * attempt, the details would be delivered along with the activity task for retry attempt.
-   * Activity could extract the details by {@link #getHeartbeatDetails(Class, Object)}() and resume
-   * from the progress.
+   * Extracts heartbeat details from the last failed attempt. This is used in combination with retry
+   * options. An activity could be scheduled with an optional {@link
+   * com.uber.cadence.common.RetryOptions} on {@link ActivityOptions}. If an activity failed then
+   * the server would attempt to dispatch another activity task to retry according to the retry
+   * options. If there was heartbeat details reported by the activity from the failed attempt, the
+   * details would be delivered along with the activity task for the retry attempt. The activity
+   * could extract the details by {@link #getHeartbeatDetails(Class, Object)}() and resume from the
+   * progress.
    *
    * @param detailsClass type of the heartbeat details
-   * @param defaultValue value ot return if no heartbeat was ever emitted
+   * @param defaultValue value to return if no heartbeat was ever emitted
    */
   public static <V> V getHeartbeatDetails(Class<V> detailsClass, V defaultValue) {
     return ActivityInternal.getHeartbeatDetails(detailsClass, detailsClass, defaultValue);
   }
 
   /**
-   * Similar to {@link #getHeartbeatDetails(Class, Object)}. Use when details is a generic type.
+   * Similar to {@link #getHeartbeatDetails(Class, Object)}. Use when details is of a generic type.
    *
    * @param detailsClass type of the heartbeat details
    * @param detailsType type including generic information of the heartbeat details.

--- a/src/main/java/com/uber/cadence/activity/ActivityOptions.java
+++ b/src/main/java/com/uber/cadence/activity/ActivityOptions.java
@@ -175,13 +175,17 @@ public final class ActivityOptions {
       if (heartbeatTimeout == null) {
         heartbeat = scheduleToClose;
       }
+      RetryOptions ro = null;
+      if (retryOptions != null) {
+        ro = new RetryOptions.Builder(retryOptions).validateBuildWithDefaults();
+      }
       return new ActivityOptions(
           roundUpToSeconds(heartbeat),
           roundUpToSeconds(scheduleToClose),
           roundUpToSeconds(scheduleToStart),
           roundUpToSeconds(startToClose),
           taskList,
-          retryOptions);
+          ro);
     }
   }
 

--- a/src/main/java/com/uber/cadence/activity/ActivityTask.java
+++ b/src/main/java/com/uber/cadence/activity/ActivityTask.java
@@ -56,4 +56,6 @@ public interface ActivityTask {
   Duration getStartToCloseTimeout();
 
   Duration getHeartbeatTimeout();
+
+  byte[] getHeartbeatDetails();
 }

--- a/src/main/java/com/uber/cadence/common/RetryOptions.java
+++ b/src/main/java/com/uber/cadence/common/RetryOptions.java
@@ -208,35 +208,15 @@ public final class RetryOptions {
 
     /** Validates property values and builds RetryOptions with default values. */
     public RetryOptions validateBuildWithDefaults() {
-      validate();
       double backoff = backoffCoefficient;
       if (backoff == 0d) {
         backoff = DEFAULT_BACKOFF_COEFFICIENT;
       }
-      return new RetryOptions(
-          initialInterval, backoff, expiration, maximumAttempts, maximumInterval, doNotRetry);
-    }
-
-    private void validate() {
-      if (initialInterval == null) {
-        throw new IllegalArgumentException("required property initialInterval not set");
-      }
-      if (expiration == null) {
-        throw new IllegalArgumentException("required property expiration is not set");
-      }
-      if (maximumInterval != null && maximumInterval.compareTo(initialInterval) == -1) {
-        throw new IllegalStateException(
-            "maximumInterval("
-                + maximumInterval
-                + ") cannot be smaller than initialInterval("
-                + initialInterval);
-      }
-      if (backoffCoefficient != 0d && backoffCoefficient < 1d) {
-        throw new IllegalArgumentException("coefficient less than 1: " + backoffCoefficient);
-      }
-      if (maximumAttempts != 0 && maximumAttempts < 0) {
-        throw new IllegalArgumentException("negative maximum attempts");
-      }
+      RetryOptions result =
+          new RetryOptions(
+              initialInterval, backoff, expiration, maximumAttempts, maximumInterval, doNotRetry);
+      result.validate();
+      return result;
     }
   }
 
@@ -290,6 +270,10 @@ public final class RetryOptions {
   public void validate() {
     if (initialInterval == null) {
       throw new IllegalStateException("required property initialInterval not set");
+    }
+    if (expiration == null && maximumAttempts <= 0) {
+      throw new IllegalArgumentException(
+          "both MaximumAttempts and Expiration on retry policy are not set, at least one of them must be set");
     }
     if (maximumInterval != null && maximumInterval.compareTo(initialInterval) == -1) {
       throw new IllegalStateException(

--- a/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
@@ -95,6 +95,7 @@ public class WorkflowExecutionUtils {
           .setBackoffCoefficient(2)
           .setInitialInterval(Duration.ofMillis(500))
           .setMaximumInterval(Duration.ofSeconds(30))
+          .setMaximumAttempts(Integer.MAX_VALUE)
           .setDoNotRetry(BadRequestError.class, EntityNotExistsError.class)
           .build();
 

--- a/src/main/java/com/uber/cadence/internal/replay/ActivityDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ActivityDecisionContext.java
@@ -26,6 +26,7 @@ import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.ScheduleActivityTaskDecisionAttributes;
 import com.uber.cadence.TaskList;
 import com.uber.cadence.TimeoutType;
+import com.uber.cadence.internal.common.RetryParameters;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -81,6 +82,10 @@ final class ActivityDecisionContext {
     this.decisions = decisions;
   }
 
+  public boolean isActivityScheduledWithRetryOptions() {
+    return decisions.isActivityScheduledWithRetryOptions();
+  }
+
   Consumer<Exception> scheduleActivityTask(
       ExecuteActivityParameters parameters, BiConsumer<byte[], Exception> callback) {
     final OpenRequestInfo<byte[], ActivityType> context =
@@ -111,6 +116,11 @@ final class ActivityDecisionContext {
       tl.setName(taskList);
       attributes.setTaskList(tl);
     }
+    RetryParameters retryParameters = parameters.getRetryParameters();
+    if (retryParameters != null) {
+      attributes.setRetryPolicy(retryParameters.toRetryPolicy());
+    }
+
     long scheduledEventId = decisions.scheduleActivityTask(attributes);
     context.setCompletionHandle(callback);
     scheduledActivities.put(scheduledEventId, context);

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -103,8 +103,8 @@ public interface DecisionContext extends ReplayAware {
   boolean isServerSideChildWorkflowRetry();
 
   /**
-   * Is the next event in the history is activity scheduled event and it has an attached retry
-   * policy. Used for backwards compatibility with the code that used local activity retry when
+   * Is the next event in the history is an activity scheduled event and it has an attached retry
+   * policy. Used for the backwards compatibility with the code that used local activity retry when
    * RetryOptions were specified.
    */
   boolean isServerSideActivityRetry();

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -96,11 +96,18 @@ public interface DecisionContext extends ReplayAware {
       BiConsumer<byte[], Exception> callback);
 
   /**
-   * Is the next event in the history is child workflow initiated event and it has attached retry
+   * Is the next event in the history is child workflow initiated event and it has an attached retry
    * policy. Used for backwards compatibility with the code that used local workflow retry when
    * RetryOptions were specified.
    */
   boolean isServerSideChildWorkflowRetry();
+
+  /**
+   * Is the next event in the history is activity scheduled event and it has an attached retry
+   * policy. Used for backwards compatibility with the code that used local activity retry when
+   * RetryOptions were specified.
+   */
+  boolean isServerSideActivityRetry();
 
   Consumer<Exception> signalWorkflowExecution(
       SignalExternalWorkflowParameters signalParameters, BiConsumer<Void, Exception> callback);

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
@@ -173,6 +173,11 @@ final class DecisionContextImpl implements DecisionContext, HistoryEventHandler 
   }
 
   @Override
+  public boolean isServerSideActivityRetry() {
+    return activityClient.isActivityScheduledWithRetryOptions();
+  }
+
+  @Override
   public Consumer<Exception> signalWorkflowExecution(
       SignalExternalWorkflowParameters signalParameters, BiConsumer<Void, Exception> callback) {
     return workflowClient.signalWorkflowExecution(signalParameters, callback);

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
@@ -222,7 +222,7 @@ class DecisionsHelper {
 
   /**
    * @return true if it is not replay or retryOptions are present in the ActivityTaskScheduled
-   *     event.
+   *     event. false is only for the legacy code that used client side retry.
    */
   boolean isActivityScheduledWithRetryOptions() {
     Optional<HistoryEvent> optionalEvent = getOptionalDecisionEvent(nextDecisionEventId);

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
@@ -19,6 +19,7 @@ package com.uber.cadence.internal.replay;
 
 import com.uber.cadence.ActivityTaskCancelRequestedEventAttributes;
 import com.uber.cadence.ActivityTaskCanceledEventAttributes;
+import com.uber.cadence.ActivityTaskScheduledEventAttributes;
 import com.uber.cadence.ActivityTaskStartedEventAttributes;
 import com.uber.cadence.CancelWorkflowExecutionDecisionAttributes;
 import com.uber.cadence.ChildWorkflowExecutionCanceledEventAttributes;
@@ -202,7 +203,7 @@ class DecisionsHelper {
    * @return true if it is not replay or retryOptions are present in the
    *     StartChildWorkflowExecutionInitiated event.
    */
-  boolean isChildWorkflowExecutionStartedWithRetryOptions() {
+  boolean isChildWorkflowExecutionInitiatedWithRetryOptions() {
     Optional<HistoryEvent> optionalEvent = getOptionalDecisionEvent(nextDecisionEventId);
     if (!optionalEvent.isPresent()) {
       return true;
@@ -213,6 +214,26 @@ class DecisionsHelper {
     }
     StartChildWorkflowExecutionInitiatedEventAttributes attr =
         event.getStartChildWorkflowExecutionInitiatedEventAttributes();
+    if (attr == null) {
+      throw new Error("Corrupted event: " + event);
+    }
+    return attr.getRetryPolicy() != null;
+  }
+
+  /**
+   * @return true if it is not replay or retryOptions are present in the ActivityTaskScheduled
+   *     event.
+   */
+  boolean isActivityScheduledWithRetryOptions() {
+    Optional<HistoryEvent> optionalEvent = getOptionalDecisionEvent(nextDecisionEventId);
+    if (!optionalEvent.isPresent()) {
+      return true;
+    }
+    HistoryEvent event = optionalEvent.get();
+    if (event.getEventType() != EventType.ActivityTaskScheduled) {
+      return false;
+    }
+    ActivityTaskScheduledEventAttributes attr = event.getActivityTaskScheduledEventAttributes();
     if (attr == null) {
       throw new Error("Corrupted event: " + event);
     }

--- a/src/main/java/com/uber/cadence/internal/replay/ExecuteActivityParameters.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ExecuteActivityParameters.java
@@ -18,7 +18,8 @@
 package com.uber.cadence.internal.replay;
 
 import com.uber.cadence.ActivityType;
-import java.nio.charset.StandardCharsets;
+import com.uber.cadence.internal.common.RetryParameters;
+import java.util.Arrays;
 
 public class ExecuteActivityParameters implements Cloneable {
 
@@ -31,6 +32,7 @@ public class ExecuteActivityParameters implements Cloneable {
   private long scheduleToStartTimeoutSeconds;
   private long startToCloseTimeoutSeconds;
   private String taskList;
+  private RetryParameters retryParameters;
   //    private int taskPriority;
 
   public ExecuteActivityParameters() {}
@@ -331,28 +333,43 @@ public class ExecuteActivityParameters implements Cloneable {
     return this;
   }
 
-  /**
-   * Returns a string representation of this object; useful for testing and debugging.
-   *
-   * @return A string representation of this object.
-   * @see java.lang.Object#toString()
-   */
+  public RetryParameters getRetryParameters() {
+    return retryParameters;
+  }
+
+  public void setRetryParameters(RetryParameters retryParameters) {
+    this.retryParameters = retryParameters;
+  }
+
+  public ExecuteActivityParameters withRetryParameters(RetryParameters retryParameters) {
+    this.retryParameters = retryParameters;
+    return this;
+  }
+
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("{");
-    sb.append("ActivityType: " + activityType + ", ");
-    sb.append("ActivityId: " + activityId + ", ");
-    sb.append("Input: " + new String(input, 0, 512, StandardCharsets.UTF_8) + ", ");
-    //        sb.append("Control: " + control + ", ");
-    sb.append("HeartbeatTimeout: " + heartbeatTimeoutSeconds + ", ");
-    sb.append("ScheduleToStartTimeout: " + scheduleToStartTimeoutSeconds + ", ");
-    sb.append("ScheduleToCloseTimeout: " + scheduleToCloseTimeoutSeconds + ", ");
-    sb.append("StartToCloseTimeout: " + startToCloseTimeoutSeconds + ", ");
-    sb.append("TaskList: " + taskList + ", ");
-    //        sb.append("TaskPriority: " + taskPriority);
-    sb.append("}");
-    return sb.toString();
+    return "ExecuteActivityParameters{"
+        + "activityId='"
+        + activityId
+        + '\''
+        + ", activityType="
+        + activityType
+        + ", heartbeatTimeoutSeconds="
+        + heartbeatTimeoutSeconds
+        + ", input="
+        + Arrays.toString(input)
+        + ", scheduleToCloseTimeoutSeconds="
+        + scheduleToCloseTimeoutSeconds
+        + ", scheduleToStartTimeoutSeconds="
+        + scheduleToStartTimeoutSeconds
+        + ", startToCloseTimeoutSeconds="
+        + startToCloseTimeoutSeconds
+        + ", taskList='"
+        + taskList
+        + '\''
+        + ", retryParameters="
+        + retryParameters
+        + '}';
   }
 
   public ExecuteActivityParameters copy() {
@@ -366,6 +383,7 @@ public class ExecuteActivityParameters implements Cloneable {
     result.setScheduleToCloseTimeoutSeconds(scheduleToCloseTimeoutSeconds);
     result.setStartToCloseTimeoutSeconds(startToCloseTimeoutSeconds);
     result.setTaskList(taskList);
+    result.setRetryParameters(retryParameters.copy());
     //        result.setTaskPriority(taskPriority);
     return result;
   }

--- a/src/main/java/com/uber/cadence/internal/replay/WorkflowDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/WorkflowDecisionContext.java
@@ -28,7 +28,6 @@ import com.uber.cadence.ChildWorkflowExecutionTimedOutEventAttributes;
 import com.uber.cadence.ExternalWorkflowExecutionSignaledEventAttributes;
 import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.RequestCancelExternalWorkflowExecutionDecisionAttributes;
-import com.uber.cadence.RetryPolicy;
 import com.uber.cadence.SignalExternalWorkflowExecutionDecisionAttributes;
 import com.uber.cadence.SignalExternalWorkflowExecutionFailedEventAttributes;
 import com.uber.cadence.StartChildWorkflowExecutionDecisionAttributes;
@@ -146,15 +145,7 @@ final class WorkflowDecisionContext {
     attributes.setWorkflowIdReusePolicy(parameters.getWorkflowIdReusePolicy());
     RetryParameters retryParameters = parameters.getRetryParameters();
     if (retryParameters != null) {
-      RetryPolicy retryPolicy =
-          new RetryPolicy()
-              .setNonRetriableErrorReasons(retryParameters.getNonRetriableErrorReasons())
-              .setMaximumAttempts(retryParameters.getMaximumAttempts())
-              .setInitialIntervalInSeconds(retryParameters.getInitialIntervalInSeconds())
-              .setExpirationIntervalInSeconds(retryParameters.getExpirationIntervalInSeconds())
-              .setBackoffCoefficient(retryParameters.getBackoffCoefficient())
-              .setMaximumIntervalInSeconds(retryParameters.getMaximumIntervalInSeconds());
-      attributes.setRetryPolicy(retryPolicy);
+      attributes.setRetryPolicy(retryParameters.toRetryPolicy());
     }
     long initiatedEventId = decisions.startChildWorkflowExecution(attributes);
     final OpenChildWorkflowRequestInfo context =
@@ -165,7 +156,7 @@ final class WorkflowDecisionContext {
   }
 
   boolean isChildWorkflowExecutionStartedWithRetryOptions() {
-    return decisions.isChildWorkflowExecutionStartedWithRetryOptions();
+    return decisions.isChildWorkflowExecutionInitiatedWithRetryOptions();
   }
 
   Consumer<Exception> signalWorkflowExecution(

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
@@ -21,6 +21,7 @@ import com.uber.cadence.activity.ActivityTask;
 import com.uber.cadence.client.ActivityCompletionException;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import java.lang.reflect.Type;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -53,7 +54,7 @@ public interface ActivityExecutionContext {
    */
   <V> void recordActivityHeartbeat(V details) throws ActivityCompletionException;
 
-  <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType, V defaultValue);
+  <V> Optional<V> getHeartbeatDetails(Class<V> detailsClass, Type detailsType);
 
   /**
    * If this method is called during an activity execution then activity is not going to complete

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
@@ -19,7 +19,6 @@ package com.uber.cadence.internal.sync;
 
 import com.uber.cadence.activity.ActivityTask;
 import com.uber.cadence.client.ActivityCompletionException;
-import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import java.lang.reflect.Type;
 import java.util.concurrent.CancellationException;

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
@@ -19,7 +19,9 @@ package com.uber.cadence.internal.sync;
 
 import com.uber.cadence.activity.ActivityTask;
 import com.uber.cadence.client.ActivityCompletionException;
+import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.serviceclient.IWorkflowService;
+import java.lang.reflect.Type;
 import java.util.concurrent.CancellationException;
 
 /**
@@ -52,6 +54,8 @@ public interface ActivityExecutionContext {
    */
   void recordActivityHeartbeat(Object details) throws ActivityCompletionException;
 
+  <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType);
+
   /**
    * If this method is called during an activity execution then activity is not going to complete
    * when its method returns. It is expected to be completed asynchronously using {@link
@@ -68,4 +72,6 @@ public interface ActivityExecutionContext {
   IWorkflowService getService();
 
   String getDomain();
+
+  DataConverter getDataConverter();
 }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
@@ -54,7 +54,7 @@ public interface ActivityExecutionContext {
    */
   void recordActivityHeartbeat(Object details) throws ActivityCompletionException;
 
-  <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType);
+  <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType, V defaultValue);
 
   /**
    * If this method is called during an activity execution then activity is not going to complete

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContext.java
@@ -52,7 +52,7 @@ public interface ActivityExecutionContext {
    *     workflow.Should be rethrown from activity implementation to indicate successful
    *     cancellation.
    */
-  void recordActivityHeartbeat(Object details) throws ActivityCompletionException;
+  <V> void recordActivityHeartbeat(V details) throws ActivityCompletionException;
 
   <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType, V defaultValue);
 
@@ -72,6 +72,4 @@ public interface ActivityExecutionContext {
   IWorkflowService getService();
 
   String getDomain();
-
-  DataConverter getDataConverter();
 }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
@@ -88,7 +88,7 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
     lock.lock();
     try {
       // always set lastDetail. Successful heartbeat will clear it.
-      lastDetails = Optional.of(details);
+      lastDetails = Optional.ofNullable(details);
       heartbeatCalled = true;
       // Only do sync heartbeat if there is no such call scheduled.
       if (future == null) {

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
@@ -103,19 +103,17 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
   }
 
   @Override
-  public <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType, V defaultValue) {
+  public <V> Optional<V> getHeartbeatDetails(Class<V> detailsClass, Type detailsType) {
     lock.lock();
     try {
       if (lastDetails != null) {
-        @SuppressWarnings("unchecked")
-        V ld = (V) this.lastDetails;
-        return ld;
+        return (Optional<V>) this.lastDetails;
       }
       byte[] details = task.getHeartbeatDetails();
       if (details == null) {
-        return defaultValue;
+        return Optional.empty();
       }
-      return dataConverter.fromData(details, detailsClass, detailsType);
+      return Optional.of(dataConverter.fromData(details, detailsClass, detailsType));
     } finally {
       lock.unlock();
     }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
@@ -103,7 +103,7 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
   }
 
   @Override
-  public <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType) {
+  public <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType, V defaultValue) {
     lock.lock();
     try {
       if (lastDetails != null) {
@@ -111,7 +111,11 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
         V ld = (V) this.lastDetails;
         return ld;
       }
-      return dataConverter.fromData(task.getHeartbeatDetails(), detailsClass, detailsType);
+      byte[] details = task.getHeartbeatDetails();
+      if (details == null) {
+        return defaultValue;
+      }
+      return dataConverter.fromData(details, detailsClass, detailsType);
     } finally {
       lock.unlock();
     }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityExecutionContextImpl.java
@@ -83,7 +83,7 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
 
   /** @see ActivityExecutionContext#recordActivityHeartbeat(Object) */
   @Override
-  public void recordActivityHeartbeat(Object details) throws ActivityCompletionException {
+  public <V> void recordActivityHeartbeat(V details) throws ActivityCompletionException {
     lock.lock();
     try {
       // always set lastDetail. Successful heartbeat will clear it.
@@ -213,10 +213,5 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
   @Override
   public String getDomain() {
     return domain;
-  }
-
-  @Override
-  public DataConverter getDataConverter() {
-    return dataConverter;
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityInternal.java
@@ -20,6 +20,7 @@ package com.uber.cadence.internal.sync;
 import com.uber.cadence.activity.ActivityTask;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import java.lang.reflect.Type;
+import java.util.Optional;
 
 public final class ActivityInternal {
 
@@ -49,7 +50,7 @@ public final class ActivityInternal {
     getContext().doNotCompleteOnReturn();
   }
 
-  public static <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType, V defaultValue) {
-    return getContext().getHeartbeatDetails(detailsClass, detailsType, defaultValue);
+  public static <V> Optional<V> getHeartbeatDetails(Class<V> detailsClass, Type detailsType) {
+    return getContext().getHeartbeatDetails(detailsClass, detailsType);
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityInternal.java
@@ -19,6 +19,7 @@ package com.uber.cadence.internal.sync;
 
 import com.uber.cadence.activity.ActivityTask;
 import com.uber.cadence.serviceclient.IWorkflowService;
+import java.lang.reflect.Type;
 
 public final class ActivityInternal {
 
@@ -46,5 +47,9 @@ public final class ActivityInternal {
 
   public static void doNotCompleteOnReturn() {
     getContext().doNotCompleteOnReturn();
+  }
+
+  public static <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType) {
+    return getContext().getHeartbeatDetails(detailsClass, detailsType);
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityInternal.java
@@ -49,7 +49,7 @@ public final class ActivityInternal {
     getContext().doNotCompleteOnReturn();
   }
 
-  public static <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType) {
-    return getContext().getHeartbeatDetails(detailsClass, detailsType);
+  public static <V> V getHeartbeatDetails(Class<V> detailsClass, Type detailsType, V defaultValue) {
+    return getContext().getHeartbeatDetails(detailsClass, detailsType, defaultValue);
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityTaskImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityTaskImpl.java
@@ -71,6 +71,11 @@ final class ActivityTaskImpl implements ActivityTask {
     return Duration.ofSeconds(response.getHeartbeatTimeoutSeconds());
   }
 
+  @Override
+  public byte[] getHeartbeatDetails() {
+    return response.getHeartbeatDetails();
+  }
+
   public byte[] getInput() {
     return response.getInput();
   }

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -554,6 +554,11 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     }
 
     @Override
+    public boolean isServerSideActivityRetry() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
     public Consumer<Exception> signalWorkflowExecution(
         SignalExternalWorkflowParameters signalParameters, BiConsumer<Void, Exception> callback) {
       throw new UnsupportedOperationException("not implemented");

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -53,9 +53,7 @@ import com.uber.cadence.workflow.WorkflowInterceptor;
 import com.uber.m3.tally.Scope;
 import java.lang.reflect.Type;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -120,7 +118,7 @@ final class SyncDecisionContext implements WorkflowInterceptor {
       Object[] args,
       ActivityOptions options) {
     RetryOptions retryOptions = options.getRetryOptions();
-    if (retryOptions != null) {
+    if (retryOptions != null && !context.isServerSideActivityRetry()) {
       return WorkflowRetryerInternal.retryAsync(
           retryOptions,
           () -> executeActivityOnce(activityName, options, args, resultClass, resultType));
@@ -154,6 +152,10 @@ final class SyncDecisionContext implements WorkflowInterceptor {
         .withStartToCloseTimeoutSeconds(options.getStartToCloseTimeout().getSeconds())
         .withScheduleToCloseTimeoutSeconds(options.getScheduleToCloseTimeout().getSeconds())
         .setHeartbeatTimeoutSeconds(options.getHeartbeatTimeout().getSeconds());
+    RetryOptions retryOptions = options.getRetryOptions();
+    if (retryOptions != null) {
+      parameters.setRetryParameters(new RetryParameters(retryOptions));
+    }
     Consumer<Exception> cancellationCallback =
         context.scheduleActivityTask(
             parameters,
@@ -275,25 +277,7 @@ final class SyncDecisionContext implements WorkflowInterceptor {
     RetryParameters retryParameters = null;
     RetryOptions retryOptions = options.getRetryOptions();
     if (retryOptions != null) {
-      retryParameters = new RetryParameters();
-      retryParameters.setBackoffCoefficient(retryOptions.getBackoffCoefficient());
-      retryParameters.setExpirationIntervalInSeconds(
-          (int) roundUpToSeconds(retryOptions.getExpiration()).getSeconds());
-      retryParameters.setMaximumAttempts(retryOptions.getMaximumAttempts());
-      retryParameters.setInitialIntervalInSeconds(
-          (int) roundUpToSeconds(retryOptions.getInitialInterval()).getSeconds());
-      retryParameters.setMaximumIntervalInSeconds(
-          (int) roundUpToSeconds(retryOptions.getMaximumInterval()).getSeconds());
-      // Use exception type name as the reason
-      List<String> reasons = new ArrayList<>();
-      // Use exception type name as the reason
-      List<Class<? extends Throwable>> doNotRetry = retryOptions.getDoNotRetry();
-      if (doNotRetry != null) {
-        for (Class<? extends Throwable> r : doNotRetry) {
-          reasons.add(r.getName());
-        }
-        retryParameters.setNonRetriableErrorReasons(reasons);
-      }
+      retryParameters = new RetryParameters(retryOptions);
     }
     StartChildWorkflowExecutionParameters parameters =
         new StartChildWorkflowExecutionParameters.Builder()

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -118,6 +118,7 @@ final class SyncDecisionContext implements WorkflowInterceptor {
       Object[] args,
       ActivityOptions options) {
     RetryOptions retryOptions = options.getRetryOptions();
+    // Replays a legacy history that used the client side retry correctly
     if (retryOptions != null && !context.isServerSideActivityRetry()) {
       return WorkflowRetryerInternal.retryAsync(
           retryOptions,

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInvocationHandler.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInvocationHandler.java
@@ -154,6 +154,18 @@ class WorkflowInvocationHandler implements InvocationHandler {
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) {
+    try {
+      if (method.equals(Object.class.getMethod("toString"))) {
+        // TODO: workflow info
+        return "WorkflowInvocationHandler";
+      }
+    } catch (NoSuchMethodException e) {
+      throw new Error("unexpected", e);
+    }
+    if (!method.getDeclaringClass().isInterface()) {
+      throw new IllegalArgumentException(
+          "Interface type is expected: " + method.getDeclaringClass());
+    }
     WorkflowMethod workflowMethod = method.getAnnotation(WorkflowMethod.class);
     QueryMethod queryMethod = method.getAnnotation(QueryMethod.class);
     SignalMethod signalMethod = method.getAnnotation(SignalMethod.class);

--- a/src/main/java/com/uber/cadence/internal/testservice/RequestContext.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/RequestContext.java
@@ -17,6 +17,7 @@
 
 package com.uber.cadence.internal.testservice;
 
+import com.uber.cadence.BadRequestError;
 import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.InternalServiceError;
@@ -34,7 +35,7 @@ final class RequestContext {
   @FunctionalInterface
   interface CommitCallback {
 
-    void apply(int historySize) throws InternalServiceError;
+    void apply(int historySize) throws InternalServiceError, BadRequestError;
   }
 
   static final class Timer {
@@ -205,12 +206,13 @@ final class RequestContext {
   }
 
   /** @return nextEventId */
-  long commitChanges(TestWorkflowStore store) throws InternalServiceError, EntityNotExistsError {
+  long commitChanges(TestWorkflowStore store)
+      throws InternalServiceError, EntityNotExistsError, BadRequestError {
     return store.save(this);
   }
 
   /** Called by {@link TestWorkflowStore#save(RequestContext)} */
-  void fireCallbacks(int historySize) throws InternalServiceError {
+  void fireCallbacks(int historySize) throws InternalServiceError, BadRequestError {
     for (CommitCallback callback : commitCallbacks) {
       callback.apply(historySize);
     }

--- a/src/main/java/com/uber/cadence/internal/testservice/RequestContext.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/RequestContext.java
@@ -28,6 +28,7 @@ import com.uber.cadence.internal.testservice.TestWorkflowStore.DecisionTask;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 
 final class RequestContext {
@@ -123,7 +124,7 @@ final class RequestContext {
   }
 
   long currentTimeInNanoseconds() {
-    return clock.getAsLong() * NANOS_PER_MILLIS;
+    return TimeUnit.MILLISECONDS.toNanos(clock.getAsLong());
   }
 
   /** Returns eventId of the added event; */

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachine.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachine.java
@@ -22,6 +22,7 @@ import com.uber.cadence.InternalServiceError;
 import com.uber.cadence.internal.testservice.StateMachines.Action;
 import com.uber.cadence.internal.testservice.StateMachines.State;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +40,20 @@ import java.util.Objects;
  */
 final class StateMachine<Data> {
 
+  /** Function invoked when an action happens in a given state */
   @FunctionalInterface
   interface Callback<D, R> {
 
     void apply(RequestContext ctx, D data, R request, long referenceId)
+        throws InternalServiceError, BadRequestError;
+  }
+
+  /** Function invoked when an action happens in a given state */
+  @FunctionalInterface
+  interface DynamicCallback<D, R> {
+
+    /** @return state after the action */
+    State apply(RequestContext ctx, D data, R request, long referenceId)
         throws InternalServiceError, BadRequestError;
   }
 
@@ -94,33 +105,70 @@ final class StateMachine<Data> {
     }
   }
 
-  private static class TransitionDestination<Data> {
+  private interface TransitionDestination<Data, R> {
+    State apply(RequestContext ctx, Data data, R request, long referenceId)
+        throws InternalServiceError, BadRequestError;
+  }
+
+  private static class FixedTransitionDestination<Data, R>
+      implements TransitionDestination<Data, R> {
 
     final State state;
 
-    final Callback<Data, ?> callback;
+    final Callback<Data, R> callback;
 
-    private TransitionDestination(State state, Callback<Data, ?> callback) {
+    private FixedTransitionDestination(State state, Callback<Data, R> callback) {
       this.state = state;
       this.callback = callback;
-    }
-
-    public State getState() {
-      return state;
-    }
-
-    public Callback<Data, ?> getCallback() {
-      return callback;
     }
 
     @Override
     public String toString() {
       return "TransitionDestination{" + "state=" + state + ", callback=" + callback + '}';
     }
+
+    @Override
+    public State apply(RequestContext ctx, Data data, R request, long referenceId)
+        throws InternalServiceError, BadRequestError {
+      callback.apply(ctx, data, request, referenceId);
+      return state;
+    }
+  }
+
+  private static class DynamicTransitionDestination<Data, R>
+      implements TransitionDestination<Data, R> {
+
+    final DynamicCallback<Data, R> callback;
+    State[] expectedStates;
+    State state;
+
+    private DynamicTransitionDestination(
+        State[] expectedStates, DynamicCallback<Data, R> callback) {
+      this.expectedStates = expectedStates;
+      this.callback = callback;
+    }
+
+    @Override
+    public String toString() {
+      return "DynamicTransitionDestination{" + "state=" + state + ", callback=" + callback + '}';
+    }
+
+    @Override
+    public State apply(RequestContext ctx, Data data, R request, long referenceId)
+        throws InternalServiceError, BadRequestError {
+      state = callback.apply(ctx, data, request, referenceId);
+      for (State s : expectedStates) {
+        if (s == state) {
+          return state;
+        }
+      }
+      throw new IllegalStateException(
+          state + " is not expected. Expected states are: " + Arrays.toString(expectedStates));
+    }
   }
 
   private final List<Transition> transitionHistory = new ArrayList<>();
-  private final Map<Transition, TransitionDestination<Data>> transitions = new HashMap<>();
+  private final Map<Transition, TransitionDestination<Data, ?>> transitions = new HashMap<>();
 
   private State state = StateMachines.State.NONE;
 
@@ -148,21 +196,27 @@ final class StateMachine<Data> {
    * @return the current StateMachine instance for fluid pattern.
    */
   <V> StateMachine<Data> add(State from, Action action, State to, Callback<Data, V> callback) {
-    transitions.put(new Transition(from, action), new TransitionDestination<>(to, callback));
+    transitions.put(new Transition(from, action), new FixedTransitionDestination<>(to, callback));
     return this;
   }
 
-  <V> void action(Action action, RequestContext context, V request, long referenceId)
+  <V> StateMachine<Data> add(
+      State from, Action action, State[] toStates, DynamicCallback<Data, V> callback) {
+    transitions.put(
+        new Transition(from, action), new DynamicTransitionDestination<>(toStates, callback));
+    return this;
+  }
+
+  <R> void action(Action action, RequestContext context, R request, long referenceId)
       throws InternalServiceError, BadRequestError {
     Transition transition = new Transition(state, action);
-    TransitionDestination<Data> destination = transitions.get(transition);
+    @SuppressWarnings("unchecked")
+    TransitionDestination<Data, R> destination =
+        (TransitionDestination<Data, R>) transitions.get(transition);
     if (destination == null) {
       throw new InternalServiceError("Invalid " + transition + ", history: " + transitionHistory);
     }
-    @SuppressWarnings("unchecked")
-    Callback<Data, V> callback = (Callback<Data, V>) destination.getCallback();
-    callback.apply(context, data, request, referenceId);
+    state = destination.apply(context, data, request, referenceId);
     transitionHistory.add(transition);
-    state = destination.getState();
   }
 }

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachine.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachine.java
@@ -48,7 +48,10 @@ final class StateMachine<Data> {
         throws InternalServiceError, BadRequestError;
   }
 
-  /** Function invoked when an action happens in a given state */
+  /**
+   * Function invoked when an action happens in a given state. Returns the next state. Used when the
+   * next state depends not only on the current state and action, but also on the data.
+   */
   @FunctionalInterface
   interface DynamicCallback<D, R> {
 
@@ -193,13 +196,23 @@ final class StateMachine<Data> {
    * @param to destination state of a transition.
    * @param callback callback to invoke upon transition
    * @param <V> type of callback parameter.
-   * @return the current StateMachine instance for fluid pattern.
+   * @return the current StateMachine instance for the fluid pattern.
    */
   <V> StateMachine<Data> add(State from, Action action, State to, Callback<Data, V> callback) {
     transitions.put(new Transition(from, action), new FixedTransitionDestination<>(to, callback));
     return this;
   }
 
+  /**
+   * Registers a dynamic transition between states.
+   * Used when the same action can transition to more than one state depending on data.
+   *
+   * @param from initial state that transition applies to
+   * @param toStates allowed destination states of a transition.
+   * @param callback callback to invoke upon transition
+   * @param <V> type of callback parameter.
+   * @return the current StateMachine instance for the fluid pattern.
+   */
   <V> StateMachine<Data> add(
       State from, Action action, State[] toStates, DynamicCallback<Data, V> callback) {
     transitions.put(

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachine.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachine.java
@@ -204,8 +204,8 @@ final class StateMachine<Data> {
   }
 
   /**
-   * Registers a dynamic transition between states.
-   * Used when the same action can transition to more than one state depending on data.
+   * Registers a dynamic transition between states. Used when the same action can transition to more
+   * than one state depending on data.
    *
    * @param from initial state that transition applies to
    * @param toStates allowed destination states of a transition.

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -783,6 +783,9 @@ class StateMachines {
         new ActivityTaskStartedEventAttributes()
             .setIdentity(request.getIdentity())
             .setScheduledEventId(data.scheduledEventId);
+    if (data.retryState != null) {
+      a.setAttempt(data.retryState.getAttempt());
+    }
     HistoryEvent event =
         new HistoryEvent()
             .setEventType(EventType.ActivityTaskStarted)
@@ -986,12 +989,12 @@ class StateMachines {
         ctx.onCommit(
             (historySize) -> {
               data.retryState = nextAttempt;
-              data.activityTask.getTask().setAttempt(data.retryState.getAttempt());
+              data.activityTask.getTask().setAttempt(nextAttempt.getAttempt());
             });
         return true;
+      } else {
+        data.startedEventId = ctx.addEvent(data.startedEvent);
       }
-    } else {
-      ctx.addEvent(data.startedEvent);
     }
     return false;
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -980,6 +980,7 @@ class StateMachines {
       int backoffIntervalInSeconds =
           data.retryState.getBackoffIntervalInSeconds(errorReason, data.store.currentTimeMillis());
       if (backoffIntervalInSeconds > 0) {
+        data.activityTask.getTask().setHeartbeatDetails(data.heartbeatDetails);
         ctx.addActivityTask(data.activityTask);
         ctx.onCommit(
             (historySize) -> {

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -149,6 +149,7 @@ class StateMachines {
 
   static final class WorkflowData {
     Optional<RetryState> retryState = Optional.empty();
+    int backoffStartIntervalInSeconds;
   }
 
   static final class DecisionTaskData {
@@ -471,6 +472,7 @@ class StateMachines {
               try {
                 data.service.startWorkflowExecutionImpl(
                     startChild,
+                    0,
                     Optional.of(ctx.getWorkflowMutableState()),
                     OptionalLong.of(data.initiatedEventId));
               } catch (WorkflowExecutionAlreadyStartedError workflowExecutionAlreadyStartedError) {
@@ -515,6 +517,9 @@ class StateMachines {
     a.setExecutionStartToCloseTimeoutSeconds(request.getExecutionStartToCloseTimeoutSeconds());
     if (request.isSetInput()) {
       a.setInput(request.getInput());
+    }
+    if (data.retryState.isPresent()) {
+      a.setAttempt(data.retryState.get().getAttempt());
     }
     HistoryEvent event =
         new HistoryEvent()

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -468,7 +468,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     if (activity != null) {
       throw new BadRequestError("Already open activity with " + activityId);
     }
-    activity = StateMachines.newActivityStateMachine();
+    activity = StateMachines.newActivityStateMachine(store);
     activities.put(activityId, activity);
     activity.action(StateMachines.Action.INITIATE, ctx, a, decisionTaskCompletedId);
     ctx.addTimer(

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1077,9 +1077,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
         ctx -> {
           StateMachine<?> activity = getActivity(activityId);
           activity.action(StateMachines.Action.FAIL, ctx, request, 0);
-          activities.remove(activityId);
-          ctx.unlockTimer();
-          scheduleDecision(ctx);
+          if (isTerminalState(activity.getState())) {
+            activities.remove(activityId);
+            ctx.unlockTimer();
+            scheduleDecision(ctx);
+          } else {
+            //            throw new Error("not implemented yet");
+          }
         });
   }
 
@@ -1090,9 +1094,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
         ctx -> {
           StateMachine<?> activity = getActivity(activityId);
           activity.action(StateMachines.Action.FAIL, ctx, request, 0);
-          activities.remove(activityId);
-          scheduleDecision(ctx);
-          ctx.unlockTimer();
+          if (isTerminalState(activity.getState())) {
+            activities.remove(activityId);
+            scheduleDecision(ctx);
+            ctx.unlockTimer();
+          } else {
+            //            throw new Error("not implemented yet");
+          }
         });
   }
 

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1082,7 +1082,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             ctx.unlockTimer();
             scheduleDecision(ctx);
           } else {
-            //            throw new Error("not implemented yet");
+                        throw new Error("not implemented yet");
           }
         });
   }
@@ -1099,7 +1099,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             scheduleDecision(ctx);
             ctx.unlockTimer();
           } else {
-            //            throw new Error("not implemented yet");
+                        throw new Error("not implemented yet");
           }
         });
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -998,8 +998,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       throws InternalServiceError, EntityNotExistsError, BadRequestError {
     update(
         ctx -> {
-          log.info("Start activity time=" + store.currentTimeMillis());
-
           String activityId = task.getActivityId();
           StateMachine<ActivityTaskData> activity = getActivity(activityId);
           activity.action(StateMachines.Action.START, ctx, pollRequest, 0);
@@ -1077,8 +1075,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       throws InternalServiceError, EntityNotExistsError, BadRequestError {
     update(
         ctx -> {
-          log.info("Fail activity time=" + store.currentTimeMillis());
-
           StateMachine<ActivityTaskData> activity = getActivity(activityId);
           activity.action(StateMachines.Action.FAIL, ctx, request, 0);
           if (isTerminalState(activity.getState())) {
@@ -1249,9 +1245,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             if (isTerminalState(workflow.getState())) {
               return;
             }
-            log.info("Workflow timed out before action");
             workflow.action(StateMachines.Action.TIME_OUT, ctx, TimeoutType.START_TO_CLOSE, 0);
-            log.info("Workflow timed out after action");
             if (parent != null) {
               ctx.lockTimer(); // unlocked by the parent
             }
@@ -1261,7 +1255,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       // Cannot fail to timer threads
       log.error("Failure trying to timeout a workflow", e);
     }
-    log.info("Workflow timed out done");
   }
 
   private void reportWorkflowTimeoutToParent(RequestContext ctx) {

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1082,7 +1082,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             ctx.unlockTimer();
             scheduleDecision(ctx);
           } else {
-                        throw new Error("not implemented yet");
+            throw new Error("not implemented yet");
           }
         });
   }
@@ -1099,7 +1099,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             scheduleDecision(ctx);
             ctx.unlockTimer();
           } else {
-                        throw new Error("not implemented yet");
+            throw new Error("not implemented yet");
           }
         });
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStore.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStore.java
@@ -17,6 +17,7 @@
 
 package com.uber.cadence.internal.testservice;
 
+import com.uber.cadence.BadRequestError;
 import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
@@ -136,7 +137,8 @@ interface TestWorkflowStore {
 
   long currentTimeMillis();
 
-  long save(RequestContext requestContext) throws InternalServiceError, EntityNotExistsError;
+  long save(RequestContext requestContext)
+      throws InternalServiceError, EntityNotExistsError, BadRequestError;
 
   void applyTimersAndLocks(RequestContext ctx);
 

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -91,7 +91,10 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
                   + WorkflowExecutionUtils.prettyPrintHistoryEvent(event));
         }
         event.setEventId(history.size() + 1L);
-        event.setTimestamp(timeInNanos);
+        // It can be set in StateMachines.startActivityTask
+        if (!event.isSetTimestamp()) {
+          event.setTimestamp(timeInNanos);
+        }
         history.add(event);
         completed = completed || WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(event);
       }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -17,6 +17,7 @@
 
 package com.uber.cadence.internal.testservice;
 
+import com.uber.cadence.BadRequestError;
 import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.EventType;
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
@@ -168,7 +169,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
   }
 
   @Override
-  public long save(RequestContext ctx) throws InternalServiceError, EntityNotExistsError {
+  public long save(RequestContext ctx)
+      throws InternalServiceError, EntityNotExistsError, BadRequestError {
     long result;
     lock.lock();
     boolean historiesEmpty = histories.isEmpty();

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -399,7 +399,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       lock.unlock();
     }
     // Uncomment to troubleshoot time skipping issues.
-    //    timerService.getDiagnostics(result);
+    timerService.getDiagnostics(result);
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/workflow/Workflow.java
+++ b/src/main/java/com/uber/cadence/workflow/Workflow.java
@@ -378,7 +378,7 @@ public final class Workflow {
   }
 
   /**
-   * Creates client stub to activities that implement given interface.
+   * Creates client stub to activities that implement given interface. `
    *
    * @param activityInterface interface type implemented by activities
    */

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -570,7 +570,6 @@ public class WorkflowTest {
     assertEquals(activitiesImpl.toString(), 3, activitiesImpl.invocations.size());
   }
 
-
   /**
    * Tests that history that was created before server side retry was supported is backwards
    * compatible with the client that supports the server side retry.
@@ -582,9 +581,9 @@ public class WorkflowTest {
       return;
     }
     WorkflowReplayer.replayWorkflowExecutionFromResource(
-            "testAsyncActivityRetryHistory.json", TestAsyncActivityRetry.class);
+        "testAsyncActivityRetryHistory.json", TestAsyncActivityRetry.class);
   }
-  
+
   public static class TestAsyncActivityRetryOptionsChange implements TestWorkflow1 {
 
     private TestActivities activities;

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -100,7 +100,7 @@ public class WorkflowTest {
    * When set to true increases test, activity and workflow timeouts to large values to support
    * stepping through code in a debugger without timing out.
    */
-  private static final boolean DEBUGGER_TIMEOUTS = false;
+  private static final boolean DEBUGGER_TIMEOUTS = true;
 
   public static final String ANNOTATION_TASK_LIST = "WorkflowTest-testExecute[Docker]";
 
@@ -3076,6 +3076,7 @@ public class WorkflowTest {
       Optional<Integer> heartbeatDetails = Activity.getHeartbeatDetails(int.class);
       assertEquals(heartbeatCounter.get(), (int) heartbeatDetails.orElse(0));
       Activity.heartbeat(heartbeatCounter.incrementAndGet());
+      assertEquals(heartbeatCounter.get(), (int) Activity.getHeartbeatDetails(int.class).get());
       try {
         throw new IOException("simulated IO problem");
       } catch (IOException e) {

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -381,6 +381,7 @@ public class WorkflowTest {
               .setStartToCloseTimeout(Duration.ofSeconds(10))
               .setRetryOptions(
                   new RetryOptions.Builder()
+                      .setExpiration(Duration.ofSeconds(100))
                       .setMaximumInterval(Duration.ofSeconds(1))
                       .setInitialInterval(Duration.ofSeconds(1))
                       .setMaximumAttempts(3)
@@ -470,6 +471,7 @@ public class WorkflowTest {
               .setStartToCloseTimeout(Duration.ofSeconds(10))
               .setRetryOptions(
                   new RetryOptions.Builder()
+                      .setExpiration(Duration.ofSeconds(100))
                       .setMaximumInterval(Duration.ofSeconds(1))
                       .setInitialInterval(Duration.ofSeconds(1))
                       .setMaximumAttempts(3)
@@ -541,6 +543,7 @@ public class WorkflowTest {
               .setStartToCloseTimeout(Duration.ofSeconds(10))
               .setRetryOptions(
                   new RetryOptions.Builder()
+                      .setExpiration(Duration.ofSeconds(100))
                       .setMaximumInterval(Duration.ofSeconds(1))
                       .setInitialInterval(Duration.ofSeconds(1))
                       .setMaximumAttempts(3)
@@ -583,6 +586,7 @@ public class WorkflowTest {
       if (Workflow.isReplaying()) {
         options.setRetryOptions(
             new RetryOptions.Builder()
+                .setExpiration(Duration.ofSeconds(100))
                 .setMaximumInterval(Duration.ofSeconds(1))
                 .setInitialInterval(Duration.ofSeconds(1))
                 .setDoNotRetry(NullPointerException.class)
@@ -591,6 +595,7 @@ public class WorkflowTest {
       } else {
         options.setRetryOptions(
             new RetryOptions.Builder()
+                .setExpiration(Duration.ofSeconds(10))
                 .setMaximumInterval(Duration.ofSeconds(1))
                 .setInitialInterval(Duration.ofSeconds(1))
                 .setMaximumAttempts(2)

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -570,6 +570,21 @@ public class WorkflowTest {
     assertEquals(activitiesImpl.toString(), 3, activitiesImpl.invocations.size());
   }
 
+
+  /**
+   * Tests that history that was created before server side retry was supported is backwards
+   * compatible with the client that supports the server side retry.
+   */
+  @Test
+  public void testAsyncActivityRetryReplay() throws Exception {
+    // Avoid executing 4 times
+    if (!testName.getMethodName().equals("testAsyncActivityRetryReplay[Docker Sticky OFF]")) {
+      return;
+    }
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+            "testAsyncActivityRetryHistory.json", TestAsyncActivityRetry.class);
+  }
+  
   public static class TestAsyncActivityRetryOptionsChange implements TestWorkflow1 {
 
     private TestActivities activities;

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -3073,7 +3073,8 @@ public class WorkflowTest {
     @Override
     public void heartbeatAndThrowIO() {
       invocations.add("throwIO");
-      assertEquals(heartbeatCounter.get(), (int) Activity.getHeartbeatDetails(int.class, 0));
+      Optional<Integer> heartbeatDetails = Activity.getHeartbeatDetails(int.class);
+      assertEquals(heartbeatCounter.get(), (int) heartbeatDetails.orElse(0));
       Activity.heartbeat(heartbeatCounter.incrementAndGet());
       try {
         throw new IOException("simulated IO problem");

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -423,7 +423,6 @@ public class WorkflowTest {
       assertTrue(e.getCause().getCause() instanceof IOException);
     }
     assertEquals(activitiesImpl.toString(), 3, activitiesImpl.invocations.size());
-    //    fail("boo");
   }
 
   public static class TestActivityRetryOptionsChange implements TestWorkflow1 {

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -2775,7 +2775,8 @@ public class WorkflowTest {
     } catch (WorkflowException e) {
       assertEquals(e.toString(), "simulated 3", e.getCause().getMessage());
     } finally {
-      assertTrue(currentTimeMillis() - start >= 2000); // Ensure that retry delays the restart
+      long elapsed = currentTimeMillis() - start;
+      assertTrue(String.valueOf(elapsed), elapsed >= 2000); // Ensure that retry delays the restart
     }
   }
 

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -2775,7 +2775,7 @@ public class WorkflowTest {
     } catch (WorkflowException e) {
       assertEquals(e.toString(), "simulated 3", e.getCause().getMessage());
     } finally {
-      assertTrue(currentTimeMillis() - start > 2000); // Ensure that retry delays the restart
+      assertTrue(currentTimeMillis() - start >= 2000); // Ensure that retry delays the restart
     }
   }
 

--- a/src/test/resources/testAsyncActivityRetryHistory.json
+++ b/src/test/resources/testAsyncActivityRetryHistory.json
@@ -1,0 +1,455 @@
+{
+  "workflowId": "6249cde7-8c5a-4273-9d83-9defd07a2f29",
+  "runId": "3382defe-f168-49e7-ab5d-761268729983",
+  "events": [
+    {
+      "eventId": 1,
+      "timestamp": 1543620644691760300,
+      "eventType": "WorkflowExecutionStarted",
+      "version": -24,
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "TestWorkflow1::execute"
+        },
+        "taskList": {
+          "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
+        },
+        "input": "IldvcmtmbG93VGVzdC10ZXN0QXN5bmNBY3Rpdml0eVJldHJ5W0RvY2tlciBTdGlja3kgT05dLTNmOWUxZjk5LTc3MTgtNDk3NS1hOGEzLWMwZGZkYWVlNDJmNyI=",
+        "executionStartToCloseTimeoutSeconds": 30,
+        "taskStartToCloseTimeoutSeconds": 5,
+        "identity": ""
+      }
+    },
+    {
+      "eventId": 2,
+      "timestamp": 1543620644691857400,
+      "eventType": "DecisionTaskScheduled",
+      "version": -24,
+      "decisionTaskScheduledEventAttributes": {
+        "taskList": {
+          "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
+        },
+        "startToCloseTimeoutSeconds": 5,
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 3,
+      "timestamp": 1543620644713589400,
+      "eventType": "DecisionTaskStarted",
+      "version": -24,
+      "decisionTaskStartedEventAttributes": {
+        "scheduledEventId": 2,
+        "identity": "90621@maxim-C02XD0AAJGH6",
+        "requestId": "7345637d-b9bb-4ed8-a60b-66c4101e7fcd"
+      }
+    },
+    {
+      "eventId": 4,
+      "timestamp": 1543620644735639900,
+      "eventType": "DecisionTaskCompleted",
+      "version": -24,
+      "decisionTaskCompletedEventAttributes": {
+        "scheduledEventId": 2,
+        "startedEventId": 3,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 5,
+      "timestamp": 1543620644735670000,
+      "eventType": "MarkerRecorded",
+      "version": -24,
+      "markerRecordedEventAttributes": {
+        "markerName": "MutableSideEffect",
+        "details": "eyJpZCI6IjhjMTA2YTQyLWYyYzgtMzMwOC04ZmZhLWFlMTI2OTRhMGFhNiIsImV2ZW50SWQiOjUsImRhdGEiOlsxMjMsMzQsMTA1LDExMCwxMDUsMTE2LDEwNSw5NywxMDgsNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsOTgsOTcsOTksMTA3LDExMSwxMDIsMTAyLDY3LDExMSwxMDEsMTAyLDEwMiwxMDUsOTksMTA1LDEwMSwxMTAsMTE2LDM0LDU4LDQ4LDQ2LDQ4LDQ0LDM0LDEwMSwxMjAsMTEyLDEwNSwxMTQsOTcsMTE2LDEwNSwxMTEsMTEwLDM0LDU4LDExMCwxMTcsMTA4LDEwOCw0NCwzNCwxMDksOTcsMTIwLDEwNSwxMDksMTE3LDEwOSw2NSwxMTYsMTE2LDEwMSwxMDksMTEyLDExNiwxMTUsMzQsNTgsNTEsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNzMsMTEwLDExNiwxMDEsMTE0LDExOCw5NywxMDgsMzQsNTgsMTIzLDM0LDExNSwxMDEsOTksMTExLDExMCwxMDAsMTE1LDM0LDU4LDQ5LDQ0LDM0LDExMCw5NywxMTAsMTExLDExNSwzNCw1OCw0OCwxMjUsNDQsMzQsMTAwLDExMSw3OCwxMTEsMTE2LDgyLDEwMSwxMTYsMTE0LDEyMSwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsMTI1XSwiYWNjZXNzQ291bnQiOjB9",
+        "decisionTaskCompletedEventId": 4
+      }
+    },
+    {
+      "eventId": 6,
+      "timestamp": 1543620644735687400,
+      "eventType": "ActivityTaskScheduled",
+      "version": -24,
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "TestActivities::throwIO"
+        },
+        "taskList": {
+          "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
+        },
+        "scheduleToCloseTimeoutSeconds": 5,
+        "scheduleToStartTimeoutSeconds": 5,
+        "startToCloseTimeoutSeconds": 10,
+        "heartbeatTimeoutSeconds": 5,
+        "decisionTaskCompletedEventId": 4
+      }
+    },
+    {
+      "eventId": 7,
+      "timestamp": 1543620644752061000,
+      "eventType": "ActivityTaskStarted",
+      "version": -24,
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": 6,
+        "identity": "90621@maxim-C02XD0AAJGH6",
+        "requestId": "f4867450-a6ca-4c58-b94b-cad48f09a5ba",
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 8,
+      "timestamp": 1543620644769046400,
+      "eventType": "ActivityTaskFailed",
+      "version": -24,
+      "activityTaskFailedEventAttributes": {
+        "reason": "java.io.IOException",
+        "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIElPIHByb2JsZW0iLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkVGVzdEFjdGl2aXRpZXNJbXBsLnRocm93SU8oV29ya2Zsb3dUZXN0LmphdmE6Mjk3MylcbnN1bi5yZWZsZWN0Lk5hdGl2ZU1ldGhvZEFjY2Vzc29ySW1wbC5pbnZva2UwKE5hdGl2ZSBNZXRob2QpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKE5hdGl2ZU1ldGhvZEFjY2Vzc29ySW1wbC5qYXZhOjYyKVxuc3VuLnJlZmxlY3QuRGVsZWdhdGluZ01ldGhvZEFjY2Vzc29ySW1wbC5pbnZva2UoRGVsZWdhdGluZ01ldGhvZEFjY2Vzc29ySW1wbC5qYXZhOjQzKVxuamF2YS5sYW5nLnJlZmxlY3QuTWV0aG9kLmludm9rZShNZXRob2QuamF2YTo0OTgpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIkUE9KT0FjdGl2aXR5SW1wbGVtZW50YXRpb24uZXhlY3V0ZShQT0pPQWN0aXZpdHlUYXNrSGFuZGxlci5qYXZhOjE5MClcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5QT0pPQWN0aXZpdHlUYXNrSGFuZGxlci5oYW5kbGUoUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIuamF2YToxNjkpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLndvcmtlci5BY3Rpdml0eVdvcmtlciRUYXNrSGFuZGxlckltcGwuaGFuZGxlKEFjdGl2aXR5V29ya2VyLmphdmE6MTkxKVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC53b3JrZXIuQWN0aXZpdHlXb3JrZXIkVGFza0hhbmRsZXJJbXBsLmhhbmRsZShBY3Rpdml0eVdvcmtlci5qYXZhOjE2NilcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwud29ya2VyLlBvbGxUYXNrRXhlY3V0b3IubGFtYmRhJGFjY2VwdCQwKFBvbGxUYXNrRXhlY3V0b3IuamF2YTo3MSlcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvci5ydW5Xb3JrZXIoVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6MTE0OSlcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvciRXb3JrZXIucnVuKFRocmVhZFBvb2xFeGVjdXRvci5qYXZhOjYyNClcbmphdmEubGFuZy5UaHJlYWQucnVuKFRocmVhZC5qYXZhOjc0OClcbiIsInN1cHByZXNzZWRFeGNlcHRpb25zIjpbXSwiY2xhc3MiOiJqYXZhLmlvLklPRXhjZXB0aW9uIn0=",
+        "scheduledEventId": 6,
+        "startedEventId": 7,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 9,
+      "timestamp": 1543620644769068900,
+      "eventType": "DecisionTaskScheduled",
+      "version": -24,
+      "decisionTaskScheduledEventAttributes": {
+        "taskList": {
+          "name": "maxim-C02XD0AAJGH6:1491fd20-a9b3-43ff-b2da-08deef00e92b"
+        },
+        "startToCloseTimeoutSeconds": 5,
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 10,
+      "timestamp": 1543620644821514200,
+      "eventType": "DecisionTaskStarted",
+      "version": -24,
+      "decisionTaskStartedEventAttributes": {
+        "scheduledEventId": 9,
+        "identity": "1491fd20-a9b3-43ff-b2da-08deef00e92b",
+        "requestId": "5c2b9c68-db56-466f-bf9a-3fe27c469dfc"
+      }
+    },
+    {
+      "eventId": 11,
+      "timestamp": 1543620645041285400,
+      "eventType": "DecisionTaskCompleted",
+      "version": -24,
+      "decisionTaskCompletedEventAttributes": {
+        "scheduledEventId": 9,
+        "startedEventId": 10,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 12,
+      "timestamp": 1543620645041301900,
+      "eventType": "TimerStarted",
+      "version": -24,
+      "timerStartedEventAttributes": {
+        "timerId": "2",
+        "startToFireTimeoutSeconds": 1,
+        "decisionTaskCompletedEventId": 11
+      }
+    },
+    {
+      "eventId": 13,
+      "timestamp": 1543620646047206600,
+      "eventType": "TimerFired",
+      "version": -24,
+      "timerFiredEventAttributes": {
+        "timerId": "2",
+        "startedEventId": 12
+      }
+    },
+    {
+      "eventId": 14,
+      "timestamp": 1543620646047227500,
+      "eventType": "DecisionTaskScheduled",
+      "version": -24,
+      "decisionTaskScheduledEventAttributes": {
+        "taskList": {
+          "name": "maxim-C02XD0AAJGH6:1491fd20-a9b3-43ff-b2da-08deef00e92b"
+        },
+        "startToCloseTimeoutSeconds": 5,
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 15,
+      "timestamp": 1543620646068515600,
+      "eventType": "DecisionTaskStarted",
+      "version": -24,
+      "decisionTaskStartedEventAttributes": {
+        "scheduledEventId": 14,
+        "identity": "1491fd20-a9b3-43ff-b2da-08deef00e92b",
+        "requestId": "0ba07097-93d6-4b15-959e-9ada7279a08b"
+      }
+    },
+    {
+      "eventId": 16,
+      "timestamp": 1543620646092745200,
+      "eventType": "DecisionTaskCompleted",
+      "version": -24,
+      "decisionTaskCompletedEventAttributes": {
+        "scheduledEventId": 14,
+        "startedEventId": 15,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 17,
+      "timestamp": 1543620646092759200,
+      "eventType": "MarkerRecorded",
+      "version": -24,
+      "markerRecordedEventAttributes": {
+        "markerName": "MutableSideEffect",
+        "details": "eyJpZCI6IjhjMTA2YTQyLWYyYzgtMzMwOC04ZmZhLWFlMTI2OTRhMGFhNiIsImV2ZW50SWQiOjE3LCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw0OCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNjUsMTE2LDExNiwxMDEsMTA5LDExMiwxMTYsMTE1LDM0LDU4LDUxLDQ0LDM0LDEwOSw5NywxMjAsMTA1LDEwOSwxMTcsMTA5LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDEwMCwxMTEsNzgsMTExLDExNiw4MiwxMDEsMTE2LDExNCwxMjEsMzQsNTgsMTEwLDExNywxMDgsMTA4LDEyNV0sImFjY2Vzc0NvdW50IjoxfQ==",
+        "decisionTaskCompletedEventId": 16
+      }
+    },
+    {
+      "eventId": 18,
+      "timestamp": 1543620646092773800,
+      "eventType": "ActivityTaskScheduled",
+      "version": -24,
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "TestActivities::throwIO"
+        },
+        "taskList": {
+          "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
+        },
+        "scheduleToCloseTimeoutSeconds": 5,
+        "scheduleToStartTimeoutSeconds": 5,
+        "startToCloseTimeoutSeconds": 10,
+        "heartbeatTimeoutSeconds": 5,
+        "decisionTaskCompletedEventId": 16
+      }
+    },
+    {
+      "eventId": 19,
+      "timestamp": 1543620646109925700,
+      "eventType": "ActivityTaskStarted",
+      "version": -24,
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": 18,
+        "identity": "90621@maxim-C02XD0AAJGH6",
+        "requestId": "261b9dba-ba02-4e96-8204-d7c7ee3f3641",
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 20,
+      "timestamp": 1543620646127372800,
+      "eventType": "ActivityTaskFailed",
+      "version": -24,
+      "activityTaskFailedEventAttributes": {
+        "reason": "java.io.IOException",
+        "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIElPIHByb2JsZW0iLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkVGVzdEFjdGl2aXRpZXNJbXBsLnRocm93SU8oV29ya2Zsb3dUZXN0LmphdmE6Mjk3MylcbnN1bi5yZWZsZWN0Lk5hdGl2ZU1ldGhvZEFjY2Vzc29ySW1wbC5pbnZva2UwKE5hdGl2ZSBNZXRob2QpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKE5hdGl2ZU1ldGhvZEFjY2Vzc29ySW1wbC5qYXZhOjYyKVxuc3VuLnJlZmxlY3QuRGVsZWdhdGluZ01ldGhvZEFjY2Vzc29ySW1wbC5pbnZva2UoRGVsZWdhdGluZ01ldGhvZEFjY2Vzc29ySW1wbC5qYXZhOjQzKVxuamF2YS5sYW5nLnJlZmxlY3QuTWV0aG9kLmludm9rZShNZXRob2QuamF2YTo0OTgpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIkUE9KT0FjdGl2aXR5SW1wbGVtZW50YXRpb24uZXhlY3V0ZShQT0pPQWN0aXZpdHlUYXNrSGFuZGxlci5qYXZhOjE5MClcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5QT0pPQWN0aXZpdHlUYXNrSGFuZGxlci5oYW5kbGUoUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIuamF2YToxNjkpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLndvcmtlci5BY3Rpdml0eVdvcmtlciRUYXNrSGFuZGxlckltcGwuaGFuZGxlKEFjdGl2aXR5V29ya2VyLmphdmE6MTkxKVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC53b3JrZXIuQWN0aXZpdHlXb3JrZXIkVGFza0hhbmRsZXJJbXBsLmhhbmRsZShBY3Rpdml0eVdvcmtlci5qYXZhOjE2NilcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwud29ya2VyLlBvbGxUYXNrRXhlY3V0b3IubGFtYmRhJGFjY2VwdCQwKFBvbGxUYXNrRXhlY3V0b3IuamF2YTo3MSlcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvci5ydW5Xb3JrZXIoVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6MTE0OSlcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvciRXb3JrZXIucnVuKFRocmVhZFBvb2xFeGVjdXRvci5qYXZhOjYyNClcbmphdmEubGFuZy5UaHJlYWQucnVuKFRocmVhZC5qYXZhOjc0OClcbiIsInN1cHByZXNzZWRFeGNlcHRpb25zIjpbXSwiY2xhc3MiOiJqYXZhLmlvLklPRXhjZXB0aW9uIn0=",
+        "scheduledEventId": 18,
+        "startedEventId": 19,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 21,
+      "timestamp": 1543620646127386500,
+      "eventType": "DecisionTaskScheduled",
+      "version": -24,
+      "decisionTaskScheduledEventAttributes": {
+        "taskList": {
+          "name": "maxim-C02XD0AAJGH6:1491fd20-a9b3-43ff-b2da-08deef00e92b"
+        },
+        "startToCloseTimeoutSeconds": 5,
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 22,
+      "timestamp": 1543620646175177400,
+      "eventType": "DecisionTaskStarted",
+      "version": -24,
+      "decisionTaskStartedEventAttributes": {
+        "scheduledEventId": 21,
+        "identity": "1491fd20-a9b3-43ff-b2da-08deef00e92b",
+        "requestId": "0cec9cab-473e-41e2-9033-65030666d332"
+      }
+    },
+    {
+      "eventId": 23,
+      "timestamp": 1543620646192364600,
+      "eventType": "DecisionTaskCompleted",
+      "version": -24,
+      "decisionTaskCompletedEventAttributes": {
+        "scheduledEventId": 21,
+        "startedEventId": 22,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 24,
+      "timestamp": 1543620646192378900,
+      "eventType": "TimerStarted",
+      "version": -24,
+      "timerStartedEventAttributes": {
+        "timerId": "4",
+        "startToFireTimeoutSeconds": 1,
+        "decisionTaskCompletedEventId": 23
+      }
+    },
+    {
+      "eventId": 25,
+      "timestamp": 1543620647195763300,
+      "eventType": "TimerFired",
+      "version": -24,
+      "timerFiredEventAttributes": {
+        "timerId": "4",
+        "startedEventId": 24
+      }
+    },
+    {
+      "eventId": 26,
+      "timestamp": 1543620647195788800,
+      "eventType": "DecisionTaskScheduled",
+      "version": -24,
+      "decisionTaskScheduledEventAttributes": {
+        "taskList": {
+          "name": "maxim-C02XD0AAJGH6:1491fd20-a9b3-43ff-b2da-08deef00e92b"
+        },
+        "startToCloseTimeoutSeconds": 5,
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 27,
+      "timestamp": 1543620647212033800,
+      "eventType": "DecisionTaskStarted",
+      "version": -24,
+      "decisionTaskStartedEventAttributes": {
+        "scheduledEventId": 26,
+        "identity": "1491fd20-a9b3-43ff-b2da-08deef00e92b",
+        "requestId": "ee2e717f-863d-41fb-ab68-6fdfe502c0b0"
+      }
+    },
+    {
+      "eventId": 28,
+      "timestamp": 1543620647231514900,
+      "eventType": "DecisionTaskCompleted",
+      "version": -24,
+      "decisionTaskCompletedEventAttributes": {
+        "scheduledEventId": 26,
+        "startedEventId": 27,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 29,
+      "timestamp": 1543620647231528700,
+      "eventType": "MarkerRecorded",
+      "version": -24,
+      "markerRecordedEventAttributes": {
+        "markerName": "MutableSideEffect",
+        "details": "eyJpZCI6IjhjMTA2YTQyLWYyYzgtMzMwOC04ZmZhLWFlMTI2OTRhMGFhNiIsImV2ZW50SWQiOjI5LCJkYXRhIjpbMTIzLDM0LDEwNSwxMTAsMTA1LDExNiwxMDUsOTcsMTA4LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDk4LDk3LDk5LDEwNywxMTEsMTAyLDEwMiw2NywxMTEsMTAxLDEwMiwxMDIsMTA1LDk5LDEwNSwxMDEsMTEwLDExNiwzNCw1OCw0OCw0Niw0OCw0NCwzNCwxMDEsMTIwLDExMiwxMDUsMTE0LDk3LDExNiwxMDUsMTExLDExMCwzNCw1OCwxMTAsMTE3LDEwOCwxMDgsNDQsMzQsMTA5LDk3LDEyMCwxMDUsMTA5LDExNywxMDksNjUsMTE2LDExNiwxMDEsMTA5LDExMiwxMTYsMTE1LDM0LDU4LDUxLDQ0LDM0LDEwOSw5NywxMjAsMTA1LDEwOSwxMTcsMTA5LDczLDExMCwxMTYsMTAxLDExNCwxMTgsOTcsMTA4LDM0LDU4LDEyMywzNCwxMTUsMTAxLDk5LDExMSwxMTAsMTAwLDExNSwzNCw1OCw0OSw0NCwzNCwxMTAsOTcsMTEwLDExMSwxMTUsMzQsNTgsNDgsMTI1LDQ0LDM0LDEwMCwxMTEsNzgsMTExLDExNiw4MiwxMDEsMTE2LDExNCwxMjEsMzQsNTgsMTEwLDExNywxMDgsMTA4LDEyNV0sImFjY2Vzc0NvdW50IjoxfQ==",
+        "decisionTaskCompletedEventId": 28
+      }
+    },
+    {
+      "eventId": 30,
+      "timestamp": 1543620647231543200,
+      "eventType": "ActivityTaskScheduled",
+      "version": -24,
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "5",
+        "activityType": {
+          "name": "TestActivities::throwIO"
+        },
+        "taskList": {
+          "name": "WorkflowTest-testAsyncActivityRetry[Docker Sticky ON]-3f9e1f99-7718-4975-a8a3-c0dfdaee42f7"
+        },
+        "scheduleToCloseTimeoutSeconds": 5,
+        "scheduleToStartTimeoutSeconds": 5,
+        "startToCloseTimeoutSeconds": 10,
+        "heartbeatTimeoutSeconds": 5,
+        "decisionTaskCompletedEventId": 28
+      }
+    },
+    {
+      "eventId": 31,
+      "timestamp": 1543620647247272200,
+      "eventType": "ActivityTaskStarted",
+      "version": -24,
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": 30,
+        "identity": "90621@maxim-C02XD0AAJGH6",
+        "requestId": "87ab5e68-66af-481c-880e-2d187fd4186b",
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 32,
+      "timestamp": 1543620647262535400,
+      "eventType": "ActivityTaskFailed",
+      "version": -24,
+      "activityTaskFailedEventAttributes": {
+        "reason": "java.io.IOException",
+        "details": "eyJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIElPIHByb2JsZW0iLCJzdGFja1RyYWNlIjoiY29tLnViZXIuY2FkZW5jZS53b3JrZmxvdy5Xb3JrZmxvd1Rlc3QkVGVzdEFjdGl2aXRpZXNJbXBsLnRocm93SU8oV29ya2Zsb3dUZXN0LmphdmE6Mjk3MylcbnN1bi5yZWZsZWN0Lk5hdGl2ZU1ldGhvZEFjY2Vzc29ySW1wbC5pbnZva2UwKE5hdGl2ZSBNZXRob2QpXG5zdW4ucmVmbGVjdC5OYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKE5hdGl2ZU1ldGhvZEFjY2Vzc29ySW1wbC5qYXZhOjYyKVxuc3VuLnJlZmxlY3QuRGVsZWdhdGluZ01ldGhvZEFjY2Vzc29ySW1wbC5pbnZva2UoRGVsZWdhdGluZ01ldGhvZEFjY2Vzc29ySW1wbC5qYXZhOjQzKVxuamF2YS5sYW5nLnJlZmxlY3QuTWV0aG9kLmludm9rZShNZXRob2QuamF2YTo0OTgpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIkUE9KT0FjdGl2aXR5SW1wbGVtZW50YXRpb24uZXhlY3V0ZShQT0pPQWN0aXZpdHlUYXNrSGFuZGxlci5qYXZhOjE5MClcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5QT0pPQWN0aXZpdHlUYXNrSGFuZGxlci5oYW5kbGUoUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIuamF2YToxNjkpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLndvcmtlci5BY3Rpdml0eVdvcmtlciRUYXNrSGFuZGxlckltcGwuaGFuZGxlKEFjdGl2aXR5V29ya2VyLmphdmE6MTkxKVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC53b3JrZXIuQWN0aXZpdHlXb3JrZXIkVGFza0hhbmRsZXJJbXBsLmhhbmRsZShBY3Rpdml0eVdvcmtlci5qYXZhOjE2NilcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwud29ya2VyLlBvbGxUYXNrRXhlY3V0b3IubGFtYmRhJGFjY2VwdCQwKFBvbGxUYXNrRXhlY3V0b3IuamF2YTo3MSlcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvci5ydW5Xb3JrZXIoVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6MTE0OSlcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvciRXb3JrZXIucnVuKFRocmVhZFBvb2xFeGVjdXRvci5qYXZhOjYyNClcbmphdmEubGFuZy5UaHJlYWQucnVuKFRocmVhZC5qYXZhOjc0OClcbiIsInN1cHByZXNzZWRFeGNlcHRpb25zIjpbXSwiY2xhc3MiOiJqYXZhLmlvLklPRXhjZXB0aW9uIn0=",
+        "scheduledEventId": 30,
+        "startedEventId": 31,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 33,
+      "timestamp": 1543620647262556500,
+      "eventType": "DecisionTaskScheduled",
+      "version": -24,
+      "decisionTaskScheduledEventAttributes": {
+        "taskList": {
+          "name": "maxim-C02XD0AAJGH6:1491fd20-a9b3-43ff-b2da-08deef00e92b"
+        },
+        "startToCloseTimeoutSeconds": 5,
+        "attempt": 0
+      }
+    },
+    {
+      "eventId": 34,
+      "timestamp": 1543620647325919700,
+      "eventType": "DecisionTaskStarted",
+      "version": -24,
+      "decisionTaskStartedEventAttributes": {
+        "scheduledEventId": 33,
+        "identity": "1491fd20-a9b3-43ff-b2da-08deef00e92b",
+        "requestId": "b71ef76e-6679-48be-b1b7-1c69cb6c1991"
+      }
+    },
+    {
+      "eventId": 35,
+      "timestamp": 1543620647350743800,
+      "eventType": "DecisionTaskCompleted",
+      "version": -24,
+      "decisionTaskCompletedEventAttributes": {
+        "scheduledEventId": 33,
+        "startedEventId": 34,
+        "identity": "90621@maxim-C02XD0AAJGH6"
+      }
+    },
+    {
+      "eventId": 36,
+      "timestamp": 1543620647350758900,
+      "eventType": "WorkflowExecutionFailed",
+      "version": -24,
+      "workflowExecutionFailedEventAttributes": {
+        "reason": "com.uber.cadence.workflow.ActivityFailureException",
+        "details": "eyJhY3Rpdml0eVR5cGUiOnsibmFtZSI6IlRlc3RBY3Rpdml0aWVzOjp0aHJvd0lPIn0sImFjdGl2aXR5SWQiOm51bGwsImV2ZW50SWQiOjMyLCJkZXRhaWxNZXNzYWdlIjoic2ltdWxhdGVkIElPIHByb2JsZW0sIEFjdGl2aXR5VHlwZVx1MDAzZFwiVGVzdEFjdGl2aXRpZXM6OnRocm93SU9cIiBBY3Rpdml0eUlEXHUwMDNkXCJudWxsXCIsIEV2ZW50SURcdTAwM2QzMiIsImNhdXNlIjp7ImRldGFpbE1lc3NhZ2UiOiJzaW11bGF0ZWQgSU8gcHJvYmxlbSIsInN0YWNrVHJhY2UiOiJjb20udWJlci5jYWRlbmNlLndvcmtmbG93LldvcmtmbG93VGVzdCRUZXN0QWN0aXZpdGllc0ltcGwudGhyb3dJTyhXb3JrZmxvd1Rlc3QuamF2YToyOTczKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZTAoTmF0aXZlIE1ldGhvZDowKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShOYXRpdmVNZXRob2RBY2Nlc3NvckltcGwuamF2YTo2MilcbnN1bi5yZWZsZWN0LkRlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuaW52b2tlKERlbGVnYXRpbmdNZXRob2RBY2Nlc3NvckltcGwuamF2YTo0MylcbmphdmEubGFuZy5yZWZsZWN0Lk1ldGhvZC5pbnZva2UoTWV0aG9kLmphdmE6NDk4KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLlBPSk9BY3Rpdml0eVRhc2tIYW5kbGVyJFBPSk9BY3Rpdml0eUltcGxlbWVudGF0aW9uLmV4ZWN1dGUoUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIuamF2YToxOTApXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuUE9KT0FjdGl2aXR5VGFza0hhbmRsZXIuaGFuZGxlKFBPSk9BY3Rpdml0eVRhc2tIYW5kbGVyLmphdmE6MTY5KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC53b3JrZXIuQWN0aXZpdHlXb3JrZXIkVGFza0hhbmRsZXJJbXBsLmhhbmRsZShBY3Rpdml0eVdvcmtlci5qYXZhOjE5MSlcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwud29ya2VyLkFjdGl2aXR5V29ya2VyJFRhc2tIYW5kbGVySW1wbC5oYW5kbGUoQWN0aXZpdHlXb3JrZXIuamF2YToxNjYpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLndvcmtlci5Qb2xsVGFza0V4ZWN1dG9yLmxhbWJkYSRhY2NlcHQkMChQb2xsVGFza0V4ZWN1dG9yLmphdmE6NzEpXG5qYXZhLnV0aWwuY29uY3VycmVudC5UaHJlYWRQb29sRXhlY3V0b3IucnVuV29ya2VyKFRocmVhZFBvb2xFeGVjdXRvci5qYXZhOjExNDkpXG5qYXZhLnV0aWwuY29uY3VycmVudC5UaHJlYWRQb29sRXhlY3V0b3IkV29ya2VyLnJ1bihUaHJlYWRQb29sRXhlY3V0b3IuamF2YTo2MjQpXG5qYXZhLmxhbmcuVGhyZWFkLnJ1bihUaHJlYWQuamF2YTo3NDgpXG4iLCJzdXBwcmVzc2VkRXhjZXB0aW9ucyI6W10sImNsYXNzIjoiamF2YS5pby5JT0V4Y2VwdGlvbiJ9LCJzdGFja1RyYWNlIjoiamF2YS5sYW5nLlRocmVhZC5nZXRTdGFja1RyYWNlKFRocmVhZC5qYXZhOjE1NTkpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuQ29tcGxldGFibGVQcm9taXNlSW1wbC50aHJvd0ZhaWx1cmUoQ29tcGxldGFibGVQcm9taXNlSW1wbC5qYXZhOjExMClcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5Db21wbGV0YWJsZVByb21pc2VJbXBsLmdldChDb21wbGV0YWJsZVByb21pc2VJbXBsLmphdmE6NzUpXG5jb20udWJlci5jYWRlbmNlLndvcmtmbG93LldvcmtmbG93VGVzdCRUZXN0QXN5bmNBY3Rpdml0eVJldHJ5LmV4ZWN1dGUoV29ya2Zsb3dUZXN0LmphdmE6NTUwKVxuc3VuLnJlZmxlY3QuTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZTAoTmF0aXZlIE1ldGhvZClcbnN1bi5yZWZsZWN0Lk5hdGl2ZU1ldGhvZEFjY2Vzc29ySW1wbC5pbnZva2UoTmF0aXZlTWV0aG9kQWNjZXNzb3JJbXBsLmphdmE6NjIpXG5zdW4ucmVmbGVjdC5EZWxlZ2F0aW5nTWV0aG9kQWNjZXNzb3JJbXBsLmludm9rZShEZWxlZ2F0aW5nTWV0aG9kQWNjZXNzb3JJbXBsLmphdmE6NDMpXG5qYXZhLmxhbmcucmVmbGVjdC5NZXRob2QuaW52b2tlKE1ldGhvZC5qYXZhOjQ5OClcbmNvbS51YmVyLmNhZGVuY2UuaW50ZXJuYWwuc3luYy5QT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbkZhY3RvcnkkUE9KT1dvcmtmbG93SW1wbGVtZW50YXRpb24uZXhlY3V0ZShQT0pPV29ya2Zsb3dJbXBsZW1lbnRhdGlvbkZhY3RvcnkuamF2YToyMTMpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuV29ya2Zsb3dSdW5uYWJsZS5ydW4oV29ya2Zsb3dSdW5uYWJsZS5qYXZhOjQ2KVxuY29tLnViZXIuY2FkZW5jZS5pbnRlcm5hbC5zeW5jLkNhbmNlbGxhdGlvblNjb3BlSW1wbC5ydW4oQ2FuY2VsbGF0aW9uU2NvcGVJbXBsLmphdmE6OTMpXG5jb20udWJlci5jYWRlbmNlLmludGVybmFsLnN5bmMuV29ya2Zsb3dUaHJlYWRJbXBsJFJ1bm5hYmxlV3JhcHBlci5ydW4oV29ya2Zsb3dUaHJlYWRJbXBsLmphdmE6ODMpXG5qYXZhLnV0aWwuY29uY3VycmVudC5FeGVjdXRvcnMkUnVubmFibGVBZGFwdGVyLmNhbGwoRXhlY3V0b3JzLmphdmE6NTExKVxuamF2YS51dGlsLmNvbmN1cnJlbnQuRnV0dXJlVGFzay5ydW4oRnV0dXJlVGFzay5qYXZhOjI2NilcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvci5ydW5Xb3JrZXIoVGhyZWFkUG9vbEV4ZWN1dG9yLmphdmE6MTE0OSlcbmphdmEudXRpbC5jb25jdXJyZW50LlRocmVhZFBvb2xFeGVjdXRvciRXb3JrZXIucnVuKFRocmVhZFBvb2xFeGVjdXRvci5qYXZhOjYyNClcbmphdmEubGFuZy5UaHJlYWQucnVuKFRocmVhZC5qYXZhOjc0OClcbiIsInN1cHByZXNzZWRFeGNlcHRpb25zIjpbXSwiY2xhc3MiOiJjb20udWJlci5jYWRlbmNlLndvcmtmbG93LkFjdGl2aXR5RmFpbHVyZUV4Y2VwdGlvbiJ9",
+        "decisionTaskCompletedEventId": 35
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The change is API compatible as ActivityOptions already had RetryOptions. 
The previous implementation used the client side retry, the new switched to the server side.
The changes include addition of the server side retry to the TestWorkflowService.