### PR TITLE
Multiple fixes to get build and unit-tests passing when building cadence-java-client from Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,10 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
 }
 
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/main/java/com/uber/cadence/converter/CustomThrowableTypeAdapter.java
+++ b/src/main/java/com/uber/cadence/converter/CustomThrowableTypeAdapter.java
@@ -171,7 +171,7 @@ class CustomThrowableTypeAdapter<T extends Throwable> extends TypeAdapter<T> {
     }
     try {
       @SuppressWarnings("StringSplitter")
-      String[] lines = stackTrace.split("\n");
+      String[] lines = stackTrace.split("\r\n|\n");
       StackTraceElement[] result = new StackTraceElement[lines.length];
       for (int i = 0; i < lines.length; i++) {
         result[i] = parseStackTraceElement(lines[i]);

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -412,7 +412,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   }
 
   private static Map<String, String> getThriftHeaders(ClientOptions options) {
-    String envUserName = System.getenv("USER");
+    String envUserName = System.getProperty("user.name");
     String envHostname;
     try {
       envHostname = InetAddress.getLocalHost().getHostName();


### PR DESCRIPTION


* WorflowServiceTChannel: fix failure to establish connection with cadence-server due to null user-name in thrift headers. On Windows user-name is provided by USERNAME environment variable instead of USER on Unix.

    com.uber.cadence.workflow.WorkflowTest > initializationError FAILED
    java.lang.ExceptionInInitializerError

        Caused by:
        java.lang.NullPointerException: null value in entry: user-name=null
            at com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:32)
            at com.google.common.collect.ImmutableMap.entryOf(ImmutableMap.java:176)
            at com.google.common.collect.ImmutableMap$Builder.put(ImmutableMap.java:285)
            at com.uber.cadence.serviceclient.WorkflowServiceTChannel.getThriftHeaders(WorkflowServiceTChannel.java:425)
            at com.uber.cadence.serviceclient.WorkflowServiceTChannel.<init>(WorkflowServiceTChannel.java:377)
            at com.uber.cadence.serviceclient.WorkflowServiceTChannel.<init>(WorkflowServiceTChannel.java:344)
            at com.uber.cadence.workflow.WorkflowTest.<clinit>(WorkflowTest.java:181)

* CustomThrowableTypeAdapter : fix wrong deserialization of throwable stacktrace generated from windows hosts. Windows end of line "\r\n" not properly detected.

com.uber.cadence.converter.DataConverterException: when parsing:"{"detailMessage":"application exception","cause":{"detailMessage":"Failure serializing exception: com.uber.cadence.converter.JsonDataConverterTest$NonSerializableException: java.lang.RuntimeException: root exception","cause":{"detailMessage":null,"cause":" into following types: [class java.lang.RuntimeException]

	at com.uber.cadence.converter.JsonDataConverter.fromData(JsonDataConverter.java:112)
	at com.uber.cadence.converter.JsonDataConverterTest.testException(JsonDataConverterTest.java:255)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.NullPointerException: stackTrace[0]
	at java.lang.Throwable.setStackTrace(Throwable.java:867)
	at com.uber.cadence.converter.CustomThrowableTypeAdapter.read(CustomThrowableTypeAdapter.java:155)
	at com.uber.cadence.converter.CustomThrowableTypeAdapter.read(CustomThrowableTypeAdapter.java:34)
	at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
	at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:285)
	at com.uber.cadence.converter.CustomThrowableTypeAdapter.read(CustomThrowableTypeAdapter.java:154)
	at com.uber.cadence.converter.CustomThrowableTypeAdapter.read(CustomThrowableTypeAdapter.java:34)
	at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222)
	at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:285)
	at com.uber.cadence.converter.CustomThrowableTypeAdapter.read(CustomThrowableTypeAdapter.java:154)
	at com.uber.cadence.converter.CustomThrowableTypeAdapter.read(CustomThrowableTypeAdapter.java:34)
	at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199)
	at com.google.gson.Gson.fromJson(Gson.java:927)
	at com.google.gson.Gson.fromJson(Gson.java:892)
	at com.google.gson.Gson.fromJson(Gson.java:841)
	at com.uber.cadence.converter.JsonDataConverter.fromData(JsonDataConverter.java:110)

* add gradle wrapper script for windows (generated with gradle wrapper)

* enforce javadoc encoding to UTF-8 to avoid build failures due to unmappable characters to local charset

    > Task :javadoc
    cadence-java-client\src\main\java\com\uber\cadence\workflow\Workflow.java:1007: error: unmappable character for encoding Cp1252
       * it will fail here and not proceed; 2) if you ever need to make more changes for ÔÇ£fooChangeÔÇ?,
                                                                                                                       ^
    cadence-java-client\src\main\java\com\uber\cadence\workflow\Workflow.java:1013: error: unmappable character for encoding Cp1252
       * sure: 1) all older version executions are completed; 2) you can no longer use ÔÇ£fooChangeÔÇ? as
                                                                                                                    ^
    cadence-java-client\src\main\java\com\uber\cadence\workflow\Workflow.java:1015: error: unmappable character for encoding Cp1252
       * changeID like ÔÇ£fooChange-fix2ÔÇ?, and start minVersion from DefaultVersion again.
                             ^
    3 errors