### PR TITLE
Fixed thread exhaustion with large number of parallel async activities  

### DIFF
--- a/src/main/java/com/uber/cadence/internal/common/Retryer.java
+++ b/src/main/java/com/uber/cadence/internal/common/Retryer.java
@@ -20,6 +20,7 @@ package com.uber.cadence.internal.common;
 import static com.uber.cadence.internal.common.CheckedExceptionWrapper.unwrap;
 
 import com.uber.cadence.common.RetryOptions;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
@@ -105,8 +106,10 @@ public final class Retryer {
           }
         }
         long elapsed = System.currentTimeMillis() - startTime;
-        if (attempt >= options.getMaximumAttempts()
-            || elapsed >= options.getExpiration().toMillis()) {
+        int maxAttempts = options.getMaximumAttempts();
+        Duration expiration = options.getExpiration();
+        if ((maxAttempts > 0 && attempt >= maxAttempts)
+            || (expiration != null && elapsed >= expiration.toMillis())) {
           rethrow(e);
         }
         log.warn("Retrying after failure", e);

--- a/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
@@ -94,7 +94,7 @@ public class WorkflowExecutionUtils {
       new RetryOptions.Builder()
           .setBackoffCoefficient(2)
           .setInitialInterval(Duration.ofMillis(500))
-          .setMaximumInterval(Duration.ofSeconds(30))
+          .setMaximumInterval(Duration.ofSeconds(10))
           .setDoNotRetry(BadRequestError.class, EntityNotExistsError.class)
           .build();
 

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -211,7 +211,6 @@ class DeterministicRunnerImpl implements DeterministicRunner {
           // Otherwise signal might be never processed if it was received
           // after workflow decided to close.
           threads.addFirst(thread);
-          thread.start();
         }
         toExecuteInWorkflowThread.clear();
         progress = false;

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadContext.java
@@ -49,8 +49,12 @@ class WorkflowThreadContext {
   }
 
   public void initialYield() {
-    if (getStatus() != Status.RUNNING) {
-      throw new IllegalStateException("not in RUNNING but in " + getStatus() + " state");
+    Status status = getStatus();
+    if (status == Status.DONE) {
+      throw new DestroyWorkflowThreadError("done in initialYield");
+    }
+    if (status != Status.RUNNING) {
+      throw new IllegalStateException("not in RUNNING but in " + status + " state");
     }
     yield("created", () -> true);
   }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
@@ -300,8 +300,7 @@ class WorkflowThreadImpl implements WorkflowThread {
   @Override
   public boolean runUntilBlocked() {
     if (taskFuture == null) {
-      // Thread is not yet started
-      return false;
+      start();
     }
     return context.runUntilBlocked();
   }


### PR DESCRIPTION
- Moved thread start to runUntilBlocked to delay grabbing thread from the pool. Before this fix to complete 500 activities asynchronously it would grab 500 threads before running the runUntilBlocked.
- Fixed Retryer to correctly interpret 0 maxAttempts and null expiration.
- Added testLargeHistory unit test

