### PR TITLE
Automatically update idl submodule on build #435

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 /build
 /out
 dummy
+src/main/idls/*

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,19 @@ license {
     exclude 'com/uber/cadence/*.java' // generated code
 }
 
+task initDlsSubmodule(type: Exec) {
+    description = 'Initializes src/main/idls submodule'
+    commandLine 'git', 'submodule', 'init'
+}
+
+task updateDlsSubmodule(type: Exec) {
+    dependsOn initDlsSubmodule
+    description = 'Updates src/main/idls submodule'
+    commandLine 'git', 'submodule', 'update'
+}
+
 compileThrift {
+    dependsOn updateDlsSubmodule
     sourceItems "src/main/idls/thrift/cadence.thrift","src/main/idls/thrift/shared.thrift"
 
     nowarn true

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -5,6 +5,8 @@ ENV APACHE_THRIFT_VERSION=0.9.3
 
 # Install dependencies using apk
 RUN apk update && apk add --virtual wget ca-certificates wget && apk add --virtual build-dependencies build-base gcc
+# Git is needed in order to update the dls submodule
+RUN apk add --virtual git
 
 # Compile source
 RUN set -ex ;\


### PR DESCRIPTION
Now that we have the IDL submodule (#427) in the Java project root folder it should also automatically update this submodule when building.
My suggestion is to do this in the `gradle.build` file.
This will not only make it easier for anyone to just code and to not have to worry about having to initialize and update the submodule him/herself.