### PR TITLE
Default retry policy for Cadence service API calls

### DIFF
--- a/src/main/java/com/uber/cadence/common/RetryOptions.java
+++ b/src/main/java/com/uber/cadence/common/RetryOptions.java
@@ -18,13 +18,6 @@
 package com.uber.cadence.common;
 
 import com.google.common.base.Defaults;
-import com.uber.cadence.BadRequestError;
-import com.uber.cadence.CancellationAlreadyRequestedError;
-import com.uber.cadence.DomainAlreadyExistsError;
-import com.uber.cadence.DomainNotActiveError;
-import com.uber.cadence.EntityNotExistsError;
-import com.uber.cadence.QueryFailedError;
-import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
 import com.uber.cadence.workflow.ActivityFailureException;
 import com.uber.cadence.workflow.ChildWorkflowFailureException;
 import java.time.Duration;
@@ -34,36 +27,9 @@ import java.util.List;
 import java.util.Objects;
 
 public final class RetryOptions {
-  public static final RetryOptions DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
 
-  private static final Duration RETRY_SERVICE_OPERATION_INITIAL_INTERVAL = Duration.ofMillis(20);
-  private static final Duration RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL = Duration.ofMinutes(1);
-  private static final double RETRY_SERVICE_OPERATION_BACKOFF = 1.2;
   private static final double DEFAULT_BACKOFF_COEFFICIENT = 2.0;
   private static final int DEFAULT_MAXIMUM_MULTIPLIER = 100;
-
-  static {
-    RetryOptions.Builder roBuilder =
-        new RetryOptions.Builder()
-            .setInitialInterval(RETRY_SERVICE_OPERATION_INITIAL_INTERVAL)
-            .setExpiration(RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL)
-            .setBackoffCoefficient(RETRY_SERVICE_OPERATION_BACKOFF);
-
-    Duration maxInterval = RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL.dividedBy(10);
-    if (maxInterval.compareTo(RETRY_SERVICE_OPERATION_INITIAL_INTERVAL) < 0) {
-      maxInterval = RETRY_SERVICE_OPERATION_INITIAL_INTERVAL;
-    }
-    roBuilder.setMaximumInterval(maxInterval);
-    roBuilder.setDoNotRetry(
-        BadRequestError.class,
-        EntityNotExistsError.class,
-        WorkflowExecutionAlreadyStartedError.class,
-        DomainAlreadyExistsError.class,
-        QueryFailedError.class,
-        DomainNotActiveError.class,
-        CancellationAlreadyRequestedError.class);
-    DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS = roBuilder.validateBuildWithDefaults();
-  }
 
   /**
    * Merges annotation with explicitly provided RetryOptions. If there is conflict RetryOptions

--- a/src/main/java/com/uber/cadence/common/RetryOptions.java
+++ b/src/main/java/com/uber/cadence/common/RetryOptions.java
@@ -43,10 +43,11 @@ public final class RetryOptions {
   private static final int DEFAULT_MAXIMUM_MULTIPLIER = 100;
 
   static {
-    RetryOptions.Builder roBuilder = new RetryOptions.Builder()
-        .setInitialInterval(RETRY_SERVICE_OPERATION_INITIAL_INTERVAL)
-        .setExpiration(RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL)
-        .setBackoffCoefficient(RETRY_SERVICE_OPERATION_BACKOFF);
+    RetryOptions.Builder roBuilder =
+        new RetryOptions.Builder()
+            .setInitialInterval(RETRY_SERVICE_OPERATION_INITIAL_INTERVAL)
+            .setExpiration(RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL)
+            .setBackoffCoefficient(RETRY_SERVICE_OPERATION_BACKOFF);
 
     Duration maxInterval = RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL.dividedBy(10);
     if (maxInterval.compareTo(RETRY_SERVICE_OPERATION_INITIAL_INTERVAL) < 0) {

--- a/src/main/java/com/uber/cadence/common/RetryOptions.java
+++ b/src/main/java/com/uber/cadence/common/RetryOptions.java
@@ -18,6 +18,13 @@
 package com.uber.cadence.common;
 
 import com.google.common.base.Defaults;
+import com.uber.cadence.BadRequestError;
+import com.uber.cadence.CancellationAlreadyRequestedError;
+import com.uber.cadence.DomainAlreadyExistsError;
+import com.uber.cadence.DomainNotActiveError;
+import com.uber.cadence.EntityNotExistsError;
+import com.uber.cadence.QueryFailedError;
+import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
 import com.uber.cadence.workflow.ActivityFailureException;
 import com.uber.cadence.workflow.ChildWorkflowFailureException;
 import java.time.Duration;
@@ -27,9 +34,35 @@ import java.util.List;
 import java.util.Objects;
 
 public final class RetryOptions {
+  public static final RetryOptions DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
 
+  private static final Duration RETRY_SERVICE_OPERATION_INITIAL_INTERVAL = Duration.ofMillis(20);
+  private static final Duration RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL = Duration.ofMinutes(1);
+  private static final double RETRY_SERVICE_OPERATION_BACKOFF = 1.2;
   private static final double DEFAULT_BACKOFF_COEFFICIENT = 2.0;
   private static final int DEFAULT_MAXIMUM_MULTIPLIER = 100;
+
+  static {
+    RetryOptions.Builder roBuilder = new RetryOptions.Builder()
+        .setInitialInterval(RETRY_SERVICE_OPERATION_INITIAL_INTERVAL)
+        .setExpiration(RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL)
+        .setBackoffCoefficient(RETRY_SERVICE_OPERATION_BACKOFF);
+
+    Duration maxInterval = RETRY_SERVICE_OPERATION_EXPIRATION_INTERVAL.dividedBy(10);
+    if (maxInterval.compareTo(RETRY_SERVICE_OPERATION_INITIAL_INTERVAL) < 0) {
+      maxInterval = RETRY_SERVICE_OPERATION_INITIAL_INTERVAL;
+    }
+    roBuilder.setMaximumInterval(maxInterval);
+    roBuilder.setDoNotRetry(
+        BadRequestError.class,
+        EntityNotExistsError.class,
+        WorkflowExecutionAlreadyStartedError.class,
+        DomainAlreadyExistsError.class,
+        QueryFailedError.class,
+        DomainNotActiveError.class,
+        CancellationAlreadyRequestedError.class);
+    DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS = roBuilder.validateBuildWithDefaults();
+  }
 
   /**
    * Merges annotation with explicitly provided RetryOptions. If there is conflict RetryOptions

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
@@ -32,7 +32,6 @@ import com.uber.cadence.TerminateWorkflowExecutionRequest;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
 import com.uber.cadence.WorkflowQuery;
-import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.internal.common.*;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
@@ -127,7 +126,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     try {
       result =
           Retryer.retryWithResult(
-              RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+              Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
               () -> service.StartWorkflowExecution(request));
     } catch (WorkflowExecutionAlreadyStartedError e) {
       throw e;
@@ -178,7 +177,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     request.setWorkflowExecution(execution);
     try {
       Retryer.retry(
-          RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+          Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
           () -> service.SignalWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
@@ -227,7 +226,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     try {
       result =
           Retryer.retryWithResult(
-              RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+              Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
               () -> service.SignalWithStartWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
@@ -245,7 +244,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     request.setWorkflowExecution(execution);
     try {
       Retryer.retry(
-          RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+          Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
           () -> service.RequestCancelWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
@@ -266,7 +265,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     try {
       QueryWorkflowResponse response =
           Retryer.retryWithResult(
-              RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+              Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
               () -> service.QueryWorkflow(request));
       return response.getQueryResult();
     } catch (TException e) {
@@ -290,7 +289,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     //        request.setChildPolicy(terminateParameters.getChildPolicy());
     try {
       Retryer.retry(
-          RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+          Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
           () -> service.TerminateWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
@@ -18,7 +18,20 @@
 package com.uber.cadence.internal.external;
 
 import com.google.common.base.Strings;
-import com.uber.cadence.*;
+import com.uber.cadence.Memo;
+import com.uber.cadence.QueryWorkflowRequest;
+import com.uber.cadence.QueryWorkflowResponse;
+import com.uber.cadence.RequestCancelWorkflowExecutionRequest;
+import com.uber.cadence.RetryPolicy;
+import com.uber.cadence.SignalWithStartWorkflowExecutionRequest;
+import com.uber.cadence.SignalWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionResponse;
+import com.uber.cadence.TaskList;
+import com.uber.cadence.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
+import com.uber.cadence.WorkflowQuery;
 import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.internal.common.*;
 import com.uber.cadence.internal.metrics.MetricsTag;
@@ -28,13 +41,10 @@ import com.uber.cadence.internal.replay.SignalExternalWorkflowParameters;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
-
 import java.nio.ByteBuffer;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
 import org.apache.thrift.TException;
 
 public final class GenericWorkflowClientExternalImpl implements GenericWorkflowClientExternal {
@@ -115,7 +125,10 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
 
     StartWorkflowExecutionResponse result;
     try {
-      result = Retryer.retryWithResult(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.StartWorkflowExecution(request));
+      result =
+          Retryer.retryWithResult(
+              RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+              () -> service.StartWorkflowExecution(request));
     } catch (WorkflowExecutionAlreadyStartedError e) {
       throw e;
     } catch (TException e) {
@@ -164,7 +177,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     execution.setWorkflowId(signalParameters.getWorkflowId());
     request.setWorkflowExecution(execution);
     try {
-      Retryer.retry(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.SignalWorkflowExecution(request));
+      Retryer.retry(
+          RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+          () -> service.SignalWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
     }
@@ -210,7 +225,10 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     }
     StartWorkflowExecutionResponse result;
     try {
-      result = Retryer.retryWithResult(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.SignalWithStartWorkflowExecution(request));
+      result =
+          Retryer.retryWithResult(
+              RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+              () -> service.SignalWithStartWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
     }
@@ -226,7 +244,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     request.setDomain(domain);
     request.setWorkflowExecution(execution);
     try {
-      Retryer.retry(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.RequestCancelWorkflowExecution(request));
+      Retryer.retry(
+          RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+          () -> service.RequestCancelWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
     }
@@ -244,7 +264,10 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     query.setQueryType(queryParameters.getQueryType());
     request.setQuery(query);
     try {
-      QueryWorkflowResponse response = Retryer.retryWithResult(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.QueryWorkflow(request));
+      QueryWorkflowResponse response =
+          Retryer.retryWithResult(
+              RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+              () -> service.QueryWorkflow(request));
       return response.getQueryResult();
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
@@ -266,7 +289,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     request.setReason(terminateParameters.getReason());
     //        request.setChildPolicy(terminateParameters.getChildPolicy());
     try {
-      Retryer.retry(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.TerminateWorkflowExecution(request));
+      Retryer.retry(
+          RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+          () -> service.TerminateWorkflowExecution(request));
     } catch (TException e) {
       throw CheckedExceptionWrapper.wrap(e);
     }

--- a/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientImpl.java
@@ -30,7 +30,6 @@ import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.client.ActivityCancelledException;
 import com.uber.cadence.client.ActivityCompletionFailureException;
 import com.uber.cadence.client.ActivityNotExistsException;
-import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.internal.common.Retryer;
 import com.uber.cadence.internal.metrics.MetricsType;
@@ -93,7 +92,7 @@ class ManualActivityCompletionClientImpl extends ManualActivityCompletionClient 
       request.setTaskToken(taskToken);
       try {
         Retryer.retry(
-            RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+            Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
             () -> service.RespondActivityTaskCompleted(request));
         metricsScope.counter(MetricsType.ACTIVITY_TASK_COMPLETED_COUNTER).inc(1);
       } catch (EntityNotExistsError e) {
@@ -137,7 +136,7 @@ class ManualActivityCompletionClientImpl extends ManualActivityCompletionClient 
       request.setTaskToken(taskToken);
       try {
         Retryer.retry(
-            RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+            Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
             () -> service.RespondActivityTaskFailed(request));
         metricsScope.counter(MetricsType.ACTIVITY_TASK_FAILED_COUNTER).inc(1);
       } catch (EntityNotExistsError e) {
@@ -154,7 +153,7 @@ class ManualActivityCompletionClientImpl extends ManualActivityCompletionClient 
       request.setRunID(execution.getRunId());
       try {
         Retryer.retry(
-            RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+            Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
             () -> service.RespondActivityTaskFailedByID(request));
         metricsScope.counter(MetricsType.ACTIVITY_TASK_FAILED_BY_ID_COUNTER).inc(1);
       } catch (EntityNotExistsError e) {

--- a/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientImpl.java
@@ -36,9 +36,7 @@ import com.uber.cadence.internal.common.Retryer;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Scope;
-
 import java.util.concurrent.CancellationException;
-
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +92,9 @@ class ManualActivityCompletionClientImpl extends ManualActivityCompletionClient 
       request.setResult(convertedResult);
       request.setTaskToken(taskToken);
       try {
-        Retryer.retry(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.RespondActivityTaskCompleted(request));
+        Retryer.retry(
+            RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+            () -> service.RespondActivityTaskCompleted(request));
         metricsScope.counter(MetricsType.ACTIVITY_TASK_COMPLETED_COUNTER).inc(1);
       } catch (EntityNotExistsError e) {
         throw new ActivityNotExistsException(e);
@@ -136,7 +136,9 @@ class ManualActivityCompletionClientImpl extends ManualActivityCompletionClient 
       request.setDetails(dataConverter.toData(failure));
       request.setTaskToken(taskToken);
       try {
-        Retryer.retry(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.RespondActivityTaskFailed(request));
+        Retryer.retry(
+            RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+            () -> service.RespondActivityTaskFailed(request));
         metricsScope.counter(MetricsType.ACTIVITY_TASK_FAILED_COUNTER).inc(1);
       } catch (EntityNotExistsError e) {
         throw new ActivityNotExistsException(e);
@@ -151,7 +153,9 @@ class ManualActivityCompletionClientImpl extends ManualActivityCompletionClient 
       request.setWorkflowID(execution.getWorkflowId());
       request.setRunID(execution.getRunId());
       try {
-        Retryer.retry(RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS, () -> service.RespondActivityTaskFailedByID(request));
+        Retryer.retry(
+            RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS,
+            () -> service.RespondActivityTaskFailedByID(request));
         metricsScope.counter(MetricsType.ACTIVITY_TASK_FAILED_BY_ID_COUNTER).inc(1);
       } catch (EntityNotExistsError e) {
         throw new ActivityNotExistsException(e);

--- a/src/main/java/com/uber/cadence/internal/worker/SingleWorkerOptions.java
+++ b/src/main/java/com/uber/cadence/internal/worker/SingleWorkerOptions.java
@@ -20,6 +20,7 @@ package com.uber.cadence.internal.worker;
 import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.converter.JsonDataConverter;
+import com.uber.cadence.internal.common.Retryer;
 import com.uber.cadence.internal.metrics.NoopScope;
 import com.uber.m3.tally.Scope;
 import java.time.Duration;
@@ -90,11 +91,11 @@ public final class SingleWorkerOptions {
 
     public SingleWorkerOptions build() {
       if (reportCompletionRetryOptions == null) {
-        reportCompletionRetryOptions = RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
+        reportCompletionRetryOptions = Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
       }
 
       if (reportFailureRetryOptions == null) {
-        reportFailureRetryOptions = RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
+        reportFailureRetryOptions = Retryer.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
       }
 
       if (pollerOptions == null) {

--- a/src/main/java/com/uber/cadence/internal/worker/SingleWorkerOptions.java
+++ b/src/main/java/com/uber/cadence/internal/worker/SingleWorkerOptions.java
@@ -90,21 +90,11 @@ public final class SingleWorkerOptions {
 
     public SingleWorkerOptions build() {
       if (reportCompletionRetryOptions == null) {
-        reportCompletionRetryOptions =
-            new RetryOptions.Builder()
-                .setInitialInterval(Duration.ofMillis(50))
-                .setMaximumInterval(Duration.ofSeconds(10))
-                .setExpiration(Duration.ofMinutes(1))
-                .build();
+        reportCompletionRetryOptions = RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
       }
 
       if (reportFailureRetryOptions == null) {
-        reportFailureRetryOptions =
-            new RetryOptions.Builder()
-                .setInitialInterval(Duration.ofMillis(50))
-                .setMaximumInterval(Duration.ofSeconds(10))
-                .setExpiration(Duration.ofMinutes(1))
-                .build();
+        reportFailureRetryOptions = RetryOptions.DEFAULT_SERVICE_OPERATION_RETRY_OPTIONS;
       }
 
       if (pollerOptions == null) {

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -1517,8 +1517,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
 
   @Override
   public StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(
-      SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
-      throws TException {
+      SignalWithStartWorkflowExecutionRequest signalWithStartRequest) throws TException {
     return measureRemoteCall(
         ServiceMethod.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
         () -> signalWithStartWorkflowExecution(signalWithStartRequest));

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -105,7 +105,7 @@ import org.slf4j.LoggerFactory;
 
 public class WorkflowServiceTChannel implements IWorkflowService {
 
-  public static final int DEFAULT_LOCAL_CADENCE_SERVER_PORT = 7933;
+  private static final int DEFAULT_LOCAL_CADENCE_SERVER_PORT = 7933;
 
   private static final String LOCALHOST = "127.0.0.1";
 
@@ -117,10 +117,10 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   /** Default RPC timeout for QueryWorkflow */
   private static final long DEFAULT_QUERY_RPC_TIMEOUT_MILLIS = 10000;
 
-  public static final String DEFAULT_CLIENT_APP_NAME = "cadence-client";
+  private static final String DEFAULT_CLIENT_APP_NAME = "cadence-client";
 
   /** Name of the Cadence service front end as required by TChannel. */
-  public static final String DEFAULT_SERVICE_NAME = "cadence-frontend";
+  private static final String DEFAULT_SERVICE_NAME = "cadence-frontend";
 
   private static final Logger log = LoggerFactory.getLogger(WorkflowServiceTChannel.class);
 
@@ -811,8 +811,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       ThriftRequest<WorkflowService.GetWorkflowExecutionHistory_args> request =
           buildThriftRequest(
               "GetWorkflowExecutionHistory",
-              new WorkflowService.GetWorkflowExecutionHistory_args(getRequest),
-              options.getRpcLongPollTimeoutMillis());
+              new WorkflowService.GetWorkflowExecutionHistory_args(getRequest));
       response = doRemoteCall(request);
       WorkflowService.GetWorkflowExecutionHistory_result result =
           response.getBody(WorkflowService.GetWorkflowExecutionHistory_result.class);
@@ -905,8 +904,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       ThriftRequest<WorkflowService.RespondDecisionTaskCompleted_args> request =
           buildThriftRequest(
               "RespondDecisionTaskCompleted",
-              new WorkflowService.RespondDecisionTaskCompleted_args(completedRequest),
-              options.getRpcLongPollTimeoutMillis());
+              new WorkflowService.RespondDecisionTaskCompleted_args(completedRequest));
       response = doRemoteCall(request);
       WorkflowService.RespondDecisionTaskCompleted_result result =
           response.getBody(WorkflowService.RespondDecisionTaskCompleted_result.class);
@@ -1520,9 +1518,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   @Override
   public StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(
       SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
-      throws BadRequestError, InternalServiceError, EntityNotExistsError, ServiceBusyError,
-          DomainNotActiveError, LimitExceededError, WorkflowExecutionAlreadyStartedError,
-          TException {
+      throws TException {
     return measureRemoteCall(
         ServiceMethod.SIGNAL_WITH_START_WORKFLOW_EXECUTION,
         () -> signalWithStartWorkflowExecution(signalWithStartRequest));
@@ -1536,8 +1532,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       ThriftRequest<WorkflowService.SignalWithStartWorkflowExecution_args> request =
           buildThriftRequest(
               "SignalWithStartWorkflowExecution",
-              new WorkflowService.SignalWithStartWorkflowExecution_args(signalWithStartRequest),
-              options.getRpcLongPollTimeoutMillis());
+              new WorkflowService.SignalWithStartWorkflowExecution_args(signalWithStartRequest));
       response = doRemoteCall(request);
       WorkflowService.SignalWithStartWorkflowExecution_result result =
           response.getBody(WorkflowService.SignalWithStartWorkflowExecution_result.class);
@@ -1943,8 +1938,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       ThriftRequest<WorkflowService.GetWorkflowExecutionHistory_args> request =
           buildThriftRequest(
               "GetWorkflowExecutionHistory",
-              new WorkflowService.GetWorkflowExecutionHistory_args(getRequest),
-              options.getRpcLongPollTimeoutMillis());
+              new WorkflowService.GetWorkflowExecutionHistory_args(getRequest));
       response = doRemoteCallAsync(request);
 
       response


### PR DESCRIPTION
resolves #258
In Java we don't have deadline in context, so we only have the default retry policy, and do not adjust based on context.deadline as Go does.