### PR TITLE
Fixed InternalServiceError Error message on continue_as_new

### DIFF
--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableState.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableState.java
@@ -96,7 +96,8 @@ interface TestWorkflowMutableState {
   void childWorkflowCanceled(String workflowId, ChildWorkflowExecutionCanceledEventAttributes a)
       throws InternalServiceError, EntityNotExistsError, BadRequestError;
 
-  void startWorkflow(Optional<SignalWorkflowExecutionRequest> signalWithStartSignal)
+  void startWorkflow(
+      boolean continuedAsNew, Optional<SignalWorkflowExecutionRequest> signalWithStartSignal)
       throws InternalServiceError, BadRequestError;
 
   void startActivityTask(PollForActivityTaskResponse task, PollForActivityTaskRequest pollRequest)

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -959,7 +959,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   }
 
   @Override
-  public void startWorkflow(Optional<SignalWorkflowExecutionRequest> signalWithStartSignal)
+  public void startWorkflow(
+      boolean continuedAsNew, Optional<SignalWorkflowExecutionRequest> signalWithStartSignal)
       throws InternalServiceError, BadRequestError {
     try {
       update(
@@ -998,7 +999,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     } catch (EntityNotExistsError entityNotExistsError) {
       throw new InternalServiceError(Throwables.getStackTraceAsString(entityNotExistsError));
     }
-    if (parent.isPresent()) {
+    if (!continuedAsNew && parent.isPresent()) {
       ChildWorkflowExecutionStartedEventAttributes a =
           new ChildWorkflowExecutionStartedEventAttributes()
               .setInitiatedEventId(parentChildInitiatedEventId.getAsLong())

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -238,6 +238,7 @@ public final class TestWorkflowService implements IWorkflowService {
       Optional<RetryState> retryState = newRetryStateLocked(retryPolicy);
       return startWorkflowExecutionNoRunningCheckLocked(
           startRequest,
+          false,
           retryState,
           backoffStartIntervalInSeconds,
           null,
@@ -275,6 +276,7 @@ public final class TestWorkflowService implements IWorkflowService {
 
   private StartWorkflowExecutionResponse startWorkflowExecutionNoRunningCheckLocked(
       StartWorkflowExecutionRequest startRequest,
+      boolean continuedAsNew,
       Optional<RetryState> retryState,
       int backoffStartIntervalInSeconds,
       byte[] lastCompletionResult,
@@ -298,7 +300,7 @@ public final class TestWorkflowService implements IWorkflowService {
     ExecutionId executionId = new ExecutionId(domain, execution);
     executionsByWorkflowId.put(workflowId, mutableState);
     executions.put(executionId, mutableState);
-    mutableState.startWorkflow(signalWithStartSignal);
+    mutableState.startWorkflow(continuedAsNew, signalWithStartSignal);
     return new StartWorkflowExecutionResponse().setRunId(execution.getRunId());
   }
 
@@ -592,6 +594,7 @@ public final class TestWorkflowService implements IWorkflowService {
       StartWorkflowExecutionResponse response =
           startWorkflowExecutionNoRunningCheckLocked(
               startRequest,
+              true,
               retryState,
               a.getBackoffStartIntervalInSeconds(),
               a.getLastCompletionResult(),


### PR DESCRIPTION
Fixed this benign, but annoying error. The root cause is reporting child start to a parent on continue as new. The parent rejects duplicated starts.

```
    15:37:00.078 [ForkJoinPool.commonPool-worker-0] ERROR c.u.c.i.t.TestWorkflowMutableStateImpl - Failure reporting child completion
    com.uber.cadence.InternalServiceError: Invalid Transition{from=STARTED, action=START}, history: [Transition{from=NONE, action=INITIATE}, Transition{from=INITIATED, action=START}]
        at com.uber.cadence.internal.testservice.StateMachine.action(StateMachine.java:230)
        at com.uber.cadence.internal.testservice.TestWorkflowMutableStateImpl.lambda$childWorkflowStarted$10(TestWorkflowMutableStateImpl.java:627)
        at com.uber.cadence.internal.testservice.TestWorkflowMutableStateImpl.update(TestWorkflowMutableStateImpl.java:154)
        at com.uber.cadence.internal.testservice.TestWorkflowMutableStateImpl.update(TestWorkflowMutableStateImpl.java:131)
        at com.uber.cadence.internal.testservice.TestWorkflowMutableStateImpl.childWorkflowStarted(TestWorkflowMutableStateImpl.java:624)
        at com.uber.cadence.internal.testservice.TestWorkflowMutableStateImpl.lambda$startWorkflow$24(TestWorkflowMutableStateImpl.java:1012)
        at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```