### PR TITLE
Sync cadence.thrift and shared.thrift from Cadence to Cadence Java Client

### DIFF
--- a/src/main/thrift/cadence.thrift
+++ b/src/main/thrift/cadence.thrift
@@ -40,7 +40,6 @@ service WorkflowService {
   void RegisterDomain(1: shared.RegisterDomainRequest registerRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.DomainAlreadyExistsError domainExistsError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -52,7 +51,6 @@ service WorkflowService {
   shared.DescribeDomainResponse DescribeDomain(1: shared.DescribeDomainRequest describeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -64,7 +62,6 @@ service WorkflowService {
     shared.ListDomainsResponse ListDomains(1: shared.ListDomainsRequest listRequest)
       throws (
         1: shared.BadRequestError badRequestError,
-        2: shared.InternalServiceError internalServiceError,
         3: shared.EntityNotExistsError entityNotExistError,
         4: shared.ServiceBusyError serviceBusyError,
         5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -76,7 +73,6 @@ service WorkflowService {
   shared.UpdateDomainResponse UpdateDomain(1: shared.UpdateDomainRequest updateRequest)
       throws (
         1: shared.BadRequestError badRequestError,
-        2: shared.InternalServiceError internalServiceError,
         3: shared.EntityNotExistsError entityNotExistError,
         4: shared.ServiceBusyError serviceBusyError,
         5: shared.DomainNotActiveError domainNotActiveError,
@@ -91,7 +87,6 @@ service WorkflowService {
   void DeprecateDomain(1: shared.DeprecateDomainRequest deprecateRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -107,7 +102,6 @@ service WorkflowService {
   shared.StartWorkflowExecutionResponse StartWorkflowExecution(1: shared.StartWorkflowExecutionRequest startRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.WorkflowExecutionAlreadyStartedError sessionAlreadyExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -123,7 +117,6 @@ service WorkflowService {
   shared.GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(1: shared.GetWorkflowExecutionHistoryRequest getRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -139,7 +132,6 @@ service WorkflowService {
   shared.PollForDecisionTaskResponse PollForDecisionTask(1: shared.PollForDecisionTaskRequest pollRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.ServiceBusyError serviceBusyError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.EntityNotExistsError entityNotExistError,
@@ -158,7 +150,6 @@ service WorkflowService {
   shared.RespondDecisionTaskCompletedResponse RespondDecisionTaskCompleted(1: shared.RespondDecisionTaskCompletedRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -175,7 +166,6 @@ service WorkflowService {
   void RespondDecisionTaskFailed(1: shared.RespondDecisionTaskFailedRequest failedRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -195,7 +185,6 @@ service WorkflowService {
   shared.PollForActivityTaskResponse PollForActivityTask(1: shared.PollForActivityTaskRequest pollRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.ServiceBusyError serviceBusyError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.EntityNotExistsError entityNotExistError,
@@ -213,7 +202,6 @@ service WorkflowService {
   shared.RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeat(1: shared.RecordActivityTaskHeartbeatRequest heartbeatRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -231,7 +219,6 @@ service WorkflowService {
   shared.RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeatByID(1: shared.RecordActivityTaskHeartbeatByIDRequest heartbeatRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -249,7 +236,6 @@ service WorkflowService {
   void  RespondActivityTaskCompleted(1: shared.RespondActivityTaskCompletedRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -267,7 +253,6 @@ service WorkflowService {
   void  RespondActivityTaskCompletedByID(1: shared.RespondActivityTaskCompletedByIDRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -285,7 +270,6 @@ service WorkflowService {
   void  RespondActivityTaskFailed(1: shared.RespondActivityTaskFailedRequest failRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -303,7 +287,6 @@ service WorkflowService {
   void  RespondActivityTaskFailedByID(1: shared.RespondActivityTaskFailedByIDRequest failRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -321,7 +304,6 @@ service WorkflowService {
   void RespondActivityTaskCanceled(1: shared.RespondActivityTaskCanceledRequest canceledRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -339,7 +321,6 @@ service WorkflowService {
   void RespondActivityTaskCanceledByID(1: shared.RespondActivityTaskCanceledByIDRequest canceledRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -356,7 +337,6 @@ service WorkflowService {
   void RequestCancelWorkflowExecution(1: shared.RequestCancelWorkflowExecutionRequest cancelRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.CancellationAlreadyRequestedError cancellationAlreadyRequestedError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -372,7 +352,6 @@ service WorkflowService {
   void SignalWorkflowExecution(1: shared.SignalWorkflowExecutionRequest signalRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -390,7 +369,6 @@ service WorkflowService {
   shared.StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(1: shared.SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -406,7 +384,6 @@ service WorkflowService {
   shared.ResetWorkflowExecutionResponse ResetWorkflowExecution(1: shared.ResetWorkflowExecutionRequest resetRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -421,7 +398,6 @@ service WorkflowService {
   void TerminateWorkflowExecution(1: shared.TerminateWorkflowExecutionRequest terminateRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -435,7 +411,6 @@ service WorkflowService {
   shared.ListOpenWorkflowExecutionsResponse ListOpenWorkflowExecutions(1: shared.ListOpenWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.LimitExceededError limitExceededError,
@@ -448,7 +423,6 @@ service WorkflowService {
   shared.ListClosedWorkflowExecutionsResponse ListClosedWorkflowExecutions(1: shared.ListClosedWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -460,7 +434,17 @@ service WorkflowService {
   shared.ListWorkflowExecutionsResponse ListWorkflowExecutions(1: shared.ListWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
+      3: shared.EntityNotExistsError entityNotExistError,
+      4: shared.ServiceBusyError serviceBusyError,
+      5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+    )
+
+  /**
+  * ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific domain.
+  **/
+  shared.ListArchivedWorkflowExecutionsResponse ListArchivedWorkflowExecutions(1: shared.ListArchivedWorkflowExecutionsRequest listRequest)
+    throws (
+      1: shared.BadRequestError badRequestError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -472,7 +456,6 @@ service WorkflowService {
   shared.ListWorkflowExecutionsResponse ScanWorkflowExecutions(1: shared.ListWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -484,7 +467,6 @@ service WorkflowService {
   shared.CountWorkflowExecutionsResponse CountWorkflowExecutions(1: shared.CountWorkflowExecutionsRequest countRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -495,7 +477,6 @@ service WorkflowService {
   **/
   shared.GetSearchAttributesResponse GetSearchAttributes()
     throws (
-      1: shared.InternalServiceError internalServiceError,
       2: shared.ServiceBusyError serviceBusyError,
       3: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
     )
@@ -508,7 +489,6 @@ service WorkflowService {
   void RespondQueryTaskCompleted(1: shared.RespondQueryTaskCompletedRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -528,7 +508,6 @@ service WorkflowService {
   shared.ResetStickyTaskListResponse ResetStickyTaskList(1: shared.ResetStickyTaskListRequest resetRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -542,7 +521,6 @@ service WorkflowService {
   shared.QueryWorkflowResponse QueryWorkflow(1: shared.QueryWorkflowRequest queryRequest)
 	throws (
 	  1: shared.BadRequestError badRequestError,
-	  2: shared.InternalServiceError internalServiceError,
 	  3: shared.EntityNotExistsError entityNotExistError,
 	  4: shared.QueryFailedError queryFailedError,
 	  5: shared.LimitExceededError limitExceededError,
@@ -556,7 +534,6 @@ service WorkflowService {
   shared.DescribeWorkflowExecutionResponse DescribeWorkflowExecution(1: shared.DescribeWorkflowExecutionRequest describeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -570,11 +547,29 @@ service WorkflowService {
   shared.DescribeTaskListResponse DescribeTaskList(1: shared.DescribeTaskListRequest request)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
       6: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
     )
 
+  /**
+  * GetClusterInfo returns information about cadence cluster
+  **/
+  shared.ClusterInfo GetClusterInfo()
+    throws (
+      1: shared.InternalServiceError internalServiceError,
+      2: shared.ServiceBusyError serviceBusyError,
+    )
+
+   /**
+   * ReapplyEvents applies stale events to the current workflow and current run
+   **/
+  shared.ListTaskListPartitionsResponse ListTaskListPartitions(1: shared.ListTaskListPartitionsRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      3: shared.EntityNotExistsError entityNotExistError,
+      4: shared.LimitExceededError limitExceededError,
+      5: shared.ServiceBusyError serviceBusyError,
+    )
 }

--- a/src/main/thrift/shared.thrift
+++ b/src/main/thrift/shared.thrift
@@ -28,6 +28,10 @@ exception InternalServiceError {
   1: required string message
 }
 
+exception InternalDataInconsistencyError {
+  1: required string message
+}
+
 exception DomainAlreadyExistsError {
   1: required string message
 }
@@ -77,10 +81,26 @@ exception RetryTaskError {
   5: optional i64 (js.type = "Long") nextEventId
 }
 
+exception RetryTaskV2Error {
+  1: required string message
+  2: optional string domainId
+  3: optional string workflowId
+  4: optional string runId
+  5: optional i64 (js.type = "Long") startEventId
+  6: optional i64 (js.type = "Long") startEventVersion
+  7: optional i64 (js.type = "Long") endEventId
+  8: optional i64 (js.type = "Long") endEventVersion
+}
+
 exception ClientVersionNotSupportedError {
   1: required string featureVersion
   2: required string clientImpl
   3: required string supportedVersions
+}
+
+exception CurrentBranchChangedError {
+  10: required string message
+  20: required binary currentBranchToken
 }
 
 enum WorkflowIdReusePolicy {
@@ -113,6 +133,13 @@ enum TimeoutType {
   SCHEDULE_TO_CLOSE,
   HEARTBEAT,
 }
+
+enum ParentClosePolicy {
+	ABANDON,
+	REQUEST_CANCEL,
+	TERMINATE,
+}
+
 
 // whenever this list of decision is changed
 // do change the mutableStateBuilder.go
@@ -217,6 +244,9 @@ enum ChildWorkflowExecutionFailedCause {
   WORKFLOW_ALREADY_RUNNING,
 }
 
+// TODO: when migrating to gRPC, add a running / none status,
+//  currently, customer is using null / nil as an indication
+//  that workflow is still running
 enum WorkflowExecutionCloseStatus {
   COMPLETED,
   FAILED,
@@ -226,14 +256,13 @@ enum WorkflowExecutionCloseStatus {
   TIMED_OUT,
 }
 
-enum ChildPolicy {
-  TERMINATE,
-  REQUEST_CANCEL,
-  ABANDON,
-}
-
 enum QueryTaskCompletedType {
   COMPLETED,
+  FAILED,
+}
+
+enum QueryResultType {
+  ANSWERED,
   FAILED,
 }
 
@@ -286,6 +315,7 @@ struct TaskList {
 
 enum EncodingType {
   ThriftRW,
+  JSON,
 }
 
 enum QueryRejectCondition {
@@ -293,6 +323,13 @@ enum QueryRejectCondition {
   NOT_OPEN
   // NOT_COMPLETED_CLEANLY indicates that query should be rejected if workflow did not complete cleanly
   NOT_COMPLETED_CLEANLY
+}
+
+enum QueryConsistencyLevel {
+  // EVENTUAL indicates that query should be eventually consistent
+  EVENTUAL
+  // STRONG indicates that any events that came before query should be reflected in workflow state before running query
+  STRONG
 }
 
 struct DataBlob {
@@ -322,6 +359,11 @@ struct SearchAttributes {
   10: optional map<string,binary> indexedFields
 }
 
+struct WorkerVersionInfo {
+  10: optional string impl
+  20: optional string featureVersion
+}
+
 struct WorkflowExecutionInfo {
   10: optional WorkflowExecution execution
   20: optional WorkflowType type
@@ -341,7 +383,7 @@ struct WorkflowExecutionConfiguration {
   10: optional TaskList taskList
   20: optional i32 executionStartToCloseTimeoutSeconds
   30: optional i32 taskStartToCloseTimeoutSeconds
-  40: optional ChildPolicy childPolicy
+//  40: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number
 }
 
 struct TransientDecisionInfo {
@@ -442,7 +484,8 @@ struct StartChildWorkflowExecutionDecisionAttributes {
   50: optional binary input
   60: optional i32 executionStartToCloseTimeoutSeconds
   70: optional i32 taskStartToCloseTimeoutSeconds
-  80: optional ChildPolicy childPolicy
+//  80: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number
+  81: optional ParentClosePolicy parentClosePolicy
   90: optional binary control
   100: optional WorkflowIdReusePolicy workflowIdReusePolicy
   110: optional RetryPolicy retryPolicy
@@ -478,7 +521,7 @@ struct WorkflowExecutionStartedEventAttributes {
   30: optional binary input
   40: optional i32 executionStartToCloseTimeoutSeconds
   50: optional i32 taskStartToCloseTimeoutSeconds
-  52: optional ChildPolicy childPolicy
+//  52: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number
   54: optional string continuedExecutionRunId
   55: optional ContinueAsNewInitiator initiator
   56: optional string continuedFailureReason
@@ -587,6 +630,7 @@ struct DecisionTaskFailedEventAttributes {
   60: optional string baseRunId
   70: optional string newRunId
   80: optional i64 (js.type = "Long") forkEventVersion
+  90: optional string binaryChecksum
 }
 
 struct ActivityTaskScheduledEventAttributes {
@@ -631,6 +675,10 @@ struct ActivityTaskTimedOutEventAttributes {
   10: optional i64 (js.type = "Long") scheduledEventId
   20: optional i64 (js.type = "Long") startedEventId
   30: optional TimeoutType timeoutType
+  // For retry activity, it may have a failure before timeout. It's important to keep those information for debug.
+  // Client can also provide the info for making next decision
+  40: optional string lastFailureReason
+  50: optional binary lastFailureDetails
 }
 
 struct ActivityTaskCancelRequestedEventAttributes {
@@ -770,7 +818,8 @@ struct StartChildWorkflowExecutionInitiatedEventAttributes {
   50:  optional binary input
   60:  optional i32 executionStartToCloseTimeoutSeconds
   70:  optional i32 taskStartToCloseTimeoutSeconds
-  80:  optional ChildPolicy childPolicy
+//  80:  optional ChildPolicy childPolicy -- Removed but reserve the IDL order number
+  81:  optional ParentClosePolicy parentClosePolicy
   90:  optional binary control
   100: optional i64 (js.type = "Long") decisionTaskCompletedEventId
   110: optional WorkflowIdReusePolicy workflowIdReusePolicy
@@ -900,6 +949,7 @@ struct History {
 
 struct WorkflowExecutionFilter {
   10: optional string workflowId
+  20: optional string runId
 }
 
 struct WorkflowTypeFilter {
@@ -924,9 +974,11 @@ struct DomainInfo {
 struct DomainConfiguration {
   10: optional i32 workflowExecutionRetentionPeriodInDays
   20: optional bool emitMetric
-  30: optional string archivalBucketName
-  50: optional ArchivalStatus archivalStatus
   70: optional BadBinaries badBinaries
+  80: optional ArchivalStatus historyArchivalStatus
+  90: optional string historyArchivalURI
+  100: optional ArchivalStatus visibilityArchivalStatus
+  110: optional string visibilityArchivalURI
 }
 
 struct BadBinaries{
@@ -966,9 +1018,11 @@ struct RegisterDomainRequest {
   // A key-value map for any customized purpose
   80: optional map<string,string> data
   90: optional string securityToken
-  100: optional ArchivalStatus archivalStatus
-  110: optional string archivalBucketName
   120: optional bool isGlobalDomain
+  130: optional ArchivalStatus historyArchivalStatus
+  140: optional string historyArchivalURI
+  150: optional ArchivalStatus visibilityArchivalStatus
+  160: optional string visibilityArchivalURI
 }
 
 struct ListDomainsRequest {
@@ -1027,7 +1081,7 @@ struct StartWorkflowExecutionRequest {
   80: optional string identity
   90: optional string requestId
   100: optional WorkflowIdReusePolicy workflowIdReusePolicy
-  110: optional ChildPolicy childPolicy
+//  110: optional ChildPolicy childPolicy -- Removed but reserve the IDL order number
   120: optional RetryPolicy retryPolicy
   130: optional string cronSchedule
   140: optional Memo memo
@@ -1060,6 +1114,7 @@ struct PollForDecisionTaskResponse {
   90: optional TaskList WorkflowExecutionTaskList
   100:  optional i64 (js.type = "Long") scheduledTimestamp
   110:  optional i64 (js.type = "Long") startedTimestamp
+  120:  optional map<string, WorkflowQuery> queries
 }
 
 struct StickyExecutionAttributes {
@@ -1076,6 +1131,7 @@ struct RespondDecisionTaskCompletedRequest {
   60: optional bool returnNewDecisionTask
   70: optional bool forceCreateNewDecisionTask
   80: optional string binaryChecksum
+  90: optional map<string, WorkflowQueryResult> queryResults
 }
 
 struct RespondDecisionTaskCompletedResponse {
@@ -1087,6 +1143,7 @@ struct RespondDecisionTaskFailedRequest {
   20: optional DecisionTaskFailedCause cause
   30: optional binary details
   40: optional string identity
+  50: optional string binaryChecksum
 }
 
 struct PollForActivityTaskRequest {
@@ -1295,6 +1352,18 @@ struct ListWorkflowExecutionsResponse {
   20: optional binary nextPageToken
 }
 
+struct ListArchivedWorkflowExecutionsRequest {
+  10: optional string domain
+  20: optional i32 pageSize
+  30: optional binary nextPageToken
+  40: optional string query
+}
+
+struct ListArchivedWorkflowExecutionsResponse {
+  10: optional list<WorkflowExecutionInfo> executions
+  20: optional binary nextPageToken
+}
+
 struct CountWorkflowExecutionsRequest {
   10: optional string domain
   20: optional string query
@@ -1314,6 +1383,7 @@ struct QueryWorkflowRequest {
   30: optional WorkflowQuery query
   // QueryRejectCondition can used to reject the query if workflow state does not satisify condition
   40: optional QueryRejectCondition queryRejectCondition
+  50: optional QueryConsistencyLevel queryConsistencyLevel
 }
 
 struct QueryRejected {
@@ -1345,6 +1415,13 @@ struct RespondQueryTaskCompletedRequest {
   20: optional QueryTaskCompletedType completedType
   30: optional binary queryResult
   40: optional string errorMessage
+  50: optional WorkerVersionInfo workerVersionInfo
+}
+
+struct WorkflowQueryResult {
+  10: optional QueryResultType resultType
+  20: optional binary answer
+  30: optional string errorMessage
 }
 
 struct DescribeWorkflowExecutionRequest {
@@ -1365,6 +1442,7 @@ struct PendingActivityInfo {
   100: optional i64 (js.type = "Long") expirationTimestamp
   110: optional string lastFailureReason
   120: optional string lastWorkerIdentity
+  130: optional binary lastFailureDetails
 }
 
 struct PendingChildExecutionInfo {
@@ -1372,6 +1450,7 @@ struct PendingChildExecutionInfo {
   20: optional string runID
   30: optional string workflowTypName
   40: optional i64 (js.type = "Long") initiatedID
+  50: optional ParentClosePolicy parentClosePolicy
 }
 
 struct DescribeWorkflowExecutionResponse {
@@ -1393,6 +1472,21 @@ struct DescribeTaskListResponse {
   20: optional TaskListStatus taskListStatus
 }
 
+struct ListTaskListPartitionsRequest {
+  10: optional string domain
+  20: optional TaskList taskList
+}
+
+struct TaskListPartitionMetadata {
+  10: optional string key
+  20: optional string ownerHostName
+}
+
+struct ListTaskListPartitionsResponse {
+  10: optional list<TaskListPartitionMetadata> activityTaskListPartitions
+  20: optional list<TaskListPartitionMetadata> decisionTaskListPartitions
+}
+
 struct TaskListStatus {
   10: optional i64 (js.type = "Long") backlogCountHint
   20: optional i64 (js.type = "Long") readLevel
@@ -1411,6 +1505,16 @@ struct DescribeHistoryHostRequest {
   10: optional string               hostAddress //ip:port
   20: optional i32                  shardIdForHost
   30: optional WorkflowExecution    executionForHost
+}
+
+struct RemoveTaskRequest {
+  10: optional i32                      shardID
+  20: optional i32                      type
+  30: optional i64 (js.type = "Long")   taskID
+}
+
+struct CloseShardRequest {
+  10: optional i32               shardID
 }
 
 struct DescribeHistoryHostResponse{
@@ -1482,5 +1586,41 @@ struct HistoryBranchRange{
 struct HistoryBranch{
   10: optional string treeID
   20: optional string branchID
-  30: optional list<HistoryBranchRange>  ancestors
+  30: optional list<HistoryBranchRange> ancestors
+}
+
+// VersionHistoryItem contains signal eventID and the corresponding version
+struct VersionHistoryItem{
+  10: optional i64 (js.type = "Long") eventID
+  20: optional i64 (js.type = "Long") version
+}
+
+// VersionHistory contains the version history of a branch
+struct VersionHistory{
+  10: optional binary branchToken
+  20: optional list<VersionHistoryItem> items
+}
+
+// VersionHistories contains all version histories from all branches
+struct VersionHistories{
+  10: optional i32 currentVersionHistoryIndex
+  20: optional list<VersionHistory> histories
+}
+
+// ReapplyEventsRequest is the request for reapply events API
+struct ReapplyEventsRequest{
+  10: optional string domainName
+  20: optional WorkflowExecution workflowExecution
+  30: optional DataBlob events
+}
+
+// SupportedClientVersions contains the support versions for client library
+struct SupportedClientVersions{
+  10: optional string goSdk
+  20: optional string javaSdk
+}
+
+// ClusterInfo contains information about cadence cluster
+struct ClusterInfo{
+  10: optional SupportedClientVersions supportedClientVersions
 }


### PR DESCRIPTION
In order to benefit from all the changes made in Cadence, the Java Client also has to be updated beginning with the thrift files.

This is a first step into having all features from Cadence into the Java Client and a requirement for #433.

