### PR TITLE
Fixed UUID generation bug when using TestWorkflowService

### DIFF
--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -87,11 +87,7 @@ public interface DecisionContext extends ReplayAware {
    */
   Map<String, Object> getPropagatedContexts();
 
-  /**
-   * Returns the set of configured context propagators
-   *
-   * @return
-   */
+  /** Returns the set of configured context propagators */
   List<ContextPropagator> getContextPropagators();
 
   /**

--- a/src/main/java/com/uber/cadence/internal/replay/WorkflowDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/WorkflowDecisionContext.java
@@ -233,6 +233,9 @@ final class WorkflowDecisionContext {
   /** Replay safe UUID */
   UUID randomUUID() {
     String runId = workflowContext.getCurrentRunId();
+    if (runId == null) {
+      throw new Error("null currentRunId");
+    }
     String id = runId + ":" + decisions.getAndIncrementNextId();
     byte[] bytes = id.getBytes(StandardCharsets.UTF_8);
     return UUID.nameUUIDFromBytes(bytes);

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -152,16 +152,22 @@ class StateMachines {
     int backoffStartIntervalInSeconds;
     String cronSchedule;
     byte[] lastCompletionResult;
+    String originalExecutionRunId;
+    Optional<String> continuedExecutionRunId;
 
     WorkflowData(
         Optional<RetryState> retryState,
         int backoffStartIntervalInSeconds,
         String cronSchedule,
-        byte[] lastCompletionResult) {
+        byte[] lastCompletionResult,
+        String originalExecutionRunId,
+        Optional<String> continuedExecutionRunId) {
       this.retryState = retryState;
       this.backoffStartIntervalInSeconds = backoffStartIntervalInSeconds;
       this.cronSchedule = cronSchedule;
       this.lastCompletionResult = lastCompletionResult;
+      this.originalExecutionRunId = originalExecutionRunId;
+      this.continuedExecutionRunId = continuedExecutionRunId;
     }
   }
 
@@ -538,6 +544,10 @@ class StateMachines {
     }
     if (data.retryState.isPresent()) {
       a.setAttempt(data.retryState.get().getAttempt());
+    }
+    a.setOriginalExecutionRunId(data.originalExecutionRunId);
+    if (data.continuedExecutionRunId.isPresent()) {
+      a.setContinuedExecutionRunId(data.continuedExecutionRunId.get());
     }
     a.setLastCompletionResult(data.lastCompletionResult);
     a.setMemo(request.getMemo());

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -25,7 +25,66 @@ import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
-import com.uber.cadence.*;
+import com.uber.cadence.ActivityTaskScheduledEventAttributes;
+import com.uber.cadence.BadRequestError;
+import com.uber.cadence.CancelTimerDecisionAttributes;
+import com.uber.cadence.CancelTimerFailedEventAttributes;
+import com.uber.cadence.CancelWorkflowExecutionDecisionAttributes;
+import com.uber.cadence.ChildWorkflowExecutionCanceledEventAttributes;
+import com.uber.cadence.ChildWorkflowExecutionCompletedEventAttributes;
+import com.uber.cadence.ChildWorkflowExecutionFailedEventAttributes;
+import com.uber.cadence.ChildWorkflowExecutionStartedEventAttributes;
+import com.uber.cadence.ChildWorkflowExecutionTimedOutEventAttributes;
+import com.uber.cadence.CompleteWorkflowExecutionDecisionAttributes;
+import com.uber.cadence.ContinueAsNewWorkflowExecutionDecisionAttributes;
+import com.uber.cadence.Decision;
+import com.uber.cadence.DecisionTaskFailedCause;
+import com.uber.cadence.EntityNotExistsError;
+import com.uber.cadence.EventType;
+import com.uber.cadence.FailWorkflowExecutionDecisionAttributes;
+import com.uber.cadence.HistoryEvent;
+import com.uber.cadence.InternalServiceError;
+import com.uber.cadence.MarkerRecordedEventAttributes;
+import com.uber.cadence.PollForActivityTaskRequest;
+import com.uber.cadence.PollForActivityTaskResponse;
+import com.uber.cadence.PollForDecisionTaskRequest;
+import com.uber.cadence.PollForDecisionTaskResponse;
+import com.uber.cadence.QueryFailedError;
+import com.uber.cadence.QueryRejectCondition;
+import com.uber.cadence.QueryRejected;
+import com.uber.cadence.QueryTaskCompletedType;
+import com.uber.cadence.QueryWorkflowRequest;
+import com.uber.cadence.QueryWorkflowResponse;
+import com.uber.cadence.RecordActivityTaskHeartbeatResponse;
+import com.uber.cadence.RecordMarkerDecisionAttributes;
+import com.uber.cadence.RequestCancelActivityTaskDecisionAttributes;
+import com.uber.cadence.RequestCancelActivityTaskFailedEventAttributes;
+import com.uber.cadence.RequestCancelExternalWorkflowExecutionDecisionAttributes;
+import com.uber.cadence.RequestCancelWorkflowExecutionRequest;
+import com.uber.cadence.RespondActivityTaskCanceledByIDRequest;
+import com.uber.cadence.RespondActivityTaskCanceledRequest;
+import com.uber.cadence.RespondActivityTaskCompletedByIDRequest;
+import com.uber.cadence.RespondActivityTaskCompletedRequest;
+import com.uber.cadence.RespondActivityTaskFailedByIDRequest;
+import com.uber.cadence.RespondActivityTaskFailedRequest;
+import com.uber.cadence.RespondDecisionTaskCompletedRequest;
+import com.uber.cadence.RespondDecisionTaskFailedRequest;
+import com.uber.cadence.RespondQueryTaskCompletedRequest;
+import com.uber.cadence.RetryPolicy;
+import com.uber.cadence.ScheduleActivityTaskDecisionAttributes;
+import com.uber.cadence.SignalExternalWorkflowExecutionDecisionAttributes;
+import com.uber.cadence.SignalExternalWorkflowExecutionFailedCause;
+import com.uber.cadence.SignalWorkflowExecutionRequest;
+import com.uber.cadence.StartChildWorkflowExecutionDecisionAttributes;
+import com.uber.cadence.StartChildWorkflowExecutionFailedEventAttributes;
+import com.uber.cadence.StartTimerDecisionAttributes;
+import com.uber.cadence.StartWorkflowExecutionRequest;
+import com.uber.cadence.StickyExecutionAttributes;
+import com.uber.cadence.TimeoutType;
+import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.WorkflowExecutionCloseStatus;
+import com.uber.cadence.WorkflowExecutionContinuedAsNewEventAttributes;
+import com.uber.cadence.WorkflowExecutionSignaledEventAttributes;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.testservice.StateMachines.Action;
 import com.uber.cadence.internal.testservice.StateMachines.ActivityTaskData;
@@ -45,7 +104,14 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -90,6 +156,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   private final Map<String, CompletableFuture<QueryWorkflowResponse>> queries =
       new ConcurrentHashMap<>();
   private final Map<String, PollForDecisionTaskResponse> queryRequests = new ConcurrentHashMap<>();
+  private final Optional<String> continuedExecutionRunId;
   public StickyExecutionAttributes stickyExecutionAttributes;
 
   /**
@@ -104,11 +171,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       byte[] lastCompletionResult,
       Optional<TestWorkflowMutableState> parent,
       OptionalLong parentChildInitiatedEventId,
+      Optional<String> continuedExecutionRunId,
       TestWorkflowService service,
       TestWorkflowStore store) {
     this.startRequest = startRequest;
     this.parent = parent;
     this.parentChildInitiatedEventId = parentChildInitiatedEventId;
+    this.continuedExecutionRunId = continuedExecutionRunId;
     this.service = service;
     String runId = UUID.randomUUID().toString();
     this.executionId =
@@ -121,7 +190,10 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             retryState,
             backoffStartIntervalInSeconds,
             startRequest.getCronSchedule(),
-            lastCompletionResult);
+            lastCompletionResult,
+            runId, // Test service doesn't support reset. Thus originalRunId is always the same as
+            // runId.
+            continuedExecutionRunId);
     this.workflow = StateMachines.newWorkflowStateMachine(data);
   }
 


### PR DESCRIPTION
Deterministic UUID generation within workflow code depends on originalRunId field of WorkflowExecutionStartedEvent. The TestWorkflowService wasn't populating it. So all Workflow.randomUUID as well as IDs of all child workflows were the same before this fix.