### PR TITLE
Make Worker.addWorkflowImplementationFactory method support 'options'

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/src/main/java/com/uber/cadence/internal/sync/POJOWorkflowImplementationFactory.java
@@ -94,12 +94,17 @@ final class POJOWorkflowImplementationFactory implements ReplayWorkflowFactory {
   }
 
   <R> void addWorkflowImplementationFactory(Class<R> clazz, Functions.Func<R> factory) {
-    workflowImplementationFactories.put(clazz, factory);
     WorkflowImplementationOptions unitTestingOptions =
         new WorkflowImplementationOptions.Builder()
             .setNonDeterministicWorkflowPolicy(FailWorkflow)
             .build();
-    addWorkflowImplementationType(unitTestingOptions, clazz);
+    addWorkflowImplementationFactory(unitTestingOptions, clazz, factory);
+  }
+
+  <R> void addWorkflowImplementationFactory(
+      WorkflowImplementationOptions options, Class<R> clazz, Functions.Func<R> factory) {
+    workflowImplementationFactories.put(clazz, factory);
+    addWorkflowImplementationType(options, clazz);
   }
 
   private void addWorkflowImplementationType(

--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
@@ -98,6 +98,11 @@ public class SyncWorkflowWorker
     factory.setWorkflowImplementationTypes(options, workflowImplementationTypes);
   }
 
+  public <R> void addWorkflowImplementationFactory(
+      WorkflowImplementationOptions options, Class<R> clazz, Func<R> factory) {
+    this.factory.addWorkflowImplementationFactory(options, clazz, factory);
+  }
+
   public <R> void addWorkflowImplementationFactory(Class<R> clazz, Func<R> factory) {
     this.factory.addWorkflowImplementationFactory(clazz, factory);
   }

--- a/src/main/java/com/uber/cadence/worker/Worker.java
+++ b/src/main/java/com/uber/cadence/worker/Worker.java
@@ -236,6 +236,23 @@ public final class Worker implements Suspendable {
   }
 
   /**
+   * Configures a factory to use when an instance of a workflow implementation is created.
+   * !IMPORTANT to provide newly created instances, each time factory is applied.
+   *
+   * <p>Unless mocking a workflow execution use {@link
+   * #registerWorkflowImplementationTypes(Class[])}.
+   *
+   * @param workflowInterface Workflow interface that this factory implements
+   * @param factory factory that when called creates a new instance of the workflow implementation
+   *     object.
+   * @param <R> type of the workflow object to create.
+   */
+  public <R> void addWorkflowImplementationFactory(
+      WorkflowImplementationOptions options, Class<R> workflowInterface, Func<R> factory) {
+    workflowWorker.addWorkflowImplementationFactory(options, workflowInterface, factory);
+  }
+
+  /**
    * Configures a factory to use when an instance of a workflow implementation is created. The only
    * valid use for this method is unit testing, specifically to instantiate mocks that implement
    * child workflows. An example of mocking a child workflow:


### PR DESCRIPTION
I would like to be able to provide my own implementation instances for workflow stubs. 
As for now, the 'newInstance()' call via reflection makes it hard to initialize dependencies in provided implementation classes.