### PR TITLE
Added missing fields to local activity task

### DIFF
--- a/src/main/java/com/uber/cadence/internal/replay/ExecuteLocalActivityParameters.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ExecuteLocalActivityParameters.java
@@ -18,11 +18,14 @@
 package com.uber.cadence.internal.replay;
 
 import com.uber.cadence.ActivityType;
+import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.common.RetryOptions;
 import java.util.Arrays;
 
 public class ExecuteLocalActivityParameters {
 
+  private String workflowDomain;
+  private WorkflowExecution workflowExecution;
   private String activityId;
   private ActivityType activityType;
   private byte[] input;
@@ -211,9 +214,30 @@ public class ExecuteLocalActivityParameters {
     this.elapsedTime = startTime;
   }
 
+  public String getWorkflowDomain() {
+    return workflowDomain;
+  }
+
+  public void setWorkflowDomain(String workflowDomain) {
+    this.workflowDomain = workflowDomain;
+  }
+
+  public WorkflowExecution getWorkflowExecution() {
+    return workflowExecution;
+  }
+
+  public void setWorkflowExecution(WorkflowExecution workflowExecution) {
+    this.workflowExecution = workflowExecution;
+  }
+
   @Override
   public String toString() {
-    return "ExecuteActivityParameters{"
+    return "ExecuteLocalActivityParameters{"
+        + "workflowDomain='"
+        + workflowDomain
+        + '\''
+        + ", workflowExecution="
+        + workflowExecution
         + "activityId='"
         + activityId
         + '\''
@@ -223,6 +247,12 @@ public class ExecuteLocalActivityParameters {
         + Arrays.toString(input)
         + ", scheduleToCloseTimeoutSeconds="
         + scheduleToCloseTimeoutSeconds
+        + ", retryOptions="
+        + retryOptions
+        + ", elapsedTime="
+        + elapsedTime
+        + ", attempt="
+        + attempt
         + '}';
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -334,6 +334,8 @@ final class SyncDecisionContext implements WorkflowInterceptor {
     }
     parameters.setAttempt(attempt);
     parameters.setElapsedTime(elapsed);
+    parameters.setWorkflowDomain(this.context.getDomain());
+    parameters.setWorkflowExecution(this.context.getWorkflowExecution());
     return parameters;
   }
 

--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -733,6 +733,7 @@ class StateMachines {
 
     PollForActivityTaskResponse taskResponse =
         new PollForActivityTaskResponse()
+            .setWorkflowDomain(ctx.getDomain())
             .setWorkflowType(data.startWorkflowExecutionRequest.workflowType)
             .setActivityType(d.getActivityType())
             .setWorkflowExecution(ctx.getExecution())

--- a/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
@@ -212,6 +212,11 @@ public final class LocalActivityWorker implements SuspendableWorker {
       metricsScope.counter(MetricsType.LOCAL_ACTIVITY_TOTAL_COUNTER).inc(1);
 
       PollForActivityTaskResponse pollTask = new PollForActivityTaskResponse();
+      pollTask.setWorkflowDomain(task.params.getWorkflowDomain());
+      pollTask.setActivityId(task.params.getActivityId());
+      pollTask.setWorkflowExecution(task.params.getWorkflowExecution());
+      pollTask.setScheduledTimestamp(System.currentTimeMillis());
+      pollTask.setStartedTimestamp(System.currentTimeMillis());
       pollTask.setActivityType(task.params.getActivityType());
       pollTask.setInput(task.params.getInput());
       pollTask.setAttempt(task.params.getAttempt());

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -3716,6 +3716,11 @@ public class WorkflowTest {
 
     @Override
     public void throwIO() {
+      assertEquals(DOMAIN, Activity.getTask().getWorkflowDomain());
+      assertNotNull(Activity.getTask().getWorkflowExecution());
+      assertNotNull(Activity.getTask().getWorkflowExecution().getWorkflowId());
+      assertFalse(Activity.getTask().getWorkflowExecution().getWorkflowId().isEmpty());
+      assertFalse(Activity.getTask().getWorkflowExecution().getRunId().isEmpty());
       lastAttempt = Activity.getTask().getAttempt();
       invocations.add("throwIO");
       try {


### PR DESCRIPTION
## Summary
This PR makes local activities report the same as metadata as activities. Now `Activity.getTask().getWorkflowExecution()` and `getWorkflowDomain()` return data for local activities.

## Reviewer
@mfateev 