### PR TITLE
Wrap data converter exception in activity failure exception

### DIFF
--- a/src/main/java/com/uber/cadence/workflow/ActivityFailureException.java
+++ b/src/main/java/com/uber/cadence/workflow/ActivityFailureException.java
@@ -29,6 +29,11 @@ public final class ActivityFailureException extends ActivityException {
   private int attempt;
   private Duration backoff;
 
+  public ActivityFailureException(ActivityType activityType, Throwable cause) {
+    super("ActivityFailureException", -1, activityType, "");
+    initCause(cause);
+  }
+
   public ActivityFailureException(
       long eventId, ActivityType activityType, String activityId, Throwable cause) {
     super("ActivityFailureException", eventId, activityType, activityId);


### PR DESCRIPTION
Currently only adding activity type. ActivityId and EventId is not available right now in SyncDecisionContext and it's not trivial to add. My understanding is that activity type should be good enough for trouble shooting purpose. Open to discussions though.