### PR TITLE
Remove disable activity and workflow worker options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ license {
     header rootProject.file('license-header.txt')
     skipExistingHeaders true
     exclude 'com/uber/cadence/*.java' // generated code
+    excludes(["**/*.json"])
 }
 
 task initDlsSubmodule(type: Exec) {

--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
@@ -118,7 +118,11 @@ public class SyncWorkflowWorker
   @Override
   public void start() {
     workflowWorker.start();
-    laWorker.start();
+    // workflowWorker doesn't start if no types are registered with it. In that case we don't need
+    // to start LocalActivity Worker.
+    if (workflowWorker.isStarted()) {
+      laWorker.start();
+    }
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
@@ -97,47 +97,32 @@ public final class ActivityWorker implements SuspendableWorker {
 
   @Override
   public boolean isStarted() {
-    if (poller == null) {
-      return false;
-    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isTerminated();
   }
 
   @Override
   public void shutdown() {
-    if (poller == null) {
-      return;
-    }
     poller.shutdown();
   }
 
   @Override
   public void shutdownNow() {
-    if (poller == null) {
-      return;
-    }
     poller.shutdownNow();
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    if (poller == null || !poller.isStarted()) {
+    if (!poller.isStarted()) {
       return;
     }
     poller.awaitTermination(timeout, unit);
@@ -145,25 +130,16 @@ public final class ActivityWorker implements SuspendableWorker {
 
   @Override
   public void suspendPolling() {
-    if (poller == null) {
-      return;
-    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
-    if (poller == null) {
-      return;
-    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isSuspended();
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
@@ -97,46 +97,73 @@ public final class ActivityWorker implements SuspendableWorker {
 
   @Override
   public boolean isStarted() {
+    if (poller == null) {
+      return false;
+    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isTerminated();
   }
 
   @Override
   public void shutdown() {
+    if (poller == null) {
+      return;
+    }
     poller.shutdown();
   }
 
   @Override
   public void shutdownNow() {
+    if (poller == null) {
+      return;
+    }
     poller.shutdownNow();
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
+    if (poller == null || !poller.isStarted()) {
+      return;
+    }
     poller.awaitTermination(timeout, unit);
   }
 
   @Override
   public void suspendPolling() {
+    if (poller == null) {
+      return;
+    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
+    if (poller == null) {
+      return;
+    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isSuspended();
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
@@ -85,47 +85,32 @@ public final class LocalActivityWorker implements SuspendableWorker {
 
   @Override
   public boolean isStarted() {
-    if (poller == null) {
-      return false;
-    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isTerminated();
   }
 
   @Override
   public void shutdown() {
-    if (poller == null) {
-      return;
-    }
     poller.shutdown();
   }
 
   @Override
   public void shutdownNow() {
-    if (poller == null) {
-      return;
-    }
     poller.shutdownNow();
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    if (poller == null || !poller.isStarted()) {
+    if (!poller.isStarted()) {
       return;
     }
     poller.awaitTermination(timeout, unit);
@@ -133,25 +118,16 @@ public final class LocalActivityWorker implements SuspendableWorker {
 
   @Override
   public void suspendPolling() {
-    if (poller == null) {
-      return;
-    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
-    if (poller == null) {
-      return;
-    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isSuspended();
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
@@ -85,46 +85,73 @@ public final class LocalActivityWorker implements SuspendableWorker {
 
   @Override
   public boolean isStarted() {
+    if (poller == null) {
+      return false;
+    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isTerminated();
   }
 
   @Override
   public void shutdown() {
+    if (poller == null) {
+      return;
+    }
     poller.shutdown();
   }
 
   @Override
   public void shutdownNow() {
+    if (poller == null) {
+      return;
+    }
     poller.shutdownNow();
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
+    if (poller == null || !poller.isStarted()) {
+      return;
+    }
     poller.awaitTermination(timeout, unit);
   }
 
   @Override
   public void suspendPolling() {
+    if (poller == null) {
+      return;
+    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
+    if (poller == null) {
+      return;
+    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isSuspended();
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/NoopSuspendableWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/NoopSuspendableWorker.java
@@ -52,9 +52,7 @@ class NoopSuspendableWorker implements SuspendableWorker {
   public void awaitTermination(long timeout, TimeUnit unit) {}
 
   @Override
-  public void start() {
-    throw new IllegalStateException("Non startable");
-  }
+  public void start() {}
 
   @Override
   public boolean isStarted() {
@@ -62,17 +60,13 @@ class NoopSuspendableWorker implements SuspendableWorker {
   }
 
   @Override
-  public void suspendPolling() {
-    throw new IllegalStateException("Non suspendable");
-  }
+  public void suspendPolling() {}
 
   @Override
-  public void resumePolling() {
-    throw new IllegalStateException("Non resumable");
-  }
+  public void resumePolling() {}
 
   @Override
   public boolean isSuspended() {
-    return false;
+    return true;
   }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/SuspendableWorkerBase.java
+++ b/src/main/java/com/uber/cadence/internal/worker/SuspendableWorkerBase.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class SuspendableWorkerBase implements SuspendableWorker {
+  private SuspendableWorker poller = new NoopSuspendableWorker();
+
+  final void setPoller(SuspendableWorker poller) {
+    this.poller = poller;
+  }
+
+  @Override
+  public boolean isStarted() {
+    return poller.isStarted();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return poller.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return poller.isTerminated();
+  }
+
+  @Override
+  public void shutdown() {
+    poller.shutdown();
+  }
+
+  @Override
+  public void shutdownNow() {
+    poller.shutdownNow();
+  }
+
+  @Override
+  public void awaitTermination(long timeout, TimeUnit unit) {
+    if (!poller.isStarted()) {
+      return;
+    }
+    poller.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public void suspendPolling() {
+    poller.suspendPolling();
+  }
+
+  @Override
+  public void resumePolling() {
+    poller.resumePolling();
+  }
+
+  @Override
+  public boolean isSuspended() {
+    return poller.isSuspended();
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
@@ -111,25 +111,16 @@ public final class WorkflowWorker
 
   @Override
   public boolean isStarted() {
-    if (poller == null) {
-      return false;
-    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isTerminated();
   }
 
@@ -198,23 +189,17 @@ public final class WorkflowWorker
 
   @Override
   public void shutdown() {
-    if (poller == null) {
-      return;
-    }
     poller.shutdown();
   }
 
   @Override
   public void shutdownNow() {
-    if (poller == null) {
-      return;
-    }
     poller.shutdownNow();
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    if (poller == null || !poller.isStarted()) {
+    if (!poller.isStarted()) {
       return;
     }
 
@@ -223,25 +208,16 @@ public final class WorkflowWorker
 
   @Override
   public void suspendPolling() {
-    if (poller == null) {
-      return;
-    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
-    if (poller == null) {
-      return;
-    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isSuspended();
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
@@ -111,16 +111,25 @@ public final class WorkflowWorker
 
   @Override
   public boolean isStarted() {
+    if (poller == null) {
+      return false;
+    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isTerminated();
   }
 
@@ -189,17 +198,23 @@ public final class WorkflowWorker
 
   @Override
   public void shutdown() {
+    if (poller == null) {
+      return;
+    }
     poller.shutdown();
   }
 
   @Override
   public void shutdownNow() {
+    if (poller == null) {
+      return;
+    }
     poller.shutdownNow();
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    if (!poller.isStarted()) {
+    if (poller == null || !poller.isStarted()) {
       return;
     }
 
@@ -208,16 +223,25 @@ public final class WorkflowWorker
 
   @Override
   public void suspendPolling() {
+    if (poller == null) {
+      return;
+    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
+    if (poller == null) {
+      return;
+    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
+    if (poller == null) {
+      return true;
+    }
     return poller.isSuspended();
   }
 

--- a/src/main/java/com/uber/cadence/worker/WorkerOptions.java
+++ b/src/main/java/com/uber/cadence/worker/WorkerOptions.java
@@ -32,8 +32,6 @@ public final class WorkerOptions {
 
   public static final class Builder {
 
-    private boolean disableWorkflowWorker;
-    private boolean disableActivityWorker;
     private double workerActivitiesPerSecond;
     private String identity;
     private DataConverter dataConverter = JsonDataConverter.getInstance();
@@ -50,28 +48,6 @@ public final class WorkerOptions {
     private Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory = (n) -> n;
     private Scope metricsScope;
     private boolean enableLoggingInReplay;
-
-    /**
-     * When set to true doesn't poll on workflow task list even if there are registered workflows
-     * with a worker. For clarity prefer not registing workflow types with a {@link Worker} to
-     * setting this option. But it can be useful for disabling polling through configuration without
-     * a code change.
-     */
-    public Builder setDisableWorkflowWorker(boolean disableWorkflowWorker) {
-      this.disableWorkflowWorker = disableWorkflowWorker;
-      return this;
-    }
-
-    /**
-     * When set to true doesn't poll on activity task list even if there are registered activities
-     * with a worker. For clarity prefer not registing activity implementations with a {@link
-     * Worker} to setting this option. But it can be useful for disabling polling through
-     * configuration without a code change.
-     */
-    public Builder setDisableActivityWorker(boolean disableActivityWorker) {
-      this.disableActivityWorker = disableActivityWorker;
-      return this;
-    }
 
     /**
      * Override human readable identity of the worker. Identity is used to identify a worker and is
@@ -210,8 +186,6 @@ public final class WorkerOptions {
       }
 
       return new WorkerOptions(
-          disableWorkflowWorker,
-          disableActivityWorker,
           workerActivitiesPerSecond,
           identity,
           dataConverter,
@@ -231,8 +205,6 @@ public final class WorkerOptions {
     }
   }
 
-  private final boolean disableWorkflowWorker;
-  private final boolean disableActivityWorker;
   private final double workerActivitiesPerSecond;
   private final String identity;
   private final DataConverter dataConverter;
@@ -251,8 +223,6 @@ public final class WorkerOptions {
   private final boolean enableLoggingInReplay;
 
   private WorkerOptions(
-      boolean disableWorkflowWorker,
-      boolean disableActivityWorker,
       double workerActivitiesPerSecond,
       String identity,
       DataConverter dataConverter,
@@ -269,8 +239,6 @@ public final class WorkerOptions {
       Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory,
       Scope metricsScope,
       boolean enableLoggingInReplay) {
-    this.disableWorkflowWorker = disableWorkflowWorker;
-    this.disableActivityWorker = disableActivityWorker;
     this.workerActivitiesPerSecond = workerActivitiesPerSecond;
     this.identity = identity;
     this.dataConverter = dataConverter;
@@ -287,14 +255,6 @@ public final class WorkerOptions {
     this.interceptorFactory = interceptorFactory;
     this.metricsScope = metricsScope;
     this.enableLoggingInReplay = enableLoggingInReplay;
-  }
-
-  public boolean isDisableWorkflowWorker() {
-    return disableWorkflowWorker;
-  }
-
-  public boolean isDisableActivityWorker() {
-    return disableActivityWorker;
   }
 
   public double getWorkerActivitiesPerSecond() {
@@ -360,11 +320,7 @@ public final class WorkerOptions {
   @Override
   public String toString() {
     return "WorkerOptions{"
-        + "disableWorkflowWorker="
-        + disableWorkflowWorker
-        + ", disableActivityWorker="
-        + disableActivityWorker
-        + ", workerActivitiesPerSecond="
+        + "workerActivitiesPerSecond="
         + workerActivitiesPerSecond
         + ", identity='"
         + identity

--- a/src/test/java/com/uber/cadence/worker/WorkerStressTests.java
+++ b/src/test/java/com/uber/cadence/worker/WorkerStressTests.java
@@ -191,9 +191,12 @@ public class WorkerStressTests {
     }
 
     private void close() {
-      factory.shutdown();
-      factory.awaitTermination(10, TimeUnit.SECONDS);
-      testEnv.close();
+      if (factory != null) {
+        factory.shutdown();
+        factory.awaitTermination(10, TimeUnit.SECONDS);
+      } else {
+        testEnv.close();
+      }
     }
   }
 


### PR DESCRIPTION
- Workers will always start, and poller will start only if types are registered.
- Simplified worker start and shutdown logic
- Fixed a bug in worker.isSuspended()

Ref: https://github.com/temporalio/sdk-java/pull/33/commits/4c1d9b02f6e73eb44d22a2e17b226611663e3373