### PR TITLE
Make timeout apply to getResultAsync instead of per history page

### DIFF
--- a/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
@@ -125,7 +125,7 @@ public class WorkflowExecutionUtils {
       TimeUnit unit)
       throws TimeoutException, CancellationException, WorkflowExecutionFailedException,
           WorkflowTerminatedException, WorkflowTimedOutException, EntityNotExistsError {
-    // getIntanceCloseEvent waits for workflow completion including new runs.
+    // getInstanceCloseEvent waits for workflow completion including new runs.
     HistoryEvent closeEvent =
         getInstanceCloseEvent(service, domain, workflowExecution, timeout, unit);
     return getResultFromCloseEvent(workflowExecution, workflowType, closeEvent);
@@ -294,7 +294,8 @@ public class WorkflowExecutionUtils {
         getWorkflowExecutionHistoryAsync(service, request);
     return response.thenComposeAsync(
         (r) -> {
-          if (timeout != 0 && System.currentTimeMillis() - start > unit.toMillis(timeout)) {
+          long elapsedTime = System.currentTimeMillis() - start;
+          if (timeout != 0 && elapsedTime > unit.toMillis(timeout)) {
             throw CheckedExceptionWrapper.wrap(
                 new TimeoutException(
                     "WorkflowId="
@@ -310,7 +311,7 @@ public class WorkflowExecutionUtils {
           if (history == null || history.getEvents().size() == 0) {
             // Empty poll returned
             return getInstanceCloseEventAsync(
-                service, domain, workflowExecution, pageToken, timeout, unit);
+                service, domain, workflowExecution, pageToken, timeout - elapsedTime, unit);
           }
           HistoryEvent event = history.getEvents().get(0);
           if (!isWorkflowExecutionCompletedEvent(event)) {
@@ -326,7 +327,12 @@ public class WorkflowExecutionUtils {
                             .getWorkflowExecutionContinuedAsNewEventAttributes()
                             .getNewExecutionRunId());
             return getInstanceCloseEventAsync(
-                service, domain, nextWorkflowExecution, r.getNextPageToken(), timeout, unit);
+                service,
+                domain,
+                nextWorkflowExecution,
+                r.getNextPageToken(),
+                timeout - elapsedTime,
+                unit);
           }
           return CompletableFuture.completedFuture(event);
         });


### PR DESCRIPTION
Currently getResultAsync timeout is for per page and might never be used. 
This PR make timeout applied to the getResultAsync call instead of user transparent page call timeout. 