### PR TITLE
Lock decider while processing

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
@@ -88,7 +88,9 @@ public class SyncWorkflowWorker
             service,
             laWorker.getLocalActivityTaskPoller());
 
-    workflowWorker = new WorkflowWorker(service, domain, taskList, workflowOptions, taskHandler);
+    workflowWorker =
+        new WorkflowWorker(
+            service, domain, taskList, workflowOptions, taskHandler, stickyTaskListName);
   }
 
   public void setWorkflowImplementationTypes(

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -215,10 +215,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           ctx -> {
             long scheduledEventId = decision.getData().scheduledEventId;
             decision.action(StateMachines.Action.START, ctx, pollRequest, 0);
-            ctx.addTimer(
-                stickyExecutionAttributes != null
-                    ? stickyExecutionAttributes.getScheduleToStartTimeoutSeconds()
-                    : startRequest.getTaskStartToCloseTimeoutSeconds(),
+            ctx.addTimer(startRequest.getTaskStartToCloseTimeoutSeconds(),
                 () -> timeoutDecisionTask(scheduledEventId),
                 "DecisionTask StartToCloseTimeout");
           });

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -215,7 +215,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           ctx -> {
             long scheduledEventId = decision.getData().scheduledEventId;
             decision.action(StateMachines.Action.START, ctx, pollRequest, 0);
-            ctx.addTimer(startRequest.getTaskStartToCloseTimeoutSeconds(),
+            ctx.addTimer(
+                startRequest.getTaskStartToCloseTimeoutSeconds(),
                 () -> timeoutDecisionTask(scheduledEventId),
                 "DecisionTask StartToCloseTimeout");
           });

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowRunLockManager.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowRunLockManager.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import java.util.HashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+final class WorkflowRunLockManager {
+
+  private static class CountableLock {
+    private ReentrantLock lock;
+    private int count;
+
+    CountableLock() {
+      this.lock = new ReentrantLock();
+      this.count = 1;
+    }
+
+    void incrementCount() {
+      count++;
+    }
+
+    void decrementCount() {
+      count--;
+    }
+
+    int getCount() {
+      return count;
+    }
+
+    ReentrantLock getLock() {
+      return lock;
+    }
+  }
+
+  private final ReentrantLock mapLock = new ReentrantLock();
+  private final HashMap<String, CountableLock> perRunLock = new HashMap<>();
+
+  ReentrantLock getLockForLocking(String runId) {
+    mapLock.lock();
+
+    try {
+      CountableLock cl;
+      if (perRunLock.containsKey(runId)) {
+        cl = perRunLock.get(runId);
+        cl.incrementCount();
+      } else {
+        cl = new CountableLock();
+        perRunLock.put(runId, cl);
+      }
+
+      return cl.getLock();
+    } finally {
+      mapLock.unlock();
+    }
+  }
+
+  void unlock(String runId) {
+    mapLock.lock();
+
+    try {
+      CountableLock cl = perRunLock.get(runId);
+      if (cl == null) {
+        throw new RuntimeException("lock for run " + runId + " does not exist.");
+      }
+
+      cl.decrementCount();
+      if (cl.getCount() == 0) {
+        perRunLock.remove(runId);
+      }
+
+      cl.getLock().unlock();
+    } finally {
+      mapLock.unlock();
+    }
+  }
+
+  int totalLocks() {
+    mapLock.lock();
+
+    try {
+      return perRunLock.size();
+    } finally {
+      mapLock.unlock();
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowRunLockManager.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowRunLockManager.java
@@ -47,10 +47,14 @@ final class WorkflowRunLockManager {
   private final Lock mapLock = new ReentrantLock();
   private final HashMap<String, CountableLock> perRunLock = new HashMap<>();
 
-  // This method returns a lock that can be used to serialize decision task processing for a
-  // particular workflow
-  // run. This is used to make sure that query tasks and real decision tasks are serialized when
-  // sticky is on.
+  /**
+   * This method returns a lock that can be used to serialize decision task processing for a
+   * particular workflow run. This is used to make sure that query tasks and real decision tasks are
+   * serialized when sticky is on.
+   *
+   * @param runId
+   * @return a lock to be used during decision task processing
+   */
   Lock getLockForLocking(String runId) {
     mapLock.lock();
 

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
 import org.apache.thrift.TException;
 import org.slf4j.MDC;
@@ -247,7 +247,7 @@ public final class WorkflowWorker
       MDC.put(LoggerTag.WORKFLOW_TYPE, task.getWorkflowType().getName());
       MDC.put(LoggerTag.RUN_ID, task.getWorkflowExecution().getRunId());
 
-      ReentrantLock runLock = null;
+      Lock runLock = null;
       if (!Strings.isNullOrEmpty(stickyTaskListName)) {
         runLock = runLocks.getLockForLocking(task.getWorkflowExecution().getRunId());
         runLock.lock();

--- a/src/test/java/com/uber/cadence/internal/worker/WorkflowRunLockManagerTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/WorkflowRunLockManagerTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReentrantLock;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkflowRunLockManagerTest {
+  private static final Logger log = LoggerFactory.getLogger(WorkflowRunLockManagerTest.class);
+  private WorkflowRunLockManager runLockManager = new WorkflowRunLockManager();
+
+  @Test
+  public void lockAndUnlockTest() throws ExecutionException, InterruptedException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    ConcurrentLinkedQueue<Integer> finishedTasks = new ConcurrentLinkedQueue<>();
+    Future<?> f1 = executor.submit(() -> finishedTasks.add(processTask("test", 1)));
+    Thread.sleep(100);
+    Future<?> f2 = executor.submit(() -> finishedTasks.add(processTask("test", 2)));
+    Thread.sleep(100);
+    Future<?> f3 = executor.submit(() -> finishedTasks.add(processTask("test", 3)));
+    f1.get();
+    f2.get();
+    f3.get();
+    log.info("All done.");
+    assertEquals(0, runLockManager.totalLocks());
+    Integer[] expectedTasks = {1, 2, 3};
+    Integer[] processedTasks = new Integer[3];
+    assertArrayEquals(expectedTasks, finishedTasks.toArray(processedTasks));
+  }
+
+  private int processTask(String runId, int taskId) {
+    ReentrantLock runLock = runLockManager.getLockForLocking(runId);
+    runLock.lock();
+
+    log.info("Got lock runId " + runId + " taskId " + taskId);
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("interrupted");
+    } finally {
+      runLockManager.unlock(runId);
+    }
+    log.info("Finished processing runId " + runId + " taskId " + taskId);
+    return taskId;
+  }
+}

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -4637,13 +4637,17 @@ public class WorkflowTest {
     Thread.sleep(500);
 
     String queryResult = workflowStub.query();
-    log.info("query result: " + queryResult);
+
+    if (disableStickyExecution) {
+      assertEquals("initial value", queryResult);
+    } else {
+      assertEquals("run2", queryResult);
+    }
 
     String result = workflowStub.execute(taskList);
     log.info("workflow output: " + result);
 
-    System.out.println(testEnvironment.getDiagnostics());
-    System.out.println(activitiesImpl.invocations);
+    activitiesImpl.assertInvocations("activity", "sleepActivity", "sleepActivity", "sleepActivity");
   }
 
   public interface SignalOrderingWorkflow {

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -4634,6 +4634,9 @@ public class WorkflowTest {
         workflowClient.newWorkflowStub(TestWorkflowQuery.class, options);
     WorkflowClient.start(workflowStub::execute, taskList);
 
+    // Sleep for a while before querying, so that the first decision task is processed and cache is
+    // populated.
+    // This also makes sure that the query lands when the local activities are executing.
     Thread.sleep(500);
 
     String queryResult = workflowStub.query();


### PR DESCRIPTION
This prevents query from messing up decision tasks in progress, especially when there's local activity.
Query should only do replay of local activities, not executing additional ones.
Also Start decision task should not look at sticky schedule to start timeout.