### PR TITLE
Fix empty result when get twice from search attributes

### DIFF
--- a/src/main/java/com/uber/cadence/workflow/WorkflowUtils.java
+++ b/src/main/java/com/uber/cadence/workflow/WorkflowUtils.java
@@ -36,8 +36,10 @@ public class WorkflowUtils {
 
   private static byte[] getValueBytes(SearchAttributes searchAttributes, String key) {
     ByteBuffer byteBuffer = searchAttributes.getIndexedFields().get(key);
-    final byte[] valueBytes = new byte[byteBuffer.limit() - byteBuffer.position()];
-    byteBuffer.get(valueBytes, 0, valueBytes.length);
+    final byte[] valueBytes = new byte[byteBuffer.remaining()];
+    byteBuffer.mark();
+    byteBuffer.get(valueBytes);
+    byteBuffer.reset();
     return valueBytes;
   }
 }

--- a/src/test/java/com/uber/cadence/workflow/WorkflowUtilsTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowUtilsTest.java
@@ -61,4 +61,20 @@ public class WorkflowUtilsTest {
         WorkflowUtils.getValueFromSearchAttributes(
             searchAttributes, "CustomBooleanField", Boolean.class));
   }
+
+  @Test
+  public void TestGetValueFromSearchAttributesRepeated() {
+    Map<String, Object> attr = new HashMap<>();
+    String stringVal = "keyword";
+    attr.put("CustomKeywordField", stringVal);
+    SearchAttributes searchAttributes = InternalUtils.convertMapToSearchAttributes(attr);
+    assertEquals(
+        stringVal,
+        WorkflowUtils.getValueFromSearchAttributes(
+            searchAttributes, "CustomKeywordField", String.class));
+    assertEquals(
+        stringVal,
+        WorkflowUtils.getValueFromSearchAttributes(
+            searchAttributes, "CustomKeywordField", String.class));
+  }
 }


### PR DESCRIPTION
Currently, call `WorkflowUtils.getValueFromSearchAttributes` on same search attribute key twice will lead to second (and following) call return empty value.

This PR fix it. 