### PR TITLE
Add default micrometer reporter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     compile group: 'com.uber.m3', name: 'tally-core', version: '0.4.0'
     compile group: 'com.google.guava', name: 'guava', version: '28.1-jre'
     compile group: 'com.cronutils', name: 'cron-utils', version: '9.0.0'
+    compile group: 'io.micrometer', name: 'micrometer-core', version: '1.1.2'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'

--- a/src/main/java/com/uber/cadence/reporter/CadenceClientStatsReporter.java
+++ b/src/main/java/com/uber/cadence/reporter/CadenceClientStatsReporter.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.reporter;
+
+import com.uber.m3.tally.Buckets;
+import com.uber.m3.tally.Capabilities;
+import com.uber.m3.tally.CapableOf;
+import com.uber.m3.tally.StatsReporter;
+import com.uber.m3.util.Duration;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class CadenceClientStatsReporter implements StatsReporter {
+
+  @Override
+  public Capabilities capabilities() {
+    return CapableOf.REPORTING;
+  }
+
+  @Override
+  public void flush() {
+    // NOOP
+  }
+
+  @Override
+  public void close() {
+    // NOOP
+  }
+
+  @Override
+  public void reportCounter(String name, Map<String, String> tags, long value) {
+    Metrics.counter(name, getTags(tags)).increment(value);
+  }
+
+  @Override
+  public void reportGauge(String name, Map<String, String> tags, double value) {
+    // NOOP
+  }
+
+  @Override
+  public void reportTimer(String name, Map<String, String> tags, Duration interval) {
+    Metrics.timer(name, getTags(tags)).record(interval.getNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public void reportHistogramValueSamples(
+      String name,
+      Map<String, String> tags,
+      Buckets buckets,
+      double bucketLowerBound,
+      double bucketUpperBound,
+      long samples) {
+    // NOOP
+  }
+
+  @Override
+  public void reportHistogramDurationSamples(
+      String name,
+      Map<String, String> tags,
+      Buckets buckets,
+      Duration bucketLowerBound,
+      Duration bucketUpperBound,
+      long samples) {
+    // NOOP
+  }
+
+  private Iterable<Tag> getTags(Map<String, String> tags) {
+    return tags.entrySet()
+        .stream()
+        .map(entry -> Tag.of(entry.getKey(), entry.getValue()))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/test/java/com/uber/cadence/reporter/CadenceClientStatsReporterTest.java
+++ b/src/test/java/com/uber/cadence/reporter/CadenceClientStatsReporterTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.reporter;
+
+import static org.junit.Assert.assertEquals;
+
+import com.uber.m3.tally.CapableOf;
+import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CadenceClientStatsReporterTest {
+
+  private static final String DEFAULT_REPORT_NAME = "cadence_workflow_start";
+  private static final Map<String, String> DEFAULT_REPORT_TAGS =
+      ImmutableMap.of("Domain", "domain_name", "TaskList", "task_list");
+  private static final long DEFAULT_COUNT = 10;
+  private static final Duration DEFAULT_DURATION = Duration.ofSeconds(10);
+
+  private CadenceClientStatsReporter cadenceClientStatsReporter = new CadenceClientStatsReporter();
+
+  @Before
+  public void init() {
+    Metrics.addRegistry(new SimpleMeterRegistry());
+  }
+
+  @After
+  public void cleanup() {
+    Metrics.globalRegistry.getMeters().forEach(Metrics.globalRegistry::remove);
+  }
+
+  @Test
+  public void testReporterCapabilitiesShouldReturnReporting() {
+    assertEquals(CapableOf.REPORTING, cadenceClientStatsReporter.capabilities());
+  }
+
+  @Test
+  public void testCounterShouldCallMetricRegistryForMonitoredCounterCadenceAction() {
+    callDefaultCounter();
+
+    assertEquals(
+        Arrays.asList(Tag.of("Domain", "domain_name"), Tag.of("TaskList", "task_list")),
+        Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).counter().getId().getTags());
+    assertEquals(10, Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).counter().count(), 0);
+  }
+
+  @Test
+  public void testTimerShouldCallMetricRegistryForMonitoredCounterCadenceAction() {
+    callDefaultTimer();
+
+    assertEquals(
+        Arrays.asList(Tag.of("Domain", "domain_name"), Tag.of("TaskList", "task_list")),
+        Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).timer().getId().getTags());
+    assertEquals(
+        10, Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).timer().totalTime(TimeUnit.SECONDS), 0);
+  }
+
+  private void callDefaultCounter() {
+    cadenceClientStatsReporter.reportCounter(
+        DEFAULT_REPORT_NAME, DEFAULT_REPORT_TAGS, DEFAULT_COUNT);
+  }
+
+  private void callDefaultTimer() {
+    cadenceClientStatsReporter.reportTimer(
+        DEFAULT_REPORT_NAME, DEFAULT_REPORT_TAGS, DEFAULT_DURATION);
+  }
+}


### PR DESCRIPTION
Add default micrometer reporter for prometheus support in cadence java client. See issue [397](https://github.com/uber/cadence-java-client/issues/397)