### PR TITLE
Exposing CancellationScope.run method

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/CancellationScopeImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/CancellationScopeImpl.java
@@ -87,7 +87,8 @@ class CancellationScopeImpl implements CancellationScope {
     }
   }
 
-  void run() {
+  @Override
+  public void run() {
     try {
       pushCurrent(this);
       runnable.run();

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
@@ -37,7 +37,6 @@ import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.QueryMethod;
-import com.uber.cadence.workflow.RunnableCancellationScope;
 import com.uber.cadence.workflow.Workflow;
 import com.uber.cadence.workflow.WorkflowInfo;
 import com.uber.cadence.workflow.WorkflowInterceptor;
@@ -280,9 +279,7 @@ public final class WorkflowInternal {
   }
 
   public static CancellationScope newCancellationScope(boolean detached, Runnable runnable) {
-    CancellationScopeImpl result = new CancellationScopeImpl(detached, runnable);
-    result.run();
-    return result;
+    return new CancellationScopeImpl(detached, runnable);
   }
 
   public static CancellationScopeImpl currentCancellationScope() {

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
@@ -27,6 +27,7 @@ import com.uber.cadence.internal.common.CheckedExceptionWrapper;
 import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.logging.ReplayAwareLogger;
 import com.uber.cadence.workflow.ActivityStub;
+import com.uber.cadence.workflow.CancellationScope;
 import com.uber.cadence.workflow.ChildWorkflowOptions;
 import com.uber.cadence.workflow.ChildWorkflowStub;
 import com.uber.cadence.workflow.CompletablePromise;
@@ -278,7 +279,7 @@ public final class WorkflowInternal {
     return CompletablePromiseImpl.promiseAnyOf(promises);
   }
 
-  public static RunnableCancellationScope newCancellationScope(boolean detached, Runnable runnable) {
+  public static CancellationScope newCancellationScope(boolean detached, Runnable runnable) {
     CancellationScopeImpl result = new CancellationScopeImpl(detached, runnable);
     result.run();
     return result;

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
@@ -27,7 +27,6 @@ import com.uber.cadence.internal.common.CheckedExceptionWrapper;
 import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.logging.ReplayAwareLogger;
 import com.uber.cadence.workflow.ActivityStub;
-import com.uber.cadence.workflow.CancellationScope;
 import com.uber.cadence.workflow.ChildWorkflowOptions;
 import com.uber.cadence.workflow.ChildWorkflowStub;
 import com.uber.cadence.workflow.CompletablePromise;
@@ -37,6 +36,7 @@ import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.QueryMethod;
+import com.uber.cadence.workflow.RunnableCancellationScope;
 import com.uber.cadence.workflow.Workflow;
 import com.uber.cadence.workflow.WorkflowInfo;
 import com.uber.cadence.workflow.WorkflowInterceptor;
@@ -278,7 +278,7 @@ public final class WorkflowInternal {
     return CompletablePromiseImpl.promiseAnyOf(promises);
   }
 
-  public static CancellationScope newCancellationScope(boolean detached, Runnable runnable) {
+  public static RunnableCancellationScope newCancellationScope(boolean detached, Runnable runnable) {
     CancellationScopeImpl result = new CancellationScopeImpl(detached, runnable);
     result.run();
     return result;

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
@@ -190,6 +190,11 @@ class WorkflowThreadImpl implements WorkflowThread {
   }
 
   @Override
+  public void run() {
+    throw new UnsupportedOperationException("not used");
+  }
+
+  @Override
   public boolean isDetached() {
     return task.cancellationScope.isDetached();
   }

--- a/src/main/java/com/uber/cadence/workflow/CancellationScope.java
+++ b/src/main/java/com/uber/cadence/workflow/CancellationScope.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CancellationException;
  * {@link Workflow#newDetachedCancellationScope(Runnable)}. Supports explicit cancelling of the code
  * a cancellation scope wraps.
  */
-public interface CancellationScope {
+public interface CancellationScope extends Runnable {
 
   /**
    * When set to false parent thread cancellation causes this one to get cancelled automatically.

--- a/src/main/java/com/uber/cadence/workflow/RunnableCancellationScope.java
+++ b/src/main/java/com/uber/cadence/workflow/RunnableCancellationScope.java
@@ -1,4 +1,0 @@
-package com.uber.cadence.workflow;
-
-public interface RunnableCancellationScope extends CancellationScope, Runnable {
-}

--- a/src/main/java/com/uber/cadence/workflow/RunnableCancellationScope.java
+++ b/src/main/java/com/uber/cadence/workflow/RunnableCancellationScope.java
@@ -1,0 +1,4 @@
+package com.uber.cadence.workflow;
+
+public interface RunnableCancellationScope extends CancellationScope, Runnable {
+}

--- a/src/main/java/com/uber/cadence/workflow/Workflow.java
+++ b/src/main/java/com/uber/cadence/workflow/Workflow.java
@@ -537,13 +537,26 @@ public final class Workflow {
     return WorkflowInternal.getWorkflowInfo();
   }
 
-  public static <R> CancellationScope newCancellationScope(Runnable runnable) {
-    return WorkflowInternal.newCancellationScope(false, runnable);
+  public static CancellationScope newCancellationScope(Runnable runnable) {
+    RunnableCancellationScope result = WorkflowInternal.newCancellationScope(false, runnable);
+    result.run();
+    return result;
   }
 
   public static CancellationScope newDetachedCancellationScope(Runnable runnable) {
+    RunnableCancellationScope result = WorkflowInternal.newCancellationScope(true, runnable);
+    result.run();
+    return result;
+  }
+
+  public static RunnableCancellationScope newRunnableCancellationScope(Runnable runnable) {
+    return WorkflowInternal.newCancellationScope(false, runnable);
+  }
+
+  public static RunnableCancellationScope newDetachedRunnableCancellationScope(Runnable runnable) {
     return WorkflowInternal.newCancellationScope(true, runnable);
   }
+
 
   /**
    * Create new timer. Note that Cadence service time resolution is in seconds. So all durations are

--- a/src/main/java/com/uber/cadence/workflow/Workflow.java
+++ b/src/main/java/com/uber/cadence/workflow/Workflow.java
@@ -537,26 +537,19 @@ public final class Workflow {
     return WorkflowInternal.getWorkflowInfo();
   }
 
+  /**
+   * Wraps runnable parameter in a CancellationScope. The {@link CancellationScope#run()} hast to be called to
+   * execute
+   * @param runnable
+   * @return
+   */
   public static CancellationScope newCancellationScope(Runnable runnable) {
-    RunnableCancellationScope result = WorkflowInternal.newCancellationScope(false, runnable);
-    result.run();
-    return result;
-  }
-
-  public static CancellationScope newDetachedCancellationScope(Runnable runnable) {
-    RunnableCancellationScope result = WorkflowInternal.newCancellationScope(true, runnable);
-    result.run();
-    return result;
-  }
-
-  public static RunnableCancellationScope newRunnableCancellationScope(Runnable runnable) {
     return WorkflowInternal.newCancellationScope(false, runnable);
   }
 
-  public static RunnableCancellationScope newDetachedRunnableCancellationScope(Runnable runnable) {
+  public static CancellationScope newDetachedCancellationScope(Runnable runnable) {
     return WorkflowInternal.newCancellationScope(true, runnable);
   }
-
 
   /**
    * Create new timer. Note that Cadence service time resolution is in seconds. So all durations are

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -867,21 +867,26 @@ public class WorkflowTest {
         testActivities.activityWithDelay(100000, true);
         fail("unreachable");
       } catch (CancellationException e) {
-        Workflow.newDetachedCancellationScope(() -> assertEquals(1, testActivities.activity1(1)));
+        Workflow.newDetachedCancellationScope(() -> assertEquals(1, testActivities.activity1(1)))
+            .run();
       }
       try {
         Workflow.sleep(Duration.ofHours(1));
         fail("unreachable");
       } catch (CancellationException e) {
         Workflow.newDetachedCancellationScope(
-            () -> assertEquals("a12", testActivities.activity2("a1", 2)));
+                () -> assertEquals("a12", testActivities.activity2("a1", 2)))
+            .run();
+        ;
       }
       try {
         Workflow.newTimer(Duration.ofHours(1)).get();
         fail("unreachable");
       } catch (CancellationException e) {
         Workflow.newDetachedCancellationScope(
-            () -> assertEquals("a123", testActivities.activity3("a1", 2, 3)));
+                () -> assertEquals("a123", testActivities.activity3("a1", 2, 3)))
+            .run();
+        ;
       }
       return "result";
     }
@@ -2680,6 +2685,7 @@ public class WorkflowTest {
       CancellationScope scope =
           Workflow.newCancellationScope(
               () -> signal.completeFrom(Async.procedure(workflow::signal1, "World")));
+      scope.run();
       scope.cancel();
       try {
         signal.get();


### PR DESCRIPTION
Currently 

`
CancellationScope s = Workflow.newCancellationScope(() -> { /* some code */});
`

executes _some code_ before returning from the `newCancellationScope` method and assigning the `s` variable. It forces any code that should be explicitly cancellable be asynchronous. This PR adds run method to `CancellationScope` and doesn't execute code in it until this method is called. So the intended usage is:

```
CancellationScope s = Workflow.newCancellationScope(() -> { /* some code */});
// Register s with whatever code that might need initiate cancellation here. 
// Then execute the cancellable code
s.run();
```