### PR TITLE
Change activity discovery logic

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
+++ b/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
@@ -92,19 +92,22 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
       }
       for (Method method : i.getRawType().getMethods()) {
         ActivityMethod annotation = method.getAnnotation(ActivityMethod.class);
-        String activityType;
-        if (annotation != null && !annotation.name().isEmpty()) {
-          activityType = annotation.name();
-        } else {
-          activityType = InternalUtils.getSimpleName(method);
-        }
-        if (activities.containsKey(activityType)) {
-          throw new IllegalStateException(
-              activityType + " activity type is already registered with the worker");
-        }
 
-        ActivityTaskExecutor implementation = newTaskExecutor.apply(method, activity);
-        activities.put(activityType, implementation);
+        if (annotation != null) {
+          String activityType;
+          if (!annotation.name().isEmpty()) {
+            activityType = annotation.name();
+          } else {
+            activityType = InternalUtils.getSimpleName(method);
+          }
+          if (activities.containsKey(activityType)) {
+            throw new IllegalStateException(
+                activityType + " activity type is already registered with the worker");
+          }
+
+          ActivityTaskExecutor implementation = newTaskExecutor.apply(method, activity);
+          activities.put(activityType, implementation);
+        }
       }
     }
   }


### PR DESCRIPTION
Update `addActivityImplementation` to only add methods as activities
which have the `ActivityMethod` annotation.

The current logic will register all interface-supplied methods as activities.
This becomes problematic when a Scala `trait` is extended multiple times
in the inheritance chain, and that `trait` supplies some methods to the class
(in my case, these would be logging utils).