### PR TITLE
Add parent workflow ID and run ID to WorkflowInfo (#442)

### DIFF
--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -43,8 +43,7 @@ public interface DecisionContext extends ReplayAware {
 
   WorkflowExecution getWorkflowExecution();
 
-  // TODO: Add to Cadence
-  //    com.uber.cadence.WorkflowExecution getParentWorkflowExecution();
+  WorkflowExecution getParentWorkflowExecution();
 
   WorkflowType getWorkflowType();
 

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
@@ -107,6 +107,11 @@ final class DecisionContextImpl implements DecisionContext, HistoryEventHandler 
   }
 
   @Override
+  public WorkflowExecution getParentWorkflowExecution() {
+    return workflowContext.getParentWorkflowExecution();
+  }
+
+  @Override
   public WorkflowType getWorkflowType() {
     return workflowContext.getWorkflowType();
   }

--- a/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
@@ -90,12 +90,6 @@ final class WorkflowContext {
   }
 
   // TODO: Implement as soon as WorkflowExecutionStartedEventAttributes have these fields added.
-  ////    WorkflowExecution getParentWorkflowExecution() {
-  //        WorkflowExecutionStartedEventAttributes attributes =
-  // getWorkflowStartedEventAttributes();
-  //        return attributes.getParentWorkflowExecution();
-  //    }
-
   ////    com.uber.cadence.ChildPolicy getChildPolicy() {
   //        WorkflowExecutionStartedEventAttributes attributes =
   // getWorkflowStartedEventAttributes();
@@ -107,6 +101,11 @@ final class WorkflowContext {
   // getWorkflowStartedEventAttributes();
   //        return attributes.getContinuedExecutionRunId();
   //    }
+
+  WorkflowExecution getParentWorkflowExecution() {
+    WorkflowExecutionStartedEventAttributes attributes = getWorkflowStartedEventAttributes();
+    return attributes.getParentWorkflowExecution();
+  }
 
   int getExecutionStartToCloseTimeoutSeconds() {
     WorkflowExecutionStartedEventAttributes attributes = getWorkflowStartedEventAttributes();

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -525,6 +525,11 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     }
 
     @Override
+    public WorkflowExecution getParentWorkflowExecution() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
     public WorkflowType getWorkflowType() {
       return new WorkflowType().setName("dummy-workflow");
     }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInfoImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInfoImpl.java
@@ -69,12 +69,12 @@ final class WorkflowInfoImpl implements WorkflowInfo {
   @Override
   public String getParentWorkflowId() {
     WorkflowExecution parentWorkflowExecution = context.getParentWorkflowExecution();
-    return parentWorkflowExecution == null ? null : parentWorkflowExecution.workflowId;
+    return parentWorkflowExecution == null ? null : parentWorkflowExecution.getWorkflowId();
   }
 
   @Override
   public String getParentRunId() {
     WorkflowExecution parentWorkflowExecution = context.getParentWorkflowExecution();
-    return parentWorkflowExecution == null ? null : parentWorkflowExecution.workflowId;
+    return parentWorkflowExecution == null ? null : parentWorkflowExecution.getRunId();
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInfoImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInfoImpl.java
@@ -18,6 +18,7 @@
 package com.uber.cadence.internal.sync;
 
 import com.uber.cadence.SearchAttributes;
+import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.internal.replay.DecisionContext;
 import com.uber.cadence.workflow.WorkflowInfo;
 import java.time.Duration;
@@ -63,5 +64,17 @@ final class WorkflowInfoImpl implements WorkflowInfo {
   @Override
   public SearchAttributes getSearchAttributes() {
     return context.getSearchAttributes();
+  }
+
+  @Override
+  public String getParentWorkflowId() {
+    WorkflowExecution parentWorkflowExecution = context.getParentWorkflowExecution();
+    return parentWorkflowExecution == null ? null : parentWorkflowExecution.workflowId;
+  }
+
+  @Override
+  public String getParentRunId() {
+    WorkflowExecution parentWorkflowExecution = context.getParentWorkflowExecution();
+    return parentWorkflowExecution == null ? null : parentWorkflowExecution.workflowId;
   }
 }

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -553,6 +553,12 @@ class StateMachines {
     a.setMemo(request.getMemo());
     a.setSearchAttributes((request.getSearchAttributes()));
     a.setHeader(request.getHeader());
+    Optional<TestWorkflowMutableState> parent = ctx.getWorkflowMutableState().getParent();
+    if (parent.isPresent()) {
+      ExecutionId parentExecutionId = parent.get().getExecutionId();
+      a.setParentWorkflowDomain(parentExecutionId.getDomain());
+      a.setParentWorkflowExecution(parentExecutionId.getExecution());
+    }
     HistoryEvent event =
         new HistoryEvent()
             .setEventType(EventType.WorkflowExecutionStarted)

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableState.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableState.java
@@ -139,4 +139,6 @@ interface TestWorkflowMutableState {
       throws EntityNotExistsError;
 
   StickyExecutionAttributes getStickyExecutionAttributes();
+
+  Optional<TestWorkflowMutableState> getParent();
 }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -281,6 +281,11 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   }
 
   @Override
+  public Optional<TestWorkflowMutableState> getParent() {
+    return parent;
+  }
+
+  @Override
   public void startDecisionTask(
       PollForDecisionTaskResponse task, PollForDecisionTaskRequest pollRequest)
       throws InternalServiceError, EntityNotExistsError, BadRequestError {

--- a/src/main/java/com/uber/cadence/workflow/WorkflowInfo.java
+++ b/src/main/java/com/uber/cadence/workflow/WorkflowInfo.java
@@ -35,4 +35,8 @@ public interface WorkflowInfo {
   Duration getExecutionStartToCloseTimeout();
 
   SearchAttributes getSearchAttributes();
+
+  String getParentWorkflowId();
+
+  String getParentRunId();
 }

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -5366,6 +5366,49 @@ public class WorkflowTest {
     tracer.setExpected("upsertSearchAttributes", "executeActivity TestActivities::activity");
   }
 
+  public static class TestMultiargsWorkflowsFuncChild implements TestMultiargsWorkflowsFunc2 {
+    @Override
+    public String func2(String s, int i) {
+      WorkflowInfo wi = Workflow.getWorkflowInfo();
+      String parentId = wi.getParentWorkflowId();
+      return parentId;
+    }
+  }
+
+  public static class TestMultiargsWorkflowsFuncParent implements TestMultiargsWorkflowsFunc {
+    @Override
+    public String func() {
+      ChildWorkflowOptions workflowOptions =
+          new ChildWorkflowOptions.Builder()
+              .setExecutionStartToCloseTimeout(Duration.ofSeconds(100))
+              .setTaskStartToCloseTimeout(Duration.ofSeconds(60))
+              .build();
+      TestMultiargsWorkflowsFunc2 child =
+          Workflow.newChildWorkflowStub(TestMultiargsWorkflowsFunc2.class, workflowOptions);
+
+      String parentWorkflowId = Workflow.getWorkflowInfo().getParentWorkflowId();
+      String childsParentWorkflowId = child.func2(null, 0);
+
+      String result = String.format("%s - %s", parentWorkflowId, childsParentWorkflowId);
+      return result;
+    }
+  }
+
+  @Test
+  public void testParentWorkflowInfoInChildWorkflows() {
+    startWorkerFor(TestMultiargsWorkflowsFuncParent.class, TestMultiargsWorkflowsFuncChild.class);
+
+    String workflowId = "testParentWorkflowInfoInChildWorkflows";
+    WorkflowOptions workflowOptions =
+        newWorkflowOptionsBuilder(taskList).setWorkflowId(workflowId).build();
+    TestMultiargsWorkflowsFunc parent =
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsFunc.class, workflowOptions);
+
+    String result = parent.func();
+    String expected = String.format("%s - %s", null, workflowId);
+    assertEquals(expected, result);
+  }
+
   private static class TracingWorkflowInterceptor implements WorkflowInterceptor {
 
     private final FilteredTrace trace;


### PR DESCRIPTION
Prior to this change, child workflows didn't have a way to retrieve the workflow ID and
run ID of the parent workflow. This change adds getters to the WorkflowInfo interface
to expose the information that exists in the WorkflowExecutionStartedEvent.

Resolves: #442