### PR TITLE
Fix start async return

### DIFF
--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
@@ -148,5 +148,6 @@ public class MetricsType {
   public static final String WORKFLOW_ACTIVE_THREAD_COUNT =
       CADENCE_METRICS_PREFIX + "workflow_active_thread_count";
 
-  public static final String NON_DETERMINISTIC_ERROR = CADENCE_METRICS_PREFIX + "non-deterministic-error";
+  public static final String NON_DETERMINISTIC_ERROR =
+      CADENCE_METRICS_PREFIX + "non-deterministic-error";
 }

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
@@ -725,9 +725,10 @@ class DecisionsHelper {
   private DecisionStateMachine getDecision(DecisionId decisionId) {
     DecisionStateMachine result = decisions.get(decisionId);
     if (result == null) {
-      Scope metricsScope = options
-          .getMetricsScope()
-          .tagged(ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, task.getWorkflowType().getName()));
+      Scope metricsScope =
+          options
+              .getMetricsScope()
+              .tagged(ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, task.getWorkflowType().getName()));
       metricsScope.counter(MetricsType.NON_DETERMINISTIC_ERROR).inc(1);
       throw new NonDeterminisicWorkflowError(
           "Unknown " + decisionId + ". " + NON_DETERMINISTIC_MESSAGE);

--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -645,8 +645,8 @@ class ReplayDecider implements Decider {
           Duration decisionTaskRemainingTime = decisionTaskRemainingTime();
           if (decisionTaskRemainingTime.isNegative() || decisionTaskRemainingTime.isZero()) {
             throw new Error(
-                "Decision task timed out while querying history. If this happens consistently please consider " +
-                    "increase decision task timeout or reduce history size.");
+                "Decision task timed out while querying history. If this happens consistently please consider "
+                    + "increase decision task timeout or reduce history size.");
           }
 
           metricsScope.counter(MetricsType.WORKFLOW_GET_HISTORY_COUNTER).inc(1);

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
@@ -234,7 +234,7 @@ class WorkflowStubImpl implements WorkflowStub {
     CompletableFuture<WorkflowExecution> result =
         startAsyncWithOptions(
             timeout, unit, WorkflowOptions.merge(null, null, null, options.get()), args);
-    result.whenComplete(
+    return result.whenComplete(
         (input, exception) -> {
           if (input != null) {
             execution.set(
@@ -243,7 +243,6 @@ class WorkflowStubImpl implements WorkflowStub {
                     .setRunId(input.getRunId()));
           }
         });
-    return result;
   }
 
   private WorkflowExecution signalWithStartWithOptions(


### PR DESCRIPTION
Currently the start async may not call `whencomplete` and causing checkstart right after startFuture.get() can sometimes return "workflow not start" error. 
This PR fix it (and contains some auto formatting update)
Test covered by existing unit tests.