### PR TITLE
Add async start to untype stub

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowStub.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowStub.java
@@ -67,6 +67,8 @@ public interface WorkflowStub {
 
   WorkflowExecution start(Object... args);
 
+  CompletableFuture<WorkflowExecution> startAsync(Object... args);
+
   WorkflowExecution signalWithStart(String signalName, Object[] signalArgs, Object[] startArgs);
 
   Optional<String> getWorkflowType();

--- a/src/main/java/com/uber/cadence/client/WorkflowStub.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowStub.java
@@ -69,6 +69,8 @@ public interface WorkflowStub {
 
   CompletableFuture<WorkflowExecution> startAsync(Object... args);
 
+  CompletableFuture<WorkflowExecution> startAsyncWithTimeout(Long timeoutInMillis, Object... args);
+
   WorkflowExecution signalWithStart(String signalName, Object[] signalArgs, Object[] startArgs);
 
   Optional<String> getWorkflowType();

--- a/src/main/java/com/uber/cadence/client/WorkflowStub.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowStub.java
@@ -69,7 +69,8 @@ public interface WorkflowStub {
 
   CompletableFuture<WorkflowExecution> startAsync(Object... args);
 
-  CompletableFuture<WorkflowExecution> startAsyncWithTimeout(Long timeoutInMillis, Object... args);
+  CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
+      long timeout, TimeUnit unit, Object... args);
 
   WorkflowExecution signalWithStart(String signalName, Object[] signalArgs, Object[] startArgs);
 

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
@@ -26,11 +26,15 @@ import com.uber.cadence.internal.common.TerminateWorkflowExecutionParameters;
 import com.uber.cadence.internal.replay.QueryWorkflowParameters;
 import com.uber.cadence.internal.replay.SignalExternalWorkflowParameters;
 import com.uber.cadence.serviceclient.IWorkflowService;
+import java.util.concurrent.CompletableFuture;
 
 public interface GenericWorkflowClientExternal {
 
   WorkflowExecution startWorkflow(StartWorkflowExecutionParameters startParameters)
       throws WorkflowExecutionAlreadyStartedError;
+
+  CompletableFuture<WorkflowExecution> startWorkflowAsync(
+      StartWorkflowExecutionParameters startParameters);
 
   void signalWorkflowExecution(SignalExternalWorkflowParameters signalParameters);
 

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
@@ -36,6 +36,9 @@ public interface GenericWorkflowClientExternal {
   CompletableFuture<WorkflowExecution> startWorkflowAsync(
       StartWorkflowExecutionParameters startParameters);
 
+  CompletableFuture<WorkflowExecution> startWorkflowAsync(
+      StartWorkflowExecutionParameters startParameters, Long timeoutInMillis);
+
   void signalWorkflowExecution(SignalExternalWorkflowParameters signalParameters);
 
   WorkflowExecution signalWithStartWorkflowExecution(

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
@@ -79,7 +79,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     try {
       return startWorkflowInternal(startParameters);
     } finally {
-      emitStartMetric(startParameters);
+      emitMetricsForStartWorkflow(startParameters);
     }
   }
 
@@ -87,11 +87,11 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
   public CompletableFuture<WorkflowExecution> startWorkflowAsync(
       StartWorkflowExecutionParameters startParameters) {
 
-    emitStartMetric(startParameters);
+    emitMetricsForStartWorkflow(startParameters);
     return startWorkflowAsyncInternal(startParameters);
   }
 
-  private void emitStartMetric(StartWorkflowExecutionParameters startParameters) {
+  private void emitMetricsForStartWorkflow(StartWorkflowExecutionParameters startParameters) {
     // TODO: can probably cache this
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(3)

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -577,6 +577,15 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     }
 
     @Override
+    public void StartWorkflowExecutionWithTimeout(
+        StartWorkflowExecutionRequest startRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.StartWorkflowExecutionWithTimeout(startRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
     public void GetWorkflowExecutionHistory(
         GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
         throws TException {

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -803,6 +803,11 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
       }
 
       @Override
+      public CompletableFuture<WorkflowExecution> startAsync(Object... args) {
+        return next.startAsync(args);
+      }
+
+      @Override
       public WorkflowExecution signalWithStart(
           String signalName, Object[] signalArgs, Object[] startArgs) {
         return next.signalWithStart(signalName, signalArgs, startArgs);

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -428,6 +428,15 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     }
 
     @Override
+    public void StartWorkflowExecutionWithTimeout(
+        StartWorkflowExecutionRequest startRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.StartWorkflowExecutionWithTimeout(startRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
     public void GetWorkflowExecutionHistory(
         GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
         throws TException {
@@ -805,6 +814,12 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
       @Override
       public CompletableFuture<WorkflowExecution> startAsync(Object... args) {
         return next.startAsync(args);
+      }
+
+      @Override
+      public CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
+          Long timeoutInMillis, Object... args) {
+        return next.startAsyncWithTimeout(timeoutInMillis, args);
       }
 
       @Override

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -818,8 +818,8 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
 
       @Override
       public CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
-          Long timeoutInMillis, Object... args) {
-        return next.startAsyncWithTimeout(timeoutInMillis, args);
+          long timeout, TimeUnit unit, Object... args) {
+        return next.startAsyncWithTimeout(timeout, unit, args);
       }
 
       @Override

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
@@ -129,9 +129,9 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   private CompletableFuture<WorkflowExecution> startAsyncWithOptions(
-      Long timeoutInMillis, WorkflowOptions o, Object... args) {
+      long timeout, TimeUnit unit, WorkflowOptions o, Object... args) {
     StartWorkflowExecutionParameters p = getStartWorkflowExecutionParameters(o, args);
-    return genericClient.startWorkflowAsync(p, timeoutInMillis);
+    return genericClient.startWorkflowAsync(p, unit.toMillis(timeout));
   }
 
   private StartWorkflowExecutionParameters getStartWorkflowExecutionParameters(
@@ -203,19 +203,19 @@ class WorkflowStubImpl implements WorkflowStub {
 
   @Override
   public CompletableFuture<WorkflowExecution> startAsync(Object... args) {
-    return startAsyncWithTimeout(Long.MAX_VALUE, args);
+    return startAsyncWithTimeout(Long.MAX_VALUE, TimeUnit.MILLISECONDS, args);
   }
 
   @Override
   public CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
-      Long timeoutInMillis, Object... args) {
+      long timeout, TimeUnit unit, Object... args) {
     if (!options.isPresent()) {
       throw new IllegalStateException("Required parameter WorkflowOptions is missing");
     }
 
     CompletableFuture<WorkflowExecution> result =
         startAsyncWithOptions(
-            timeoutInMillis, WorkflowOptions.merge(null, null, null, options.get()), args);
+            timeout, unit, WorkflowOptions.merge(null, null, null, options.get()), args);
     result.whenComplete(
         (input, exception) -> {
           if (input != null) {

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
@@ -128,6 +128,12 @@ class WorkflowStubImpl implements WorkflowStub {
     return execution.get();
   }
 
+  private CompletableFuture<WorkflowExecution> startAsyncWithOptions(
+      WorkflowOptions o, Object... args) {
+    StartWorkflowExecutionParameters p = getStartWorkflowExecutionParameters(o, args);
+    return genericClient.startWorkflowAsync(p);
+  }
+
   private StartWorkflowExecutionParameters getStartWorkflowExecutionParameters(
       WorkflowOptions o, Object[] args) {
     if (execution.get() != null) {
@@ -193,6 +199,15 @@ class WorkflowStubImpl implements WorkflowStub {
       throw new IllegalStateException("Required parameter WorkflowOptions is missing");
     }
     return startWithOptions(WorkflowOptions.merge(null, null, null, options.get()), args);
+  }
+
+  @Override
+  public CompletableFuture<WorkflowExecution> startAsync(Object... args) {
+    if (!options.isPresent()) {
+      throw new IllegalStateException("Required parameter WorkflowOptions is missing");
+    }
+
+    return startAsyncWithOptions(WorkflowOptions.merge(null, null, null, options.get()), args);
   }
 
   private WorkflowExecution signalWithStartWithOptions(

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
@@ -207,7 +207,18 @@ class WorkflowStubImpl implements WorkflowStub {
       throw new IllegalStateException("Required parameter WorkflowOptions is missing");
     }
 
-    return startAsyncWithOptions(WorkflowOptions.merge(null, null, null, options.get()), args);
+    CompletableFuture<WorkflowExecution> result =
+        startAsyncWithOptions(WorkflowOptions.merge(null, null, null, options.get()), args);
+    result.whenComplete(
+        (input, exception) -> {
+          if (input != null) {
+            execution.set(
+                new WorkflowExecution()
+                    .setWorkflowId(input.getWorkflowId())
+                    .setRunId(input.getRunId()));
+          }
+        });
+    return result;
   }
 
   private WorkflowExecution signalWithStartWithOptions(

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
@@ -129,9 +129,9 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   private CompletableFuture<WorkflowExecution> startAsyncWithOptions(
-      WorkflowOptions o, Object... args) {
+      Long timeoutInMillis, WorkflowOptions o, Object... args) {
     StartWorkflowExecutionParameters p = getStartWorkflowExecutionParameters(o, args);
-    return genericClient.startWorkflowAsync(p);
+    return genericClient.startWorkflowAsync(p, timeoutInMillis);
   }
 
   private StartWorkflowExecutionParameters getStartWorkflowExecutionParameters(
@@ -203,12 +203,19 @@ class WorkflowStubImpl implements WorkflowStub {
 
   @Override
   public CompletableFuture<WorkflowExecution> startAsync(Object... args) {
+    return startAsyncWithTimeout(Long.MAX_VALUE, args);
+  }
+
+  @Override
+  public CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
+      Long timeoutInMillis, Object... args) {
     if (!options.isPresent()) {
       throw new IllegalStateException("Required parameter WorkflowOptions is missing");
     }
 
     CompletableFuture<WorkflowExecution> result =
-        startAsyncWithOptions(WorkflowOptions.merge(null, null, null, options.get()), args);
+        startAsyncWithOptions(
+            timeoutInMillis, WorkflowOptions.merge(null, null, null, options.get()), args);
     result.whenComplete(
         (input, exception) -> {
           if (input != null) {

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -797,7 +797,15 @@ public final class TestWorkflowService implements IWorkflowService {
   public void StartWorkflowExecution(
       StartWorkflowExecutionRequest startRequest, AsyncMethodCallback resultHandler)
       throws TException {
-    throw new UnsupportedOperationException("not implemented");
+    forkJoinPool.execute(
+        () -> {
+          try {
+            StartWorkflowExecutionResponse result = StartWorkflowExecution(startRequest);
+            resultHandler.onComplete(result);
+          } catch (TException e) {
+            resultHandler.onError(e);
+          }
+        });
   }
 
   @SuppressWarnings("unchecked") // Generator ignores that AsyncMethodCallback is generic

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -797,6 +797,15 @@ public final class TestWorkflowService implements IWorkflowService {
   public void StartWorkflowExecution(
       StartWorkflowExecutionRequest startRequest, AsyncMethodCallback resultHandler)
       throws TException {
+    StartWorkflowExecutionWithTimeout(startRequest, resultHandler, null);
+  }
+
+  @Override
+  public void StartWorkflowExecutionWithTimeout(
+      StartWorkflowExecutionRequest startRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis)
+      throws TException {
     forkJoinPool.execute(
         () -> {
           try {

--- a/src/main/java/com/uber/cadence/reporter/CadenceClientStatsReporter.java
+++ b/src/main/java/com/uber/cadence/reporter/CadenceClientStatsReporter.java
@@ -59,11 +59,14 @@ public class CadenceClientStatsReporter implements StatsReporter {
 
   @Override
   public void reportGauge(String name, Map<String, String> tags, double value) {
-    AtomicDouble gauge = gauges.computeIfAbsent(name, metricName -> {
-      AtomicDouble result = Metrics.gauge(name, getTags(tags), new AtomicDouble());
-      Preconditions.checkNotNull(result, "Metrics.gauge should not return null ever");
-      return result;
-    });
+    AtomicDouble gauge =
+        gauges.computeIfAbsent(
+            name,
+            metricName -> {
+              AtomicDouble result = Metrics.gauge(name, getTags(tags), new AtomicDouble());
+              Preconditions.checkNotNull(result, "Metrics.gauge should not return null ever");
+              return result;
+            });
     gauge.set(value);
   }
 
@@ -99,7 +102,6 @@ public class CadenceClientStatsReporter implements StatsReporter {
         Tag.of(MetricsTag.ACTIVITY_TYPE, Strings.nullToEmpty(tags.get(MetricsTag.ACTIVITY_TYPE))),
         Tag.of(MetricsTag.DOMAIN, Strings.nullToEmpty(tags.get(MetricsTag.DOMAIN))),
         Tag.of(MetricsTag.TASK_LIST, Strings.nullToEmpty(tags.get(MetricsTag.TASK_LIST))),
-        Tag.of(MetricsTag.WORKFLOW_TYPE, Strings.nullToEmpty(tags.get(MetricsTag.WORKFLOW_TYPE)))
-    );
+        Tag.of(MetricsTag.WORKFLOW_TYPE, Strings.nullToEmpty(tags.get(MetricsTag.WORKFLOW_TYPE))));
   }
 }

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
@@ -19,6 +19,7 @@ package com.uber.cadence.serviceclient;
 
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
+import com.uber.cadence.StartWorkflowExecutionRequest;
 import com.uber.cadence.WorkflowService.AsyncIface;
 import com.uber.cadence.WorkflowService.Iface;
 import org.apache.thrift.TException;
@@ -26,6 +27,21 @@ import org.apache.thrift.async.AsyncMethodCallback;
 
 public interface IWorkflowService extends Iface, AsyncIface {
   void close();
+
+  /**
+   * StartWorkflowExecutionWithTimeout start workflow same as StartWorkflowExecution but with
+   * timeout
+   *
+   * @param startRequest
+   * @param resultHandler
+   * @param timeoutInMillis
+   * @throws TException
+   */
+  void StartWorkflowExecutionWithTimeout(
+      StartWorkflowExecutionRequest startRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis)
+      throws TException;
 
   /**
    * GetWorkflowExecutionHistoryWithTimeout get workflow history same as GetWorkflowExecutionHistory

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -2301,12 +2301,29 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   @Override
   public void StartWorkflowExecution(
       StartWorkflowExecutionRequest startRequest, AsyncMethodCallback resultHandler) {
+    startWorkflowExecution(startRequest, resultHandler, null);
+  }
+
+  @Override
+  public void StartWorkflowExecutionWithTimeout(
+      StartWorkflowExecutionRequest startRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis) {
+    startWorkflowExecution(startRequest, resultHandler, timeoutInMillis);
+  }
+
+  public void startWorkflowExecution(
+      StartWorkflowExecutionRequest startRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis) {
 
     startRequest.setRequestId(UUID.randomUUID().toString());
+    timeoutInMillis = validateAndUpdateTimeout(timeoutInMillis, options.getRpcTimeoutMillis());
     ThriftRequest<WorkflowService.StartWorkflowExecution_args> request =
         buildThriftRequest(
             "StartWorkflowExecution",
-            new WorkflowService.StartWorkflowExecution_args(startRequest));
+            new WorkflowService.StartWorkflowExecution_args(startRequest),
+            timeoutInMillis);
 
     CompletableFuture<ThriftResponse<WorkflowService.StartWorkflowExecution_result>> response =
         doRemoteCallAsync(request);

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -2312,7 +2312,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
     startWorkflowExecution(startRequest, resultHandler, timeoutInMillis);
   }
 
-  public void startWorkflowExecution(
+  private void startWorkflowExecution(
       StartWorkflowExecutionRequest startRequest,
       AsyncMethodCallback resultHandler,
       Long timeoutInMillis) {

--- a/src/test/java/com/uber/cadence/reporter/CadenceClientStatsReporterTest.java
+++ b/src/test/java/com/uber/cadence/reporter/CadenceClientStatsReporterTest.java
@@ -42,11 +42,12 @@ public class CadenceClientStatsReporterTest {
   private static final long DEFAULT_COUNT = 10;
   private static final double DEFAULT_VALUE = 1.0;
   private static final Duration DEFAULT_DURATION = Duration.ofSeconds(10);
-  private static final List<Tag> EXPECTED_REPORT_TAGS = Arrays.asList(
-      Tag.of(MetricsTag.ACTIVITY_TYPE, ""),
-      Tag.of(MetricsTag.DOMAIN, "domain_name"),
-      Tag.of(MetricsTag.TASK_LIST, "task_list"),
-      Tag.of(MetricsTag.WORKFLOW_TYPE, ""));
+  private static final List<Tag> EXPECTED_REPORT_TAGS =
+      Arrays.asList(
+          Tag.of(MetricsTag.ACTIVITY_TYPE, ""),
+          Tag.of(MetricsTag.DOMAIN, "domain_name"),
+          Tag.of(MetricsTag.TASK_LIST, "task_list"),
+          Tag.of(MetricsTag.WORKFLOW_TYPE, ""));
 
   private CadenceClientStatsReporter cadenceClientStatsReporter = new CadenceClientStatsReporter();
 
@@ -69,7 +70,8 @@ public class CadenceClientStatsReporterTest {
   public void testCounterShouldCallMetricRegistryForMonitoredCounterCadenceAction() {
     callDefaultCounter();
 
-    assertEquals(EXPECTED_REPORT_TAGS,
+    assertEquals(
+        EXPECTED_REPORT_TAGS,
         Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).counter().getId().getTags());
     assertEquals(10, Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).counter().count(), 0);
   }
@@ -78,7 +80,8 @@ public class CadenceClientStatsReporterTest {
   public void testTimerShouldCallMetricRegistryForMonitoredCounterCadenceAction() {
     callDefaultTimer();
 
-    assertEquals(EXPECTED_REPORT_TAGS,
+    assertEquals(
+        EXPECTED_REPORT_TAGS,
         Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).timer().getId().getTags());
     assertEquals(
         10, Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).timer().totalTime(TimeUnit.SECONDS), 0);
@@ -88,7 +91,8 @@ public class CadenceClientStatsReporterTest {
   public void testGaugeShouldCallMetricRegistryForMonitoredGaugeCadenceAction() {
     callDefaultGauge();
 
-    assertEquals(EXPECTED_REPORT_TAGS,
+    assertEquals(
+        EXPECTED_REPORT_TAGS,
         Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).gauge().getId().getTags());
     assertEquals(1.0, Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).gauge().value(), 0);
   }

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -959,7 +959,7 @@ public class WorkflowTest {
             "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
     Long timeout = new Long(200);
     CompletableFuture<WorkflowExecution> future =
-        workflowStub.startAsyncWithTimeout(timeout, taskList);
+        workflowStub.startAsyncWithTimeout(timeout, TimeUnit.MILLISECONDS, taskList);
     testUntypedAndStackTraceHelper(workflowStub, future.get());
   }
 

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -545,7 +545,7 @@ public class WorkflowTest {
   }
 
   @Test
-  public void testActivityRetryWithExiration() {
+  public void testActivityRetryWithExpiration() {
     startWorkerFor(TestActivityRetryWithExpiration.class);
     TestWorkflow1 workflowStub =
         workflowClient.newWorkflowStub(
@@ -989,6 +989,22 @@ public class WorkflowTest {
       future.get();
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof WorkflowExecutionAlreadyStartedError);
+    }
+  }
+
+  @Test
+  public void testUntypedAsyncStartAndGetResult() throws InterruptedException {
+    startWorkerFor(TestSyncWorkflowImpl.class);
+    WorkflowStub workflowStub =
+        workflowClient.newUntypedWorkflowStub(
+            "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
+    CompletableFuture<WorkflowExecution> startFuture = workflowStub.startAsync(taskList);
+    try {
+      startFuture.get();
+      CompletableFuture<String> resultFuture = workflowStub.getResultAsync(String.class);
+      assertEquals("activity10", resultFuture.get());
+    } catch (ExecutionException e) {
+      fail("unreachable");
     }
   }
 

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -954,26 +954,16 @@ public class WorkflowTest {
   @Test
   public void testUntypedAsyncStart() {
     startWorkerFor(TestSyncWorkflowImpl.class);
-    WorkflowStub startWorkflowStub =
+    WorkflowStub workflowStub =
         workflowClient.newUntypedWorkflowStub(
             "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
-    CompletableFuture<WorkflowExecution> future = startWorkflowStub.startAsync(taskList);
+    CompletableFuture<WorkflowExecution> future = workflowStub.startAsync(taskList);
 
     try {
       WorkflowExecution execution = future.get();
-      WorkflowStub workflowStub =
-          workflowClient.newUntypedWorkflowStub(execution, Optional.empty());
       String stackTrace = workflowStub.query(WorkflowClient.QUERY_TYPE_STACK_TRACE, String.class);
       assertTrue(stackTrace, stackTrace.contains("WorkflowTest$TestSyncWorkflowImpl.execute"));
       assertTrue(stackTrace, stackTrace.contains("activityWithDelay"));
-      // Test stub created from workflow execution.
-      workflowStub =
-          workflowClient.newUntypedWorkflowStub(execution, workflowStub.getWorkflowType());
-      stackTrace = workflowStub.query(WorkflowClient.QUERY_TYPE_STACK_TRACE, String.class);
-      assertTrue(stackTrace, stackTrace.contains("WorkflowTest$TestSyncWorkflowImpl.execute"));
-      assertTrue(stackTrace, stackTrace.contains("activityWithDelay"));
-      String result = workflowStub.getResult(String.class);
-      assertEquals("activity10", result);
     } catch (Exception e) {
       fail("unreachable");
     }


### PR DESCRIPTION
Currently start workflow doesn't support async handler. In some cases, customer may be super sensitive to latency and want start to be async. 
This PR add an API for async start in untype stub. 

Next step in separate PRs:
~~add startAsyncWithTimeout~~ (also done in this PR per request)
add async startAndGetResult