### PR TITLE
Retry getting result from passive in case of replication delay

### DIFF
--- a/src/main/java/com/uber/cadence/internal/common/InternalUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/InternalUtils.java
@@ -19,23 +19,23 @@ package com.uber.cadence.internal.common;
 
 import com.google.common.base.Defaults;
 import com.uber.cadence.DataBlob;
+import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.History;
 import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.HistoryEventFilterType;
 import com.uber.cadence.SearchAttributes;
 import com.uber.cadence.TaskList;
 import com.uber.cadence.TaskListKind;
-import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.converter.JsonDataConverter;
 import com.uber.cadence.internal.worker.Shutdownable;
 import com.uber.cadence.workflow.WorkflowMethod;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -193,7 +193,8 @@ public final class InternalUtils {
       try {
         blob.setData(serializer.serialize(event));
       } catch (org.apache.thrift.TException err) {
-        throw new EntityNotExistsError("Deserialize blob data to history event failed with unknown error");
+        throw new EntityNotExistsError(
+            "Deserialize blob data to history event failed with unknown error");
       }
       blobs.add(blob);
     }

--- a/src/main/java/com/uber/cadence/internal/common/InternalUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/InternalUtils.java
@@ -19,7 +19,6 @@ package com.uber.cadence.internal.common;
 
 import com.google.common.base.Defaults;
 import com.uber.cadence.DataBlob;
-import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.History;
 import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.HistoryEventFilterType;
@@ -183,18 +182,15 @@ public final class InternalUtils {
     return new History().setEvents(events);
   }
 
-  // This method deserialize the history event data to blob data
-  public static List<DataBlob> DeserializeFromHistoryEventToBlobData(List<HistoryEvent> events)
-      throws EntityNotExistsError {
-
-    List<DataBlob> blobs = new ArrayList<DataBlob>();
+  // This method serializes history event to blob data
+  public static List<DataBlob> SerializeFromHistoryEventToBlobData(List<HistoryEvent> events) {
+    List<DataBlob> blobs = new ArrayList<>(events.size());
     for (HistoryEvent event : events) {
       DataBlob blob = new DataBlob();
       try {
         blob.setData(serializer.serialize(event));
       } catch (org.apache.thrift.TException err) {
-        throw new EntityNotExistsError(
-            "Deserialize blob data to history event failed with unknown error");
+        throw new RuntimeException("Serialize to blob data failed", err);
       }
       blobs.add(blob);
     }

--- a/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
@@ -100,6 +100,9 @@ public class WorkflowExecutionUtils {
           .setDoNotRetry(BadRequestError.class, EntityNotExistsError.class)
           .build();
 
+  // Wait period for passive cluster to retry getting workflow result in case of replication delay.
+  private static final long ENTITY_NOT_EXIST_RETRY_WAIT_MILLIS = 500;
+
   /**
    * Returns result of a workflow instance execution or throws an exception if workflow did not
    * complete successfully.
@@ -178,7 +181,7 @@ public class WorkflowExecutionUtils {
   }
 
   /** Returns an instance closing event, potentially waiting for workflow to complete. */
-  public static HistoryEvent getInstanceCloseEvent(
+  private static HistoryEvent getInstanceCloseEvent(
       IWorkflowService service,
       String domain,
       WorkflowExecution workflowExecution,
@@ -191,20 +194,6 @@ public class WorkflowExecutionUtils {
     long start = System.currentTimeMillis();
     HistoryEvent event;
     do {
-      GetWorkflowExecutionHistoryRequest r = new GetWorkflowExecutionHistoryRequest();
-      r.setDomain(domain);
-      r.setExecution(workflowExecution);
-      r.setHistoryEventFilterType(HistoryEventFilterType.CLOSE_EVENT);
-      r.setNextPageToken(pageToken);
-      r.setWaitForNewEvent(true);
-      try {
-        response =
-            Retryer.retryWithResult(retryParameters, () -> service.GetWorkflowExecutionHistory(r));
-      } catch (EntityNotExistsError e) {
-        throw e;
-      } catch (TException e) {
-        throw CheckedExceptionWrapper.wrap(e);
-      }
       if (timeout != 0 && System.currentTimeMillis() - start > unit.toMillis(timeout)) {
         throw new TimeoutException(
             "WorkflowId="
@@ -215,6 +204,35 @@ public class WorkflowExecutionUtils {
                 + timeout
                 + ", unit="
                 + unit);
+      }
+
+      GetWorkflowExecutionHistoryRequest r = new GetWorkflowExecutionHistoryRequest();
+      r.setDomain(domain);
+      r.setExecution(workflowExecution);
+      r.setHistoryEventFilterType(HistoryEventFilterType.CLOSE_EVENT);
+      r.setNextPageToken(pageToken);
+      r.setWaitForNewEvent(true);
+      r.setSkipArchival(true);
+      try {
+        response =
+            Retryer.retryWithResult(retryParameters, () -> service.GetWorkflowExecutionHistory(r));
+      } catch (EntityNotExistsError e) {
+        if (e.activeCluster != null
+            && e.currentCluster != null
+            && !e.activeCluster.equals(e.currentCluster)) {
+          // Current cluster is passive cluster. Execution might not exist because of replication
+          // lag. Wait for a little bit and retry.
+          try {
+            Thread.sleep(ENTITY_NOT_EXIST_RETRY_WAIT_MILLIS);
+          } catch (InterruptedException ie) {
+            // Throw entity not exist here.
+            throw e;
+          }
+          continue;
+        }
+        throw e;
+      } catch (TException e) {
+        throw CheckedExceptionWrapper.wrap(e);
       }
       pageToken = response.getNextPageToken();
       History history = response.getHistory();

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStore.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStore.java
@@ -31,7 +31,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.thrift.TException;
 
 interface TestWorkflowStore {
 
@@ -156,7 +155,8 @@ interface TestWorkflowStore {
       throws EntityNotExistsError;
 
   GetWorkflowExecutionHistoryResponse getWorkflowExecutionHistory(
-      ExecutionId executionId, GetWorkflowExecutionHistoryRequest getRequest) throws EntityNotExistsError;
+      ExecutionId executionId, GetWorkflowExecutionHistoryRequest getRequest)
+      throws EntityNotExistsError;
 
   void getDiagnostics(StringBuilder result);
 

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -348,7 +348,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       if (!getRequest.isWaitForNewEvent()
           && getRequest.getHistoryEventFilterType() != HistoryEventFilterType.CLOSE_EVENT) {
         List<HistoryEvent> events = history.getEventsLocked();
-        List<DataBlob> blobs = InternalUtils.DeserializeFromHistoryEventToBlobData(events);
+        List<DataBlob> blobs = InternalUtils.SerializeFromHistoryEventToBlobData(events);
         // Copy the list as it is mutable. Individual events assumed immutable.
         ArrayList<HistoryEvent> eventsCopy = new ArrayList<>(events);
         return new GetWorkflowExecutionHistoryResponse()
@@ -361,7 +361,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     }
     List<HistoryEvent> events =
         history.waitForNewEvents(expectedNextEventId, getRequest.getHistoryEventFilterType());
-    List<DataBlob> blobs = InternalUtils.DeserializeFromHistoryEventToBlobData(events);
+    List<DataBlob> blobs = InternalUtils.SerializeFromHistoryEventToBlobData(events);
     GetWorkflowExecutionHistoryResponse result = new GetWorkflowExecutionHistoryResponse();
     if (events != null) {
       result.setHistory(new History().setEvents(events));

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -18,10 +18,9 @@
 package com.uber.cadence.internal.testservice;
 
 import com.uber.cadence.BadRequestError;
+import com.uber.cadence.DataBlob;
 import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.EventType;
-import com.uber.cadence.DataBlob;
-import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
 import com.uber.cadence.History;
@@ -35,6 +34,7 @@ import com.uber.cadence.PollForDecisionTaskResponse;
 import com.uber.cadence.StickyExecutionAttributes;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionInfo;
+import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.testservice.RequestContext.Timer;
 import java.time.Duration;
@@ -49,7 +49,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import org.apache.thrift.TException;
 
 class TestWorkflowStoreImpl implements TestWorkflowStore {
 
@@ -338,7 +337,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
 
   @Override
   public GetWorkflowExecutionHistoryResponse getWorkflowExecutionHistory(
-      ExecutionId executionId, GetWorkflowExecutionHistoryRequest getRequest) throws EntityNotExistsError {
+      ExecutionId executionId, GetWorkflowExecutionHistoryRequest getRequest)
+      throws EntityNotExistsError {
     HistoryStore history;
     // Used to eliminate the race condition on waitForNewEvents
     long expectedNextEventId;
@@ -352,7 +352,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
         // Copy the list as it is mutable. Individual events assumed immutable.
         ArrayList<HistoryEvent> eventsCopy = new ArrayList<>(events);
         return new GetWorkflowExecutionHistoryResponse()
-            .setHistory(new History().setEvents(eventsCopy)).setRawHistory(blobs);
+            .setHistory(new History().setEvents(eventsCopy))
+            .setRawHistory(blobs);
       }
       expectedNextEventId = history.getNextEventIdLocked();
     } finally {


### PR DESCRIPTION
Cadence supports auto forwarding for startWorkflow execution, but not for getHistory. This poses an issue if user want to start workflow and block on getting the result from the passive side, as the getHistory call will likely to fail due to the replication lag. This also can cause additional load to archival system for archive enabled domain, as cadence will fallback to query archival if it cannot find it in its primary persistence.

We are doing the following changes to mitigate this issue:
1. In GetWorkflowExecutionHistory request, add a flag to indicate skip querying archival.
2. If history does not exist and domain is not active in the region that serves the request, return this information in the error.
3. Client continue to retry and long poll in case of this error.