### PR TITLE
Fix get raw history

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
           - statsd
 
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:latestRelease-auto-setup
     logging:
       driver: none
     ports:

--- a/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
@@ -311,7 +311,19 @@ public class WorkflowExecutionUtils {
                         + ", unit="
                         + unit));
           }
-          History history = r.getHistory();
+          History history;
+          if (r.getRawHistory() != null) {
+            try {
+              history =
+                  InternalUtils.DeserializeFromBlobToHistoryEvents(
+                      r.getRawHistory(), request.getHistoryEventFilterType());
+            } catch (TException e) {
+              e.printStackTrace();
+              throw new RuntimeException("Unable to deserialize raw history");
+            }
+          } else {
+            history = r.getHistory();
+          }
           if (history == null || history.getEvents().size() == 0) {
             // Empty poll returned
             return getInstanceCloseEventAsync(

--- a/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/WorkflowExecutionUtils.java
@@ -311,19 +311,7 @@ public class WorkflowExecutionUtils {
                         + ", unit="
                         + unit));
           }
-          History history;
-          if (r.getRawHistory() != null) {
-            try {
-              history =
-                  InternalUtils.DeserializeFromBlobToHistoryEvents(
-                      r.getRawHistory(), request.getHistoryEventFilterType());
-            } catch (TException e) {
-              e.printStackTrace();
-              throw new RuntimeException("Unable to deserialize raw history");
-            }
-          } else {
-            history = r.getHistory();
-          }
+          History history = r.getHistory();
           if (history == null || history.getEvents().size() == 0) {
             // Empty poll returned
             return getInstanceCloseEventAsync(


### PR DESCRIPTION
Currently GetRawHistory is not working by going to endless loop in `getInstanceCloseEventAsync` then timeout.
This PR fix this issue.
Manually tests using existing tests.
(Because on server side raw history is disabled by default, testing this feature requires turning on this feature and set `useDockerService` to true in WorkflowTest
