### PR TITLE
Refactor options and worker dependencies

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowClient.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClient.java
@@ -108,76 +108,28 @@ public interface WorkflowClient {
   String QUERY_TYPE_REPLAY_ONLY = "__replay_only";
 
   /**
-   * Creates worker that connects to the local instance of the Cadence Service that listens on a
-   * default port (7933).
-   *
-   * @param domain domain that worker uses to poll.
-   */
-  static WorkflowClient newInstance(String domain) {
-    return WorkflowClientInternal.newInstance(domain);
-  }
-
-  /**
-   * Creates worker that connects to the local instance of the Cadence Service that listens on a
-   * default port (7933).
-   *
-   * @param domain domain that worker uses to poll.
-   * @param options Options (like {@link com.uber.cadence.converter.DataConverter}er override) for
-   *     configuring client.
-   */
-  static WorkflowClient newInstance(String domain, WorkflowClientOptions options) {
-    return WorkflowClientInternal.newInstance(domain, options);
-  }
-
-  /**
    * Creates client that connects to an instance of the Cadence Service.
    *
-   * @param host of the Cadence Service endpoint
-   * @param port of the Cadence Service endpoint
-   * @param domain domain that worker uses to poll.
+   * @param service client to the Cadence Service endpoint.
    */
-  static WorkflowClient newInstance(String host, int port, String domain) {
-    return WorkflowClientInternal.newInstance(host, port, domain);
-  }
-
-  /**
-   * Creates client that connects to an instance of the Cadence Service.
-   *
-   * @param host of the Cadence Service endpoint
-   * @param port of the Cadence Service endpoint
-   * @param domain domain that worker uses to poll.
-   * @param options Options (like {@link com.uber.cadence.converter.DataConverter}er override) for
-   *     configuring client.
-   */
-  static WorkflowClient newInstance(
-      String host, int port, String domain, WorkflowClientOptions options) {
-    return WorkflowClientInternal.newInstance(host, port, domain, options);
+  static WorkflowClient newInstance(IWorkflowService service) {
+    return WorkflowClientInternal.newInstance(service, WorkflowClientOptions.defaultInstance());
   }
 
   /**
    * Creates client that connects to an instance of the Cadence Service.
    *
    * @param service client to the Cadence Service endpoint.
-   * @param domain domain that worker uses to poll.
-   */
-  static WorkflowClient newInstance(IWorkflowService service, String domain) {
-    return WorkflowClientInternal.newInstance(service, domain);
-  }
-
-  /**
-   * Creates client that connects to an instance of the Cadence Service.
-   *
-   * @param service client to the Cadence Service endpoint.
-   * @param domain domain that worker uses to poll.
    * @param options Options (like {@link com.uber.cadence.converter.DataConverter}er override) for
    *     configuring client.
    */
-  static WorkflowClient newInstance(
-      IWorkflowService service, String domain, WorkflowClientOptions options) {
-    return WorkflowClientInternal.newInstance(service, domain, options);
+  static WorkflowClient newInstance(IWorkflowService service, WorkflowClientOptions options) {
+    return WorkflowClientInternal.newInstance(service, options);
   }
 
-  String getDomain();
+  WorkflowClientOptions getOptions();
+
+  IWorkflowService getService();
 
   /**
    * Creates workflow client stub that can be used to start a single workflow execution. The first
@@ -728,7 +680,4 @@ public interface WorkflowClient {
       A6 arg6) {
     return WorkflowClientInternal.execute(workflow, arg1, arg2, arg3, arg4, arg5, arg6);
   }
-
-  /** Closes the workflow client and the underlying IWorkflowService when this method is called. */
-  void close();
 }

--- a/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
@@ -26,8 +26,9 @@ import java.util.Objects;
 /** Options for WorkflowClient configuration. */
 public final class WorkflowClientOptions {
   private static final String DEFAULT_DOMAIN = "default";
-
   private static final WorkflowClientOptions DEFAULT_INSTANCE;
+  private static final WorkflowClientInterceptor[] EMPTY_INTERCEPTOR_ARRAY =
+      new WorkflowClientInterceptor[0];
 
   static {
     DEFAULT_INSTANCE = new Builder().build();
@@ -41,15 +42,19 @@ public final class WorkflowClientOptions {
     return new Builder();
   }
 
+  public static Builder newBuilder(WorkflowClientOptions options) {
+    return new Builder(options);
+  }
+
   public static final class Builder {
     private String domain = DEFAULT_DOMAIN;
     private DataConverter dataConverter = JsonDataConverter.getInstance();
     private WorkflowClientInterceptor[] interceptors = EMPTY_INTERCEPTOR_ARRAY;
-    private Scope metricsScope;
+    private Scope metricsScope = NoopScope.getInstance();
 
-    public Builder() {}
+    private Builder() {}
 
-    public Builder(WorkflowClientOptions options) {
+    private Builder(WorkflowClientOptions options) {
       domain = options.getDomain();
       dataConverter = options.getDataConverter();
       interceptors = options.getInterceptors();
@@ -93,15 +98,9 @@ public final class WorkflowClientOptions {
     }
 
     public WorkflowClientOptions build() {
-      if (metricsScope == null) {
-        metricsScope = NoopScope.getInstance();
-      }
       return new WorkflowClientOptions(domain, dataConverter, interceptors, metricsScope);
     }
   }
-
-  private static final WorkflowClientInterceptor[] EMPTY_INTERCEPTOR_ARRAY =
-      new WorkflowClientInterceptor[0];
 
   private final String domain;
   private final DataConverter dataConverter;

--- a/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
@@ -25,9 +25,24 @@ import java.util.Objects;
 
 /** Options for WorkflowClient configuration. */
 public final class WorkflowClientOptions {
+  private static final String DEFAULT_DOMAIN = "default";
+
+  private static final WorkflowClientOptions DEFAULT_INSTANCE;
+
+  static {
+    DEFAULT_INSTANCE = new Builder().build();
+  }
+
+  public static WorkflowClientOptions defaultInstance() {
+    return DEFAULT_INSTANCE;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
 
   public static final class Builder {
-
+    private String domain = DEFAULT_DOMAIN;
     private DataConverter dataConverter = JsonDataConverter.getInstance();
     private WorkflowClientInterceptor[] interceptors = EMPTY_INTERCEPTOR_ARRAY;
     private Scope metricsScope;
@@ -35,9 +50,15 @@ public final class WorkflowClientOptions {
     public Builder() {}
 
     public Builder(WorkflowClientOptions options) {
+      domain = options.getDomain();
       dataConverter = options.getDataConverter();
       interceptors = options.getInterceptors();
       metricsScope = options.getMetricsScope();
+    }
+
+    public Builder setDomain(String domain) {
+      this.domain = domain;
+      return this;
     }
 
     /**
@@ -75,23 +96,31 @@ public final class WorkflowClientOptions {
       if (metricsScope == null) {
         metricsScope = NoopScope.getInstance();
       }
-      return new WorkflowClientOptions(dataConverter, interceptors, metricsScope);
+      return new WorkflowClientOptions(domain, dataConverter, interceptors, metricsScope);
     }
   }
 
   private static final WorkflowClientInterceptor[] EMPTY_INTERCEPTOR_ARRAY =
       new WorkflowClientInterceptor[0];
+
+  private final String domain;
   private final DataConverter dataConverter;
-
   private final WorkflowClientInterceptor[] interceptors;
-
   private final Scope metricsScope;
 
   private WorkflowClientOptions(
-      DataConverter dataConverter, WorkflowClientInterceptor[] interceptors, Scope metricsScope) {
+      String domain,
+      DataConverter dataConverter,
+      WorkflowClientInterceptor[] interceptors,
+      Scope metricsScope) {
+    this.domain = domain;
     this.dataConverter = dataConverter;
     this.interceptors = interceptors;
     this.metricsScope = metricsScope;
+  }
+
+  public String getDomain() {
+    return domain;
   }
 
   public DataConverter getDataConverter() {

--- a/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientFactoryImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientFactoryImpl.java
@@ -24,6 +24,7 @@ import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class ManualActivityCompletionClientFactoryImpl
     extends ManualActivityCompletionClientFactory {
@@ -35,9 +36,9 @@ public class ManualActivityCompletionClientFactoryImpl
 
   public ManualActivityCompletionClientFactoryImpl(
       IWorkflowService service, String domain, DataConverter dataConverter, Scope metricsScope) {
-    this.service = service;
-    this.domain = domain;
-    this.dataConverter = dataConverter;
+    this.service = Objects.requireNonNull(service);
+    this.domain = Objects.requireNonNull(domain);
+    this.dataConverter = Objects.requireNonNull(dataConverter);
 
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(1).put(MetricsTag.DOMAIN, domain).build();
@@ -54,16 +55,11 @@ public class ManualActivityCompletionClientFactoryImpl
 
   @Override
   public ManualActivityCompletionClient getClient(byte[] taskToken) {
-    if (service == null) {
-      throw new IllegalStateException("required property service is null");
-    }
-    if (dataConverter == null) {
-      throw new IllegalStateException("required property dataConverter is null");
-    }
     if (taskToken == null || taskToken.length == 0) {
       throw new IllegalArgumentException("null or empty task token");
     }
-    return new ManualActivityCompletionClientImpl(service, taskToken, dataConverter, metricsScope);
+    return new ManualActivityCompletionClientImpl(
+        service, domain, taskToken, dataConverter, metricsScope);
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/ManualActivityCompletionClientImpl.java
@@ -57,11 +57,15 @@ class ManualActivityCompletionClientImpl extends ManualActivityCompletionClient 
   private final Scope metricsScope;
 
   ManualActivityCompletionClientImpl(
-      IWorkflowService service, byte[] taskToken, DataConverter dataConverter, Scope metricsScope) {
+      IWorkflowService service,
+      String domain,
+      byte[] taskToken,
+      DataConverter dataConverter,
+      Scope metricsScope) {
     this.service = service;
     this.taskToken = taskToken;
     this.dataConverter = dataConverter;
-    this.domain = null;
+    this.domain = domain;
     this.execution = null;
     this.activityId = null;
     this.metricsScope = metricsScope;

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -273,6 +273,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
       if (nextWakeUpTime < currentTimeMillis() || nextWakeUpTime == Long.MAX_VALUE) {
         nextWakeUpTime = 0;
       }
+
     } finally {
       inRunUntilAllBlocked = false;
       // Close was requested while running

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -74,7 +74,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     activityTaskHandler =
         new POJOActivityTaskHandler(
             new WorkflowServiceWrapper(workflowService),
-            testEnvironmentOptions.getDomain(),
+            testEnvironmentOptions.getWorkflowClientOptions().getDomain(),
             testEnvironmentOptions.getDataConverter(),
             heartbeatExecutor);
   }

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -142,23 +142,22 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     WorkerOptions.Builder builder =
         new WorkerOptions.Builder()
             .setInterceptorFactory(testEnvironmentOptions.getInterceptorFactory())
-            .setMetricsScope(testEnvironmentOptions.getMetricsScope())
+            .setMetricsScope(testEnvironmentOptions.getWorkflowClientOptions().getMetricsScope())
             .setEnableLoggingInReplay(testEnvironmentOptions.isLoggingEnabledInReplay());
     if (testEnvironmentOptions.getDataConverter() != null) {
       builder.setDataConverter(testEnvironmentOptions.getDataConverter());
     }
     builder = overrideOptions.apply(builder);
-    Worker result = workerFactory.newWorker(taskList, builder.build());
-    return result;
+    return workerFactory.newWorker(taskList, builder.build());
   }
 
   @Override
   public WorkflowClient newWorkflowClient() {
     WorkflowClientOptions options =
-        new WorkflowClientOptions.Builder()
+        WorkflowClientOptions.newBuilder()
             .setDataConverter(testEnvironmentOptions.getDataConverter())
             .setInterceptors(new TimeLockingInterceptor(service))
-            .setMetricsScope(testEnvironmentOptions.getMetricsScope())
+            .setMetricsScope(testEnvironmentOptions.getWorkflowClientOptions().getMetricsScope())
             .setDomain(testEnvironmentOptions.getWorkflowClientOptions().getDomain())
             .build();
     return WorkflowClientInternal.newInstance(service, options);
@@ -172,7 +171,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     System.arraycopy(existingInterceptors, 0, interceptors, 0, existingInterceptors.length);
     interceptors[interceptors.length - 1] = new TimeLockingInterceptor(service);
     WorkflowClientOptions newOptions =
-        new WorkflowClientOptions.Builder(options).setInterceptors(interceptors).build();
+        WorkflowClientOptions.newBuilder(options).setInterceptors(interceptors).build();
     return WorkflowClientInternal.newInstance(service, newOptions);
   }
 

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -17,7 +17,76 @@
 
 package com.uber.cadence.internal.sync;
 
-import com.uber.cadence.*;
+import com.uber.cadence.BadRequestError;
+import com.uber.cadence.CancellationAlreadyRequestedError;
+import com.uber.cadence.ClientVersionNotSupportedError;
+import com.uber.cadence.ClusterInfo;
+import com.uber.cadence.CountWorkflowExecutionsRequest;
+import com.uber.cadence.CountWorkflowExecutionsResponse;
+import com.uber.cadence.DeprecateDomainRequest;
+import com.uber.cadence.DescribeDomainRequest;
+import com.uber.cadence.DescribeDomainResponse;
+import com.uber.cadence.DescribeTaskListRequest;
+import com.uber.cadence.DescribeTaskListResponse;
+import com.uber.cadence.DescribeWorkflowExecutionRequest;
+import com.uber.cadence.DescribeWorkflowExecutionResponse;
+import com.uber.cadence.DomainAlreadyExistsError;
+import com.uber.cadence.DomainNotActiveError;
+import com.uber.cadence.EntityNotExistsError;
+import com.uber.cadence.GetSearchAttributesResponse;
+import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
+import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
+import com.uber.cadence.InternalServiceError;
+import com.uber.cadence.LimitExceededError;
+import com.uber.cadence.ListArchivedWorkflowExecutionsRequest;
+import com.uber.cadence.ListArchivedWorkflowExecutionsResponse;
+import com.uber.cadence.ListClosedWorkflowExecutionsRequest;
+import com.uber.cadence.ListClosedWorkflowExecutionsResponse;
+import com.uber.cadence.ListDomainsRequest;
+import com.uber.cadence.ListDomainsResponse;
+import com.uber.cadence.ListOpenWorkflowExecutionsRequest;
+import com.uber.cadence.ListOpenWorkflowExecutionsResponse;
+import com.uber.cadence.ListTaskListPartitionsRequest;
+import com.uber.cadence.ListTaskListPartitionsResponse;
+import com.uber.cadence.ListWorkflowExecutionsRequest;
+import com.uber.cadence.ListWorkflowExecutionsResponse;
+import com.uber.cadence.PollForActivityTaskRequest;
+import com.uber.cadence.PollForActivityTaskResponse;
+import com.uber.cadence.PollForDecisionTaskRequest;
+import com.uber.cadence.PollForDecisionTaskResponse;
+import com.uber.cadence.QueryFailedError;
+import com.uber.cadence.QueryRejectCondition;
+import com.uber.cadence.QueryWorkflowRequest;
+import com.uber.cadence.QueryWorkflowResponse;
+import com.uber.cadence.RecordActivityTaskHeartbeatByIDRequest;
+import com.uber.cadence.RecordActivityTaskHeartbeatRequest;
+import com.uber.cadence.RecordActivityTaskHeartbeatResponse;
+import com.uber.cadence.RegisterDomainRequest;
+import com.uber.cadence.RequestCancelWorkflowExecutionRequest;
+import com.uber.cadence.ResetStickyTaskListRequest;
+import com.uber.cadence.ResetStickyTaskListResponse;
+import com.uber.cadence.ResetWorkflowExecutionRequest;
+import com.uber.cadence.ResetWorkflowExecutionResponse;
+import com.uber.cadence.RespondActivityTaskCanceledByIDRequest;
+import com.uber.cadence.RespondActivityTaskCanceledRequest;
+import com.uber.cadence.RespondActivityTaskCompletedByIDRequest;
+import com.uber.cadence.RespondActivityTaskCompletedRequest;
+import com.uber.cadence.RespondActivityTaskFailedByIDRequest;
+import com.uber.cadence.RespondActivityTaskFailedRequest;
+import com.uber.cadence.RespondDecisionTaskCompletedRequest;
+import com.uber.cadence.RespondDecisionTaskCompletedResponse;
+import com.uber.cadence.RespondDecisionTaskFailedRequest;
+import com.uber.cadence.RespondQueryTaskCompletedRequest;
+import com.uber.cadence.ServiceBusyError;
+import com.uber.cadence.SignalWithStartWorkflowExecutionRequest;
+import com.uber.cadence.SignalWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionResponse;
+import com.uber.cadence.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.UpdateDomainRequest;
+import com.uber.cadence.UpdateDomainResponse;
+import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
 import com.uber.cadence.client.ActivityCompletionClient;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientInterceptor;
@@ -56,8 +125,10 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     }
     service = new WorkflowServiceWrapper();
     service.lockTimeSkipping("TestWorkflowEnvironmentInternal constructor");
+    WorkflowClient client =
+        WorkflowClient.newInstance(service, testEnvironmentOptions.getWorkflowClientOptions());
     workerFactory =
-        new Worker.Factory(service, options.getDomain(), options.getWorkerFactoryOptions());
+        Worker.Factory.newInstance(client, testEnvironmentOptions.getWorkerFactoryOptions());
   }
 
   @Override
@@ -88,8 +159,9 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
             .setDataConverter(testEnvironmentOptions.getDataConverter())
             .setInterceptors(new TimeLockingInterceptor(service))
             .setMetricsScope(testEnvironmentOptions.getMetricsScope())
+            .setDomain(testEnvironmentOptions.getWorkflowClientOptions().getDomain())
             .build();
-    return WorkflowClientInternal.newInstance(service, testEnvironmentOptions.getDomain(), options);
+    return WorkflowClientInternal.newInstance(service, options);
   }
 
   @Override
@@ -101,8 +173,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     interceptors[interceptors.length - 1] = new TimeLockingInterceptor(service);
     WorkflowClientOptions newOptions =
         new WorkflowClientOptions.Builder(options).setInterceptors(interceptors).build();
-    return WorkflowClientInternal.newInstance(
-        service, testEnvironmentOptions.getDomain(), newOptions);
+    return WorkflowClientInternal.newInstance(service, newOptions);
   }
 
   @Override
@@ -127,7 +198,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
 
   @Override
   public String getDomain() {
-    return testEnvironmentOptions.getDomain();
+    return testEnvironmentOptions.getWorkflowClientOptions().getDomain();
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -33,7 +33,6 @@ import com.uber.cadence.internal.external.ManualActivityCompletionClientFactory;
 import com.uber.cadence.internal.external.ManualActivityCompletionClientFactoryImpl;
 import com.uber.cadence.internal.sync.WorkflowInvocationHandler.InvocationType;
 import com.uber.cadence.serviceclient.IWorkflowService;
-import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.QueryMethod;
 import com.uber.cadence.workflow.WorkflowMethod;
@@ -51,104 +50,49 @@ public final class WorkflowClientInternal implements WorkflowClient {
   private final DataConverter dataConverter;
   private final WorkflowClientInterceptor[] interceptors;
   private final IWorkflowService workflowService;
-
-  /**
-   * Creates worker that connects to the local instance of the Cadence Service that listens on a
-   * default port (7933).
-   *
-   * @param domain domain that worker uses to poll.
-   */
-  public static WorkflowClient newInstance(String domain) {
-    return new WorkflowClientInternal(
-        new WorkflowServiceTChannel(), domain, new WorkflowClientOptions.Builder().build());
-  }
-
-  /**
-   * Creates worker that connects to the local instance of the Cadence Service that listens on a
-   * default port (7933).
-   *
-   * @param domain domain that worker uses to poll.
-   * @param options Options (like {@link com.uber.cadence.converter.DataConverter} override) for
-   *     configuring client.
-   */
-  public static WorkflowClient newInstance(String domain, WorkflowClientOptions options) {
-    return new WorkflowClientInternal(new WorkflowServiceTChannel(), domain, options);
-  }
-
-  /**
-   * Creates client that connects to an instance of the Cadence Service.
-   *
-   * @param host of the Cadence Service endpoint
-   * @param port of the Cadence Service endpoint
-   * @param domain domain that worker uses to poll.
-   */
-  public static WorkflowClient newInstance(String host, int port, String domain) {
-    return new WorkflowClientInternal(
-        new WorkflowServiceTChannel(host, port),
-        domain,
-        new WorkflowClientOptions.Builder().build());
-  }
-
-  /**
-   * Creates client that connects to an instance of the Cadence Service.
-   *
-   * @param host of the Cadence Service endpoint
-   * @param port of the Cadence Service endpoint
-   * @param domain domain that worker uses to poll.
-   * @param options Options (like {@link com.uber.cadence.converter.DataConverter} override) for
-   *     configuring client.
-   */
-  public static WorkflowClient newInstance(
-      String host, int port, String domain, WorkflowClientOptions options) {
-    return new WorkflowClientInternal(new WorkflowServiceTChannel(host, port), domain, options);
-  }
+  private final WorkflowClientOptions options;
 
   /**
    * Creates client that connects to an instance of the Cadence Service.
    *
    * @param service client to the Cadence Service endpoint.
-   * @param domain domain that worker uses to poll.
-   */
-  public static WorkflowClient newInstance(IWorkflowService service, String domain) {
-    return new WorkflowClientInternal(service, domain, null);
-  }
-
-  /**
-   * Creates client that connects to an instance of the Cadence Service.
-   *
-   * @param service client to the Cadence Service endpoint.
-   * @param domain domain that worker uses to poll.
    * @param options Options (like {@link com.uber.cadence.converter.DataConverter} override) for
    *     configuring client.
    */
   public static WorkflowClient newInstance(
-      IWorkflowService service, String domain, WorkflowClientOptions options) {
-    return new WorkflowClientInternal(service, domain, options);
+      IWorkflowService service, WorkflowClientOptions options) {
+    return new WorkflowClientInternal(service, options);
   }
 
-  private WorkflowClientInternal(
-      IWorkflowService service, String domain, WorkflowClientOptions options) {
+  private WorkflowClientInternal(IWorkflowService service, WorkflowClientOptions options) {
     if (options == null) {
       options = new WorkflowClientOptions.Builder().build();
     }
+    this.options = options;
     this.workflowService = service;
     this.genericClient =
-        new GenericWorkflowClientExternalImpl(service, domain, options.getMetricsScope());
+        new GenericWorkflowClientExternalImpl(
+            service, options.getDomain(), options.getMetricsScope());
     this.dataConverter = options.getDataConverter();
     this.interceptors = options.getInterceptors();
     this.manualActivityCompletionClientFactory =
         new ManualActivityCompletionClientFactoryImpl(
-            service, domain, dataConverter, options.getMetricsScope());
+            service, options.getDomain(), dataConverter, options.getMetricsScope());
+  }
+
+  @Override
+  public WorkflowClientOptions getOptions() {
+    return options;
+  }
+
+  @Override
+  public IWorkflowService getService() {
+    return workflowService;
   }
 
   @Override
   public <T> T newWorkflowStub(Class<T> workflowInterface) {
     return newWorkflowStub(workflowInterface, (WorkflowOptions) null);
-  }
-
-  @Override
-  public String getDomain() {
-    return genericClient.getDomain();
   }
 
   @Override
@@ -450,10 +394,5 @@ public final class WorkflowClientInternal implements WorkflowClient {
       A5 arg5,
       A6 arg6) {
     return execute(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
-  }
-
-  @Override
-  public void close() {
-    this.workflowService.close();
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -40,6 +40,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -61,13 +62,12 @@ public final class WorkflowClientInternal implements WorkflowClient {
    */
   public static WorkflowClient newInstance(
       IWorkflowService service, WorkflowClientOptions options) {
+    Objects.requireNonNull(service);
+    Objects.requireNonNull(options);
     return new WorkflowClientInternal(service, options);
   }
 
   private WorkflowClientInternal(IWorkflowService service, WorkflowClientOptions options) {
-    if (options == null) {
-      options = new WorkflowClientOptions.Builder().build();
-    }
     this.options = options;
     this.workflowService = service;
     this.genericClient =

--- a/src/main/java/com/uber/cadence/internal/worker/PollDecisionTaskDispatcher.java
+++ b/src/main/java/com/uber/cadence/internal/worker/PollDecisionTaskDispatcher.java
@@ -76,7 +76,6 @@ public final class PollDecisionTaskDispatcher
 
       try {
         service.RespondDecisionTaskFailed(request);
-
       } catch (Exception e) {
         uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), e);
       }

--- a/src/main/java/com/uber/cadence/internal/worker/Poller.java
+++ b/src/main/java/com/uber/cadence/internal/worker/Poller.java
@@ -90,8 +90,8 @@ public final class Poller<T> implements SuspendableWorker {
 
   @Override
   public void start() {
-    if (log.isInfoEnabled()) {
-      log.info("start(): " + toString());
+    if (log.isDebugEnabled()) {
+      log.debug("start(): " + toString());
     }
     if (pollerOptions.getMaximumPollRatePerSecond() > 0.0) {
       pollRateThrottler =
@@ -143,7 +143,7 @@ public final class Poller<T> implements SuspendableWorker {
 
   @Override
   public void shutdown() {
-    log.info("shutdown");
+    log.debug("shutdown");
     if (!isStarted()) {
       return;
     }
@@ -159,8 +159,8 @@ public final class Poller<T> implements SuspendableWorker {
 
   @Override
   public void shutdownNow() {
-    if (log.isInfoEnabled()) {
-      log.info("shutdownNow poller=" + this.pollerOptions.getPollThreadNamePrefix());
+    if (log.isDebugEnabled()) {
+      log.debug("shutdownNow poller=" + this.pollerOptions.getPollThreadNamePrefix());
     }
     if (!isStarted()) {
       return;

--- a/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
+++ b/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
@@ -1,0 +1,314 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017-2020 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.serviceclient;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.uber.cadence.internal.metrics.NoopScope;
+import com.uber.m3.tally.Scope;
+import java.util.Map;
+
+public class ClientOptions {
+  private static final int DEFAULT_LOCAL_CADENCE_SERVER_PORT = 7933;
+
+  private static final String LOCALHOST = "127.0.0.1";
+
+  /** Default RPC timeout used for all non long poll calls. */
+  private static final long DEFAULT_RPC_TIMEOUT_MILLIS = 1000;
+  /** Default RPC timeout used for all long poll calls. */
+  private static final long DEFAULT_POLL_RPC_TIMEOUT_MILLIS = 125 * 1000;
+
+  /** Default RPC timeout for QueryWorkflow */
+  private static final long DEFAULT_QUERY_RPC_TIMEOUT_MILLIS = 10 * 1000;
+
+  /** Default RPC timeout for ListArchivedWorkflow */
+  private static final long DEFAULT_LIST_ARCHIVED_WORKFLOW_TIMEOUT_MILLIS = 180 * 1000;
+
+  private static final String DEFAULT_CLIENT_APP_NAME = "cadence-client";
+
+  /** Name of the Cadence service front end as required by TChannel. */
+  private static final String DEFAULT_SERVICE_NAME = "cadence-frontend";
+
+  private final String host;
+  private final int port;
+
+  /** The tChannel timeout in milliseconds */
+  private final long rpcTimeoutMillis;
+
+  /** The tChannel timeout for long poll calls in milliseconds */
+  private final long rpcLongPollTimeoutMillis;
+
+  /** The tChannel timeout for query workflow call in milliseconds */
+  private final long rpcQueryTimeoutMillis;
+
+  /** The tChannel timeout for list archived workflow call in milliseconds */
+  private final long rpcListArchivedWorkflowTimeoutMillis;
+
+  /** TChannel service name that the Cadence service was started with. */
+  private final String serviceName;
+
+  /** Name of the service using the cadence-client. */
+  private final String clientAppName;
+
+  /** Client for metrics reporting. */
+  private final Scope metricsScope;
+
+  /** Optional TChannel transport headers */
+  private final Map<String, String> transportHeaders;
+
+  /** Optional TChannel headers */
+  private final Map<String, String> headers;
+
+  private static final ClientOptions DEFAULT_INSTANCE;
+
+  static {
+    DEFAULT_INSTANCE = new Builder().build();
+  }
+
+  public static ClientOptions defaultInstance() {
+    return DEFAULT_INSTANCE;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  private ClientOptions(Builder builder) {
+    if (Strings.isNullOrEmpty(builder.host)) {
+      host =
+          Strings.isNullOrEmpty(System.getenv("CADENCE_SEEDS"))
+              ? LOCALHOST
+              : System.getenv("CADENCE_SEEDS");
+    } else {
+      host = builder.host;
+    }
+
+    this.port = builder.port;
+    this.rpcTimeoutMillis = builder.rpcTimeoutMillis;
+    if (builder.clientAppName == null) {
+      this.clientAppName = DEFAULT_CLIENT_APP_NAME;
+    } else {
+      this.clientAppName = builder.clientAppName;
+    }
+    if (builder.serviceName == null) {
+      this.serviceName = DEFAULT_SERVICE_NAME;
+    } else {
+      this.serviceName = builder.serviceName;
+    }
+    this.rpcLongPollTimeoutMillis = builder.rpcLongPollTimeoutMillis;
+    this.rpcQueryTimeoutMillis = builder.rpcQueryTimeoutMillis;
+    this.rpcListArchivedWorkflowTimeoutMillis = builder.rpcListArchivedWorkflowTimeoutMillis;
+    if (builder.metricsScope == null) {
+      builder.metricsScope = NoopScope.getInstance();
+    }
+    this.metricsScope = builder.metricsScope;
+    if (builder.transportHeaders != null) {
+      this.transportHeaders = ImmutableMap.copyOf(builder.transportHeaders);
+    } else {
+      this.transportHeaders = ImmutableMap.of();
+    }
+
+    if (builder.headers != null) {
+      this.headers = ImmutableMap.copyOf(builder.headers);
+    } else {
+      this.headers = ImmutableMap.of();
+    }
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  /** @return Returns the rpc timeout value in millis. */
+  public long getRpcTimeoutMillis() {
+    return rpcTimeoutMillis;
+  }
+
+  /** @return Returns the rpc timout for long poll requests in millis. */
+  public long getRpcLongPollTimeoutMillis() {
+    return rpcLongPollTimeoutMillis;
+  }
+
+  /** @return Returns the rpc timout for query workflow requests in millis. */
+  public long getRpcQueryTimeoutMillis() {
+    return rpcQueryTimeoutMillis;
+  }
+
+  /** @return Returns the rpc timout for list archived workflow requests in millis. */
+  public long getRpcListArchivedWorkflowTimeoutMillis() {
+    return rpcListArchivedWorkflowTimeoutMillis;
+  }
+
+  /** Returns the client application name. */
+  public String getClientAppName() {
+    return this.clientAppName;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public Scope getMetricsScope() {
+    return metricsScope;
+  }
+
+  public Map<String, String> getTransportHeaders() {
+    return transportHeaders;
+  }
+
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  /**
+   * Builder is the builder for ClientOptions.
+   *
+   * @author venkat
+   */
+  public static class Builder {
+    private String host;
+    private int port = DEFAULT_LOCAL_CADENCE_SERVER_PORT;
+    private String clientAppName = DEFAULT_CLIENT_APP_NAME;
+    private long rpcTimeoutMillis = DEFAULT_RPC_TIMEOUT_MILLIS;
+    private long rpcLongPollTimeoutMillis = DEFAULT_POLL_RPC_TIMEOUT_MILLIS;
+    public long rpcQueryTimeoutMillis = DEFAULT_QUERY_RPC_TIMEOUT_MILLIS;
+    public long rpcListArchivedWorkflowTimeoutMillis =
+        DEFAULT_LIST_ARCHIVED_WORKFLOW_TIMEOUT_MILLIS;
+    public String serviceName;
+    private Scope metricsScope;
+    private Map<String, String> transportHeaders;
+    private Map<String, String> headers;
+
+    public Builder setHost(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder setPort(int port) {
+      this.port = port;
+      return this;
+    }
+
+    /**
+     * Sets the rpc timeout value for non query and non long poll calls. Default is 1000.
+     *
+     * @param timeoutMillis timeout, in millis.
+     */
+    public Builder setRpcTimeout(long timeoutMillis) {
+      this.rpcTimeoutMillis = timeoutMillis;
+      return this;
+    }
+
+    /**
+     * Sets the rpc timeout value for the following long poll based operations: PollForDecisionTask,
+     * PollForActivityTask, GetWorkflowExecutionHistory. Should never be below 60000 as this is
+     * server side timeout for the long poll. Default is 61000.
+     *
+     * @param timeoutMillis timeout, in millis.
+     */
+    public Builder setRpcLongPollTimeout(long timeoutMillis) {
+      this.rpcLongPollTimeoutMillis = timeoutMillis;
+      return this;
+    }
+
+    /**
+     * Sets the rpc timeout value for query calls. Default is 10000.
+     *
+     * @param timeoutMillis timeout, in millis.
+     */
+    public Builder setQueryRpcTimeout(long timeoutMillis) {
+      this.rpcQueryTimeoutMillis = timeoutMillis;
+      return this;
+    }
+
+    /**
+     * Sets the rpc timeout value for query calls. Default is 180000.
+     *
+     * @param timeoutMillis timeout, in millis.
+     */
+    public Builder setListArchivedWorkflowRpcTimeout(long timeoutMillis) {
+      this.rpcListArchivedWorkflowTimeoutMillis = timeoutMillis;
+      return this;
+    }
+
+    /**
+     * Sets the client application name.
+     *
+     * <p>This name will be used as the tchannel client service name. It will also be reported as a
+     * tag along with metrics emitted to m3.
+     *
+     * @param clientAppName String representing the client application name.
+     * @return Builder for ClentOptions
+     */
+    public Builder setClientAppName(String clientAppName) {
+      this.clientAppName = clientAppName;
+      return this;
+    }
+
+    /**
+     * Sets the service name that Cadence service was started with.
+     *
+     * @param serviceName String representing the service name
+     * @return Builder for ClentOptions
+     */
+    public Builder setServiceName(String serviceName) {
+      this.serviceName = serviceName;
+      return this;
+    }
+
+    /**
+     * Sets the metrics scope to be used for metrics reporting.
+     *
+     * @param metricsScope
+     * @return Builder for ClentOptions
+     */
+    public Builder setMetricsScope(Scope metricsScope) {
+      this.metricsScope = metricsScope;
+      return this;
+    }
+
+    /**
+     * Sets additional transport headers for tchannel client.
+     *
+     * @param transportHeaders Map with additional transport headers
+     * @return Builder for ClentOptions
+     */
+    public Builder setTransportHeaders(Map<String, String> transportHeaders) {
+      this.transportHeaders = transportHeaders;
+      return this;
+    }
+
+    public Builder setHeaders(Map<String, String> headers) {
+      this.headers = headers;
+      return this;
+    }
+
+    /**
+     * Builds and returns a ClientOptions object.
+     *
+     * @return ClientOptions object with the specified params.
+     */
+    public ClientOptions build() {
+      return new ClientOptions(this);
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
+++ b/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
@@ -190,13 +190,15 @@ public class ClientOptions {
     private String clientAppName = DEFAULT_CLIENT_APP_NAME;
     private long rpcTimeoutMillis = DEFAULT_RPC_TIMEOUT_MILLIS;
     private long rpcLongPollTimeoutMillis = DEFAULT_POLL_RPC_TIMEOUT_MILLIS;
-    public long rpcQueryTimeoutMillis = DEFAULT_QUERY_RPC_TIMEOUT_MILLIS;
-    public long rpcListArchivedWorkflowTimeoutMillis =
+    private long rpcQueryTimeoutMillis = DEFAULT_QUERY_RPC_TIMEOUT_MILLIS;
+    private long rpcListArchivedWorkflowTimeoutMillis =
         DEFAULT_LIST_ARCHIVED_WORKFLOW_TIMEOUT_MILLIS;
-    public String serviceName;
+    private String serviceName;
     private Scope metricsScope;
     private Map<String, String> transportHeaders;
     private Map<String, String> headers;
+
+    private Builder() {}
 
     public Builder setHost(String host) {
       this.host = host;

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -17,7 +17,6 @@
 
 package com.uber.cadence.serviceclient;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.uber.cadence.BadRequestError;
 import com.uber.cadence.ClientVersionNotSupportedError;
@@ -93,7 +92,6 @@ import com.uber.cadence.internal.Version;
 import com.uber.cadence.internal.common.CheckedExceptionWrapper;
 import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.metrics.MetricsType;
-import com.uber.cadence.internal.metrics.NoopScope;
 import com.uber.cadence.internal.metrics.ServiceMethod;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
@@ -108,7 +106,10 @@ import com.uber.tchannel.messages.ThriftResponse;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.thrift.TException;
@@ -118,254 +119,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WorkflowServiceTChannel implements IWorkflowService {
-
-  private static final int DEFAULT_LOCAL_CADENCE_SERVER_PORT = 7933;
-
-  private static final String LOCALHOST = "127.0.0.1";
-
-  /** Default RPC timeout used for all non long poll calls. */
-  private static final long DEFAULT_RPC_TIMEOUT_MILLIS = 1000;
-  /** Default RPC timeout used for all long poll calls. */
-  private static final long DEFAULT_POLL_RPC_TIMEOUT_MILLIS = 121 * 1000;
-
-  /** Default RPC timeout for QueryWorkflow */
-  private static final long DEFAULT_QUERY_RPC_TIMEOUT_MILLIS = 10 * 1000;
-
-  /** Default RPC timeout for ListArchivedWorkflow */
-  private static final long DEFAULT_LIST_ARCHIVED_WORKFLOW_TIMEOUT_MILLIS = 180 * 1000;
-
-  private static final String DEFAULT_CLIENT_APP_NAME = "cadence-client";
-
-  /** Name of the Cadence service front end as required by TChannel. */
-  private static final String DEFAULT_SERVICE_NAME = "cadence-frontend";
-
   private static final Logger log = LoggerFactory.getLogger(WorkflowServiceTChannel.class);
-
-  public static class ClientOptions {
-
-    /** The tChannel timeout in milliseconds */
-    private final long rpcTimeoutMillis;
-
-    /** The tChannel timeout for long poll calls in milliseconds */
-    private final long rpcLongPollTimeoutMillis;
-
-    /** The tChannel timeout for query workflow call in milliseconds */
-    private final long rpcQueryTimeoutMillis;
-
-    /** The tChannel timeout for list archived workflow call in milliseconds */
-    private final long rpcListArchivedWorkflowTimeoutMillis;
-
-    /** TChannel service name that the Cadence service was started with. */
-    private final String serviceName;
-
-    /** Name of the service using the cadence-client. */
-    private final String clientAppName;
-
-    /** Client for metrics reporting. */
-    private final Scope metricsScope;
-
-    /** Optional TChannel transport headers */
-    private final Map<String, String> transportHeaders;
-
-    /** Optional TChannel headers */
-    private final Map<String, String> headers;
-
-    private ClientOptions(Builder builder) {
-      this.rpcTimeoutMillis = builder.rpcTimeoutMillis;
-      if (builder.clientAppName == null) {
-        this.clientAppName = DEFAULT_CLIENT_APP_NAME;
-      } else {
-        this.clientAppName = builder.clientAppName;
-      }
-      if (builder.serviceName == null) {
-        this.serviceName = DEFAULT_SERVICE_NAME;
-      } else {
-        this.serviceName = builder.serviceName;
-      }
-      this.rpcLongPollTimeoutMillis = builder.rpcLongPollTimeoutMillis;
-      this.rpcQueryTimeoutMillis = builder.rpcQueryTimeoutMillis;
-      this.rpcListArchivedWorkflowTimeoutMillis = builder.rpcListArchivedWorkflowTimeoutMillis;
-      if (builder.metricsScope == null) {
-        builder.metricsScope = NoopScope.getInstance();
-      }
-      this.metricsScope = builder.metricsScope;
-      if (builder.transportHeaders != null) {
-        this.transportHeaders = ImmutableMap.copyOf(builder.transportHeaders);
-      } else {
-        this.transportHeaders = ImmutableMap.of();
-      }
-
-      if (builder.headers != null) {
-        this.headers = ImmutableMap.copyOf(builder.headers);
-      } else {
-        this.headers = ImmutableMap.of();
-      }
-    }
-
-    /** @return Returns the rpc timeout value in millis. */
-    public long getRpcTimeoutMillis() {
-      return rpcTimeoutMillis;
-    }
-
-    /** @return Returns the rpc timout for long poll requests in millis. */
-    public long getRpcLongPollTimeoutMillis() {
-      return rpcLongPollTimeoutMillis;
-    }
-
-    /** @return Returns the rpc timout for query workflow requests in millis. */
-    public long getRpcQueryTimeoutMillis() {
-      return rpcQueryTimeoutMillis;
-    }
-
-    /** @return Returns the rpc timout for list archived workflow requests in millis. */
-    public long getRpcListArchivedWorkflowTimeoutMillis() {
-      return rpcListArchivedWorkflowTimeoutMillis;
-    }
-
-    /** Returns the client application name. */
-    public String getClientAppName() {
-      return this.clientAppName;
-    }
-
-    public String getServiceName() {
-      return serviceName;
-    }
-
-    public Scope getMetricsScope() {
-      return metricsScope;
-    }
-
-    public Map<String, String> getTransportHeaders() {
-      return transportHeaders;
-    }
-
-    public Map<String, String> getHeaders() {
-      return headers;
-    }
-
-    /**
-     * Builder is the builder for ClientOptions.
-     *
-     * @author venkat
-     */
-    public static class Builder {
-
-      private String clientAppName = DEFAULT_CLIENT_APP_NAME;
-      //            private MetricsClient metricsClient = new DefaultMetricsClient();
-      private long rpcTimeoutMillis = DEFAULT_RPC_TIMEOUT_MILLIS;
-      private long rpcLongPollTimeoutMillis = DEFAULT_POLL_RPC_TIMEOUT_MILLIS;
-      public long rpcQueryTimeoutMillis = DEFAULT_QUERY_RPC_TIMEOUT_MILLIS;
-      public long rpcListArchivedWorkflowTimeoutMillis =
-          DEFAULT_LIST_ARCHIVED_WORKFLOW_TIMEOUT_MILLIS;
-      public String serviceName;
-      private Scope metricsScope;
-      private Map<String, String> transportHeaders;
-      private Map<String, String> headers;
-
-      /**
-       * Sets the rpc timeout value for non query and non long poll calls. Default is 1000.
-       *
-       * @param timeoutMillis timeout, in millis.
-       */
-      public Builder setRpcTimeout(long timeoutMillis) {
-        this.rpcTimeoutMillis = timeoutMillis;
-        return this;
-      }
-
-      /**
-       * Sets the rpc timeout value for the following long poll based operations:
-       * PollForDecisionTask, PollForActivityTask, GetWorkflowExecutionHistory. Should never be
-       * below 60000 as this is server side timeout for the long poll. Default is 61000.
-       *
-       * @param timeoutMillis timeout, in millis.
-       */
-      public Builder setRpcLongPollTimeout(long timeoutMillis) {
-        this.rpcLongPollTimeoutMillis = timeoutMillis;
-        return this;
-      }
-
-      /**
-       * Sets the rpc timeout value for query calls. Default is 10000.
-       *
-       * @param timeoutMillis timeout, in millis.
-       */
-      public Builder setQueryRpcTimeout(long timeoutMillis) {
-        this.rpcQueryTimeoutMillis = timeoutMillis;
-        return this;
-      }
-
-      /**
-       * Sets the rpc timeout value for query calls. Default is 180000.
-       *
-       * @param timeoutMillis timeout, in millis.
-       */
-      public Builder setListArchivedWorkflowRpcTimeout(long timeoutMillis) {
-        this.rpcListArchivedWorkflowTimeoutMillis = timeoutMillis;
-        return this;
-      }
-
-      /**
-       * Sets the client application name.
-       *
-       * <p>This name will be used as the tchannel client service name. It will also be reported as
-       * a tag along with metrics emitted to m3.
-       *
-       * @param clientAppName String representing the client application name.
-       * @return Builder for ClentOptions
-       */
-      public Builder setClientAppName(String clientAppName) {
-        this.clientAppName = clientAppName;
-        return this;
-      }
-
-      /**
-       * Sets the service name that Cadence service was started with.
-       *
-       * @param serviceName String representing the service name
-       * @return Builder for ClentOptions
-       */
-      public Builder setServiceName(String serviceName) {
-        this.serviceName = serviceName;
-        return this;
-      }
-
-      /**
-       * Sets the metrics scope to be used for metrics reporting.
-       *
-       * @param metricsScope
-       * @return Builder for ClentOptions
-       */
-      public Builder setMetricsScope(Scope metricsScope) {
-        this.metricsScope = metricsScope;
-        return this;
-      }
-
-      /**
-       * Sets additional transport headers for tchannel client.
-       *
-       * @param transportHeaders Map with additional transport headers
-       * @return Builder for ClentOptions
-       */
-      public Builder setTransportHeaders(Map<String, String> transportHeaders) {
-        this.transportHeaders = transportHeaders;
-        return this;
-      }
-
-      public Builder setHeaders(Map<String, String> headers) {
-        this.headers = headers;
-        return this;
-      }
-
-      /**
-       * Builds and returns a ClientOptions object.
-       *
-       * @return ClientOptions object with the specified params.
-       */
-      public ClientOptions build() {
-        return new ClientOptions(this);
-      }
-    }
-  }
 
   private static final String INTERFACE_NAME = "WorkflowService";
 
@@ -375,64 +129,33 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   private final SubChannel subChannel;
 
   /**
-   * Creates Cadence client that connects to the local instance of the Cadence Service that listens
-   * on a default port (7933).
-   */
-  public WorkflowServiceTChannel() {
-    this(
-        Strings.isNullOrEmpty(System.getenv("CADENCE_SEEDS"))
-            ? LOCALHOST
-            : System.getenv("CADENCE_SEEDS"),
-        DEFAULT_LOCAL_CADENCE_SERVER_PORT,
-        new ClientOptions.Builder().build());
-  }
-
-  /**
-   * Creates Cadence client that connects to the specified host and port using default options.
-   *
-   * @param host host to connect
-   * @param port port to connect
-   */
-  public WorkflowServiceTChannel(String host, int port) {
-    this(host, port, new ClientOptions.Builder().build());
-  }
-
-  /**
    * Creates Cadence client that connects to the specified host and port using specified options.
    *
-   * @param host host to connect
-   * @param port port to connect
    * @param options configuration options like rpc timeouts.
    */
-  public WorkflowServiceTChannel(String host, int port, ClientOptions options) {
-    if (host == null) {
-      throw new IllegalArgumentException("null host");
-    }
-    if (port <= 0) {
-      throw new IllegalArgumentException("0 or negative port");
-    }
+  public WorkflowServiceTChannel(ClientOptions options) {
     this.options = options;
     this.thriftHeaders = getThriftHeaders(options);
-    // this.metricsReporter = new MetricsReporter(options.getMetricsClient());
-    // Need to create tChannel last in order to prevent leaking when an exception is thrown
     this.tChannel = new TChannel.Builder(options.getClientAppName()).build();
 
+    InetAddress address;
     try {
-      InetAddress address = InetAddress.getByName(host);
-      ArrayList<InetSocketAddress> peers = new ArrayList<>();
-      peers.add(new InetSocketAddress(address, port));
-      this.subChannel = tChannel.makeSubChannel(options.getServiceName()).setPeers(peers);
-      log.info(
-          "Initialized TChannel for service "
-              + this.subChannel.getServiceName()
-              + ", LibraryVersion: "
-              + Version.LIBRARY_VERSION
-              + ", FeatureVersion: "
-              + Version.FEATURE_VERSION);
+      address = InetAddress.getByName(options.getHost());
     } catch (UnknownHostException e) {
       tChannel.shutdown();
-      throw new RuntimeException("Unable to get name of host " + host, e);
+      throw new RuntimeException("Unable to get name of host " + options.getHost(), e);
     }
+
+    ArrayList<InetSocketAddress> peers = new ArrayList<>();
+    peers.add(new InetSocketAddress(address, options.getPort()));
+    this.subChannel = tChannel.makeSubChannel(options.getServiceName()).setPeers(peers);
+    log.info(
+        "Initialized TChannel for service "
+            + this.subChannel.getServiceName()
+            + ", LibraryVersion: "
+            + Version.LIBRARY_VERSION
+            + ", FeatureVersion: "
+            + Version.FEATURE_VERSION);
   }
 
   /**
@@ -444,7 +167,6 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   public WorkflowServiceTChannel(SubChannel subChannel, ClientOptions options) {
     this.options = options;
     this.thriftHeaders = getThriftHeaders(options);
-    // this.metricsReporter = new MetricsReporter(options.getMetricsClient());
     this.tChannel = null;
     this.subChannel = subChannel;
   }
@@ -466,8 +188,8 @@ public class WorkflowServiceTChannel implements IWorkflowService {
             .put("cadence-client-feature-version", Version.FEATURE_VERSION)
             .put("cadence-client-name", "uber-java");
 
-    if (options.headers != null) {
-      for (Map.Entry<String, String> entry : options.headers.entrySet()) {
+    if (options.getHeaders() != null) {
+      for (Map.Entry<String, String> entry : options.getHeaders().entrySet()) {
         builder.put(entry.getKey(), entry.getValue());
       }
     }

--- a/src/main/java/com/uber/cadence/testing/TestEnvironmentOptions.java
+++ b/src/main/java/com/uber/cadence/testing/TestEnvironmentOptions.java
@@ -21,10 +21,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.converter.JsonDataConverter;
-import com.uber.cadence.internal.metrics.NoopScope;
 import com.uber.cadence.worker.Worker;
 import com.uber.cadence.workflow.WorkflowInterceptor;
-import com.uber.m3.tally.Scope;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -36,8 +34,6 @@ public final class TestEnvironmentOptions {
     private DataConverter dataConverter = JsonDataConverter.getInstance();
 
     private Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory = (n) -> n;
-
-    private Scope metricsScope;
 
     private boolean enableLoggingInReplay;
 
@@ -67,14 +63,6 @@ public final class TestEnvironmentOptions {
       return this;
     }
 
-    /**
-     * Set scope to use for metrics reporting. Optional. Default is noop scope that skips reporting.
-     */
-    public Builder setMetricsScope(Scope metricsScope) {
-      this.metricsScope = metricsScope;
-      return this;
-    }
-
     /** Set factoryOptions for worker factory used to create workers. */
     public Builder setWorkerFactoryOptions(Worker.FactoryOptions options) {
       this.factoryOptions = options;
@@ -88,10 +76,6 @@ public final class TestEnvironmentOptions {
     }
 
     public TestEnvironmentOptions build() {
-      if (metricsScope == null) {
-        metricsScope = NoopScope.getInstance();
-      }
-
       if (factoryOptions == null) {
         factoryOptions =
             new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build();
@@ -100,7 +84,6 @@ public final class TestEnvironmentOptions {
       return new TestEnvironmentOptions(
           dataConverter,
           interceptorFactory,
-          metricsScope,
           factoryOptions,
           workflowClientOptions,
           enableLoggingInReplay);
@@ -109,7 +92,6 @@ public final class TestEnvironmentOptions {
 
   private final DataConverter dataConverter;
   private final Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory;
-  private final Scope metricsScope;
   private final boolean enableLoggingInReplay;
   private final Worker.FactoryOptions workerFactoryOptions;
   private final WorkflowClientOptions workflowClientOptions;
@@ -117,13 +99,11 @@ public final class TestEnvironmentOptions {
   private TestEnvironmentOptions(
       DataConverter dataConverter,
       Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory,
-      Scope metricsScope,
       Worker.FactoryOptions options,
       WorkflowClientOptions workflowClientOptions,
       boolean enableLoggingInReplay) {
     this.dataConverter = dataConverter;
     this.interceptorFactory = interceptorFactory;
-    this.metricsScope = metricsScope;
     this.workerFactoryOptions = options;
     this.workflowClientOptions = workflowClientOptions;
     this.enableLoggingInReplay = enableLoggingInReplay;
@@ -135,10 +115,6 @@ public final class TestEnvironmentOptions {
 
   public Function<WorkflowInterceptor, WorkflowInterceptor> getInterceptorFactory() {
     return interceptorFactory;
-  }
-
-  public Scope getMetricsScope() {
-    return metricsScope;
   }
 
   public boolean isLoggingEnabledInReplay() {

--- a/src/main/java/com/uber/cadence/testing/TestEnvironmentOptions.java
+++ b/src/main/java/com/uber/cadence/testing/TestEnvironmentOptions.java
@@ -18,6 +18,7 @@
 package com.uber.cadence.testing;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.converter.JsonDataConverter;
 import com.uber.cadence.internal.metrics.NoopScope;
@@ -34,8 +35,6 @@ public final class TestEnvironmentOptions {
 
     private DataConverter dataConverter = JsonDataConverter.getInstance();
 
-    private String domain = "unit-test";
-
     private Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory = (n) -> n;
 
     private Scope metricsScope;
@@ -44,15 +43,16 @@ public final class TestEnvironmentOptions {
 
     private Worker.FactoryOptions factoryOptions;
 
-    /** Sets data converter to use for unit-tests. Default is {@link JsonDataConverter}. */
-    public Builder setDataConverter(DataConverter dataConverter) {
-      this.dataConverter = Objects.requireNonNull(dataConverter);
+    private WorkflowClientOptions workflowClientOptions = WorkflowClientOptions.defaultInstance();
+
+    public Builder setWorkflowClientOptions(WorkflowClientOptions workflowClientOptions) {
+      this.workflowClientOptions = workflowClientOptions;
       return this;
     }
 
-    /** Set domain to use for test workflows. Optional. Default is "unit-test" */
-    public Builder setDomain(String domain) {
-      this.domain = Objects.requireNonNull(domain);
+    /** Sets data converter to use for unit-tests. Default is {@link JsonDataConverter}. */
+    public Builder setDataConverter(DataConverter dataConverter) {
+      this.dataConverter = Objects.requireNonNull(dataConverter);
       return this;
     }
 
@@ -76,7 +76,7 @@ public final class TestEnvironmentOptions {
     }
 
     /** Set factoryOptions for worker factory used to create workers. */
-    public Builder setFactoryOptions(Worker.FactoryOptions options) {
+    public Builder setWorkerFactoryOptions(Worker.FactoryOptions options) {
       this.factoryOptions = options;
       return this;
     }
@@ -99,42 +99,38 @@ public final class TestEnvironmentOptions {
 
       return new TestEnvironmentOptions(
           dataConverter,
-          domain,
           interceptorFactory,
           metricsScope,
           factoryOptions,
+          workflowClientOptions,
           enableLoggingInReplay);
     }
   }
 
   private final DataConverter dataConverter;
-  private final String domain;
   private final Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory;
   private final Scope metricsScope;
   private final boolean enableLoggingInReplay;
   private final Worker.FactoryOptions workerFactoryOptions;
+  private final WorkflowClientOptions workflowClientOptions;
 
   private TestEnvironmentOptions(
       DataConverter dataConverter,
-      String domain,
       Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory,
       Scope metricsScope,
       Worker.FactoryOptions options,
+      WorkflowClientOptions workflowClientOptions,
       boolean enableLoggingInReplay) {
     this.dataConverter = dataConverter;
-    this.domain = domain;
     this.interceptorFactory = interceptorFactory;
     this.metricsScope = metricsScope;
     this.workerFactoryOptions = options;
+    this.workflowClientOptions = workflowClientOptions;
     this.enableLoggingInReplay = enableLoggingInReplay;
   }
 
   public DataConverter getDataConverter() {
     return dataConverter;
-  }
-
-  public String getDomain() {
-    return domain;
   }
 
   public Function<WorkflowInterceptor, WorkflowInterceptor> getInterceptorFactory() {
@@ -153,14 +149,17 @@ public final class TestEnvironmentOptions {
     return workerFactoryOptions;
   }
 
+  public WorkflowClientOptions getWorkflowClientOptions() {
+    return workflowClientOptions;
+  }
+
   @Override
   public String toString() {
     return "TestEnvironmentOptions{"
         + "dataConverter="
         + dataConverter
-        + ", domain='"
-        + domain
-        + '\''
+        + ", workflowClientOptions="
+        + workflowClientOptions
         + '}';
   }
 }

--- a/src/test/java/com/uber/cadence/RegisterTestDomain.java
+++ b/src/test/java/com/uber/cadence/RegisterTestDomain.java
@@ -2,6 +2,7 @@ package com.uber.cadence;
 
 import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
 
+import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
 import org.apache.thrift.TException;
@@ -11,12 +12,12 @@ public class RegisterTestDomain {
   private static final boolean useDockerService =
       Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
 
-  public static void main(String[] args) throws TException, InterruptedException {
+  public static void main(String[] args) throws InterruptedException {
     if (!useDockerService) {
       return;
     }
 
-    IWorkflowService service = new WorkflowServiceTChannel();
+    IWorkflowService service = new WorkflowServiceTChannel(ClientOptions.defaultInstance());
     RegisterDomainRequest request =
         new RegisterDomainRequest().setName(DOMAIN).setWorkflowExecutionRetentionPeriodInDays(1);
     while (true) {

--- a/src/test/java/com/uber/cadence/activity/LocalActivityContextPropagationTest.java
+++ b/src/test/java/com/uber/cadence/activity/LocalActivityContextPropagationTest.java
@@ -24,7 +24,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
-import com.uber.cadence.client.WorkflowClientOptions.Builder;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.context.ContextPropagator;
 import com.uber.cadence.testing.TestEnvironmentOptions;
@@ -82,10 +81,8 @@ public class LocalActivityContextPropagationTest {
           LocalActivityContextPropagationWorkflowImpl::new);
 
       worker.registerActivitiesImplementations(localActivityContextPropagation);
-
-      WorkflowClientOptions workflowClientOptions = new Builder().build();
-      WorkflowClient workflowClient = testEnv.newWorkflowClient(workflowClientOptions);
-
+      WorkflowClient workflowClient =
+          testEnv.newWorkflowClient(WorkflowClientOptions.defaultInstance());
       testEnv.start();
 
       return workflowClient;

--- a/src/test/java/com/uber/cadence/activity/LocalActivityContextPropagationTest.java
+++ b/src/test/java/com/uber/cadence/activity/LocalActivityContextPropagationTest.java
@@ -69,7 +69,7 @@ public class LocalActivityContextPropagationTest {
       testEnv =
           TestWorkflowEnvironment.newInstance(
               new TestEnvironmentOptions.Builder()
-                  .setFactoryOptions(
+                  .setWorkerFactoryOptions(
                       new FactoryOptions.Builder()
                           .setContextPropagators(
                               propagationEnabled ? PROPAGATORS : Collections.emptyList())

--- a/src/test/java/com/uber/cadence/internal/testing/WorkflowTestingTest.java
+++ b/src/test/java/com/uber/cadence/internal/testing/WorkflowTestingTest.java
@@ -101,7 +101,7 @@ public class WorkflowTestingTest {
   public void setUp() {
     TestEnvironmentOptions options =
         new TestEnvironmentOptions.Builder()
-            .setFactoryOptions(
+            .setWorkerFactoryOptions(
                 new Worker.FactoryOptions.Builder()
                     .setContextPropagators(Collections.singletonList(new TestContextPropagator()))
                     .build())
@@ -580,7 +580,7 @@ public class WorkflowTestingTest {
             .GetWorkflowExecutionHistory(
                 new GetWorkflowExecutionHistoryRequest()
                     .setExecution(new WorkflowExecution().setWorkflowId(workflowID))
-                    .setDomain(client.getDomain()))
+                    .setDomain(client.getOptions().getDomain()))
             .getHistory();
     List<HistoryEvent> historyEvents = history.getEvents();
     assertTrue(

--- a/src/test/java/com/uber/cadence/worker/CleanWorkerShutdownTest.java
+++ b/src/test/java/com/uber/cadence/worker/CleanWorkerShutdownTest.java
@@ -30,7 +30,9 @@ import com.uber.cadence.activity.Activity;
 import com.uber.cadence.activity.ActivityMethod;
 import com.uber.cadence.client.ActivityWorkerShutdownException;
 import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
+import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
 import com.uber.cadence.testing.TestEnvironmentOptions;
@@ -79,7 +81,7 @@ public class CleanWorkerShutdownTest {
   @Before
   public void setUp() {
     if (useExternalService) {
-      service = new WorkflowServiceTChannel();
+      service = new WorkflowServiceTChannel(ClientOptions.defaultInstance());
     }
   }
 
@@ -135,16 +137,18 @@ public class CleanWorkerShutdownTest {
     Worker.Factory workerFactory = null;
     TestWorkflowEnvironment testEnvironment = null;
     CompletableFuture<Boolean> started = new CompletableFuture<>();
+    WorkflowClientOptions clientOptions =
+        WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build();
     if (useExternalService) {
-      workerFactory = new Worker.Factory(service, DOMAIN);
+      workflowClient = WorkflowClient.newInstance(service, clientOptions);
+      workerFactory = Worker.Factory.newInstance(workflowClient);
       Worker worker = workerFactory.newWorker(taskList);
-      workflowClient = WorkflowClient.newInstance(service, DOMAIN);
       worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class);
       worker.registerActivitiesImplementations(new ActivitiesImpl(started));
       workerFactory.start();
     } else {
       TestEnvironmentOptions testOptions =
-          new TestEnvironmentOptions.Builder().setDomain(DOMAIN).build();
+          new TestEnvironmentOptions.Builder().setWorkflowClientOptions(clientOptions).build();
       testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
       service = testEnvironment.getWorkflowService();
       Worker worker = testEnvironment.newWorker(taskList);
@@ -187,16 +191,18 @@ public class CleanWorkerShutdownTest {
     Worker.Factory workerFactory = null;
     TestWorkflowEnvironment testEnvironment = null;
     CompletableFuture<Boolean> started = new CompletableFuture<>();
+    WorkflowClientOptions clientOptions =
+        WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build();
     if (useExternalService) {
-      workerFactory = new Worker.Factory(service, DOMAIN);
+      workflowClient = WorkflowClient.newInstance(service, clientOptions);
+      workerFactory = Worker.Factory.newInstance(workflowClient);
       Worker worker = workerFactory.newWorker(taskList);
-      workflowClient = WorkflowClient.newInstance(service, DOMAIN);
       worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class);
       worker.registerActivitiesImplementations(new ActivitiesImpl(started));
       workerFactory.start();
     } else {
       TestEnvironmentOptions testOptions =
-          new TestEnvironmentOptions.Builder().setDomain(DOMAIN).build();
+          new TestEnvironmentOptions.Builder().setWorkflowClientOptions(clientOptions).build();
       testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
       service = testEnvironment.getWorkflowService();
       Worker worker = testEnvironment.newWorker(taskList);
@@ -266,16 +272,18 @@ public class CleanWorkerShutdownTest {
     Worker.Factory workerFactory = null;
     TestWorkflowEnvironment testEnvironment = null;
     CompletableFuture<Boolean> started = new CompletableFuture<>();
+    WorkflowClientOptions clientOptions =
+        WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build();
     if (useExternalService) {
-      workerFactory = new Worker.Factory(service, DOMAIN);
+      workflowClient = WorkflowClient.newInstance(service, clientOptions);
+      workerFactory = Worker.Factory.newInstance(workflowClient);
       Worker worker = workerFactory.newWorker(taskList);
-      workflowClient = WorkflowClient.newInstance(service, DOMAIN);
       worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class);
       worker.registerActivitiesImplementations(new HeartbeatingActivitiesImpl(started));
       workerFactory.start();
     } else {
       TestEnvironmentOptions testOptions =
-          new TestEnvironmentOptions.Builder().setDomain(DOMAIN).build();
+          new TestEnvironmentOptions.Builder().setWorkflowClientOptions(clientOptions).build();
       testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
       service = testEnvironment.getWorkflowService();
       Worker worker = testEnvironment.newWorker(taskList);

--- a/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
+++ b/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
@@ -553,7 +553,7 @@ public class StickyWorkerTest {
         options = new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build();
       }
       if (useExternalService) {
-        factory = Worker.Factory.newInstance(getWorkflowClient());
+        factory = Worker.Factory.newInstance(getWorkflowClient(), options);
       } else {
         WorkflowClientOptions clientOptions =
             WorkflowClientOptions.newBuilder().setDomain(DOMAIN).setMetricsScope(scope).build();

--- a/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
+++ b/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
@@ -35,6 +35,7 @@ import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
+import com.uber.cadence.internal.metrics.NoopScope;
 import com.uber.cadence.internal.replay.DeciderCache;
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
@@ -71,8 +72,8 @@ import org.slf4j.LoggerFactory;
 @RunWith(Parameterized.class)
 public class StickyWorkerTest {
 
-  private static final boolean useDockerService =
-      Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
+  private static final boolean useDockerService = true;
+  //      Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
 
   @Parameterized.Parameter public boolean useExternalService;
 
@@ -117,12 +118,9 @@ public class StickyWorkerTest {
             .reporter(reporter)
             .reportEvery(com.uber.m3.util.Duration.ofMillis(300));
 
-    TestEnvironmentWrapper wrapper =
-        new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder()
-                .setDisableStickyExecution(false)
-                .setMetricScope(scope)
-                .build());
+    Worker.FactoryOptions factoryOptions =
+        new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build();
+    TestEnvironmentWrapper wrapper = new TestEnvironmentWrapper(factoryOptions, scope);
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName, new WorkerOptions.Builder().build());
     worker.registerWorkflowImplementationTypes(GreetingSignalWorkflowImpl.class);
@@ -175,14 +173,13 @@ public class StickyWorkerTest {
             .reporter(reporter)
             .reportEvery(com.uber.m3.util.Duration.ofMillis(300));
 
-    TestEnvironmentWrapper wrapper =
-        new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder()
-                .setDisableStickyExecution(false)
-                .setMetricScope(scope)
-                .setMaxWorkflowThreadCount(10)
-                .setCacheMaximumSize(100)
-                .build());
+    Worker.FactoryOptions factoryOptions =
+        new Worker.FactoryOptions.Builder()
+            .setDisableStickyExecution(false)
+            .setMaxWorkflowThreadCount(10)
+            .setCacheMaximumSize(100)
+            .build();
+    TestEnvironmentWrapper wrapper = new TestEnvironmentWrapper(factoryOptions, scope);
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker =
         factory.newWorker(
@@ -233,12 +230,10 @@ public class StickyWorkerTest {
             .reporter(reporter)
             .reportEvery(com.uber.m3.util.Duration.ofMillis(300));
 
-    TestEnvironmentWrapper wrapper =
-        new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder()
-                .setDisableStickyExecution(false)
-                .setMetricScope(scope)
-                .build());
+    Worker.FactoryOptions factoryOptions =
+        new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build();
+
+    TestEnvironmentWrapper wrapper = new TestEnvironmentWrapper(factoryOptions, scope);
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName, new WorkerOptions.Builder().build());
     worker.registerWorkflowImplementationTypes(ActivitiesWorkflowImpl.class);
@@ -291,12 +286,9 @@ public class StickyWorkerTest {
             .reporter(reporter)
             .reportEvery(com.uber.m3.util.Duration.ofMillis(300));
 
-    TestEnvironmentWrapper wrapper =
-        new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder()
-                .setDisableStickyExecution(false)
-                .setMetricScope(scope)
-                .build());
+    Worker.FactoryOptions factoryOptions =
+        new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build();
+    TestEnvironmentWrapper wrapper = new TestEnvironmentWrapper(factoryOptions, scope);
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName, new WorkerOptions.Builder().build());
     worker.registerWorkflowImplementationTypes(
@@ -342,12 +334,9 @@ public class StickyWorkerTest {
             .reporter(reporter)
             .reportEvery(com.uber.m3.util.Duration.ofMillis(300));
 
-    TestEnvironmentWrapper wrapper =
-        new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder()
-                .setDisableStickyExecution(false)
-                .setMetricScope(scope)
-                .build());
+    Worker.FactoryOptions factoryOptions =
+        new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build();
+    TestEnvironmentWrapper wrapper = new TestEnvironmentWrapper(factoryOptions, scope);
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName, new WorkerOptions.Builder().build());
     worker.registerWorkflowImplementationTypes(TestMutableSideEffectWorkflowImpl.class);
@@ -396,7 +385,8 @@ public class StickyWorkerTest {
     String taskListName = "notCachedStickyTest";
     TestEnvironmentWrapper wrapper =
         new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder().setDisableStickyExecution(true).build());
+            new Worker.FactoryOptions.Builder().setDisableStickyExecution(true).build(),
+            NoopScope.getInstance());
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName);
     worker.registerWorkflowImplementationTypes(GreetingSignalWorkflowImpl.class);
@@ -429,7 +419,8 @@ public class StickyWorkerTest {
     String taskListName = "evictedStickyTest";
     TestEnvironmentWrapper wrapper =
         new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build());
+            new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build(),
+            NoopScope.getInstance());
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName);
     worker.registerWorkflowImplementationTypes(GreetingSignalWorkflowImpl.class);
@@ -469,7 +460,8 @@ public class StickyWorkerTest {
     String taskListName = "queryStickyTest";
     TestEnvironmentWrapper wrapper =
         new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build());
+            new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build(),
+            NoopScope.getInstance());
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName);
     worker.registerWorkflowImplementationTypes(GreetingSignalWorkflowImpl.class);
@@ -510,7 +502,8 @@ public class StickyWorkerTest {
     String taskListName = "queryEvictionStickyTest";
     TestEnvironmentWrapper wrapper =
         new TestEnvironmentWrapper(
-            new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build());
+            new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build(),
+            NoopScope.getInstance());
     Worker.Factory factory = wrapper.getWorkerFactory();
     Worker worker = factory.newWorker(taskListName);
     worker.registerWorkflowImplementationTypes(GreetingSignalWorkflowImpl.class);
@@ -552,8 +545,10 @@ public class StickyWorkerTest {
 
     private TestWorkflowEnvironment testEnv;
     private Worker.Factory factory;
+    private final Scope scope;
 
-    public TestEnvironmentWrapper(Worker.FactoryOptions options) {
+    public TestEnvironmentWrapper(Worker.FactoryOptions options, Scope scope) {
+      this.scope = scope;
       if (options == null) {
         options = new Worker.FactoryOptions.Builder().setDisableStickyExecution(false).build();
       }
@@ -577,7 +572,7 @@ public class StickyWorkerTest {
 
     private WorkflowClient getWorkflowClient() {
       WorkflowClientOptions clientOptions =
-          WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build();
+          WorkflowClientOptions.newBuilder().setDomain(DOMAIN).setMetricsScope(scope).build();
       return useExternalService
           ? WorkflowClient.newInstance(service, clientOptions)
           : testEnv.newWorkflowClient();

--- a/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
+++ b/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
@@ -72,8 +72,8 @@ import org.slf4j.LoggerFactory;
 @RunWith(Parameterized.class)
 public class StickyWorkerTest {
 
-  private static final boolean useDockerService = true;
-  //      Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
+  private static final boolean useDockerService =
+      Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
 
   @Parameterized.Parameter public boolean useExternalService;
 
@@ -556,7 +556,7 @@ public class StickyWorkerTest {
         factory = Worker.Factory.newInstance(getWorkflowClient());
       } else {
         WorkflowClientOptions clientOptions =
-            WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build();
+            WorkflowClientOptions.newBuilder().setDomain(DOMAIN).setMetricsScope(scope).build();
         TestEnvironmentOptions testOptions =
             new TestEnvironmentOptions.Builder()
                 .setWorkflowClientOptions(clientOptions)

--- a/src/test/java/com/uber/cadence/workflow/LoggerTest.java
+++ b/src/test/java/com/uber/cadence/workflow/LoggerTest.java
@@ -24,6 +24,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.internal.logging.LoggerTag;
 import com.uber.cadence.testing.TestEnvironmentOptions;
@@ -86,9 +87,11 @@ public class LoggerTest {
 
   @Test
   public void testWorkflowLogger() {
+    WorkflowClientOptions clientOptions =
+        WorkflowClientOptions.newBuilder().setDomain(WorkflowTest.DOMAIN).build();
     TestEnvironmentOptions testOptions =
         new TestEnvironmentOptions.Builder()
-            .setDomain(WorkflowTest.DOMAIN)
+            .setWorkflowClientOptions(clientOptions)
             .setEnableLoggingInReplay(false)
             .build();
     TestWorkflowEnvironment env = TestWorkflowEnvironment.newInstance(testOptions);

--- a/src/test/java/com/uber/cadence/workflow/MetricsTest.java
+++ b/src/test/java/com/uber/cadence/workflow/MetricsTest.java
@@ -197,12 +197,12 @@ public class MetricsTest {
     Scope scope = new RootScopeBuilder().reporter(reporter).reportEvery(reportingFrequecy);
 
     WorkflowClientOptions clientOptions =
-        new WorkflowClientOptions.Builder().setDomain(WorkflowTest.DOMAIN).build();
-    TestEnvironmentOptions testOptions =
-        new TestEnvironmentOptions.Builder()
-            .setWorkflowClientOptions(clientOptions)
+        WorkflowClientOptions.newBuilder()
+            .setDomain(WorkflowTest.DOMAIN)
             .setMetricsScope(scope)
             .build();
+    TestEnvironmentOptions testOptions =
+        new TestEnvironmentOptions.Builder().setWorkflowClientOptions(clientOptions).build();
     testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
   }
 

--- a/src/test/java/com/uber/cadence/workflow/MetricsTest.java
+++ b/src/test/java/com/uber/cadence/workflow/MetricsTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 
 import com.uber.cadence.activity.ActivityOptions;
 import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.internal.metrics.MetricsTag;
@@ -195,9 +196,11 @@ public class MetricsTest {
     reporter = mock(StatsReporter.class);
     Scope scope = new RootScopeBuilder().reporter(reporter).reportEvery(reportingFrequecy);
 
+    WorkflowClientOptions clientOptions =
+        new WorkflowClientOptions.Builder().setDomain(WorkflowTest.DOMAIN).build();
     TestEnvironmentOptions testOptions =
         new TestEnvironmentOptions.Builder()
-            .setDomain(WorkflowTest.DOMAIN)
+            .setWorkflowClientOptions(clientOptions)
             .setMetricsScope(scope)
             .build();
     testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -68,6 +68,7 @@ import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.sync.DeterministicRunnerTest;
 import com.uber.cadence.internal.worker.PollerOptions;
 import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
 import com.uber.cadence.testing.TestEnvironmentOptions;
 import com.uber.cadence.testing.TestWorkflowEnvironment;
@@ -211,7 +212,7 @@ public class WorkflowTest {
   private TestWorkflowEnvironment testEnvironment;
   private ScheduledExecutorService scheduledExecutor;
   private List<ScheduledFuture<?>> delayedCallbacks = new ArrayList<>();
-  private static final WorkflowServiceTChannel service =
+  private static final IWorkflowService service =
       new WorkflowServiceTChannel(ClientOptions.defaultInstance());
 
   @AfterClass

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -208,7 +208,6 @@ public class WorkflowTest {
   private Worker worker;
   private TestActivitiesImpl activitiesImpl;
   private WorkflowClient workflowClient;
-  private WorkflowClient workflowClientWithOptions;
   private TestWorkflowEnvironment testEnvironment;
   private ScheduledExecutorService scheduledExecutor;
   private List<ScheduledFuture<?>> delayedCallbacks = new ArrayList<>();
@@ -281,15 +280,14 @@ public class WorkflowTest {
     tracer = new TracingWorkflowInterceptorFactory();
     // TODO: Create a version of TestWorkflowEnvironment that runs against a real service.
     WorkflowClientOptions clientOptions =
-        new WorkflowClientOptions.Builder().setDomain(DOMAIN).build();
+        WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build();
     if (useExternalService) {
-      workflowClient = WorkflowClient.newInstance(service);
-      workflowClientWithOptions = WorkflowClient.newInstance(service, clientOptions);
+      workflowClient = WorkflowClient.newInstance(service, clientOptions);
       Worker.FactoryOptions factoryOptions =
           new Worker.FactoryOptions.Builder()
               .setDisableStickyExecution(disableStickyExecution)
               .build();
-      workerFactory = new Worker.Factory(workflowClientWithOptions, factoryOptions);
+      workerFactory = new Worker.Factory(workflowClient, factoryOptions);
       WorkerOptions workerOptions =
           new WorkerOptions.Builder()
               .setActivityPollerOptions(new PollerOptions.Builder().setPollThreadCount(5).build())
@@ -311,7 +309,6 @@ public class WorkflowTest {
       testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
       worker = testEnvironment.newWorker(taskList);
       workflowClient = testEnvironment.newWorkflowClient();
-      workflowClientWithOptions = testEnvironment.newWorkflowClient();
     }
 
     ActivityCompletionClient completionClient = workflowClient.newActivityCompletionClient();
@@ -1448,7 +1445,7 @@ public class WorkflowTest {
     }
     // Check that duplicated start is not allowed for AllowDuplicate IdReusePolicy
     TestMultiargsWorkflowsFunc2 stubF2 =
-        workflowClientWithOptions.newWorkflowStub(
+        workflowClient.newWorkflowStub(
             TestMultiargsWorkflowsFunc2.class,
             newWorkflowOptionsBuilder(taskList)
                 .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.AllowDuplicate)
@@ -1474,32 +1471,25 @@ public class WorkflowTest {
     assertResult("123456", WorkflowClient.start(stubF6::func6, "1", 2, 3, 4, 5, 6));
 
     TestMultiargsWorkflowsProc stubP =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc.class, workflowOptions);
     waitForProc(WorkflowClient.start(stubP::proc));
     TestMultiargsWorkflowsProc1 stubP1 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc1.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc1.class, workflowOptions);
     waitForProc(WorkflowClient.start(stubP1::proc1, "1"));
     TestMultiargsWorkflowsProc2 stubP2 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc2.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc2.class, workflowOptions);
     waitForProc(WorkflowClient.start(stubP2::proc2, "1", 2));
     TestMultiargsWorkflowsProc3 stubP3 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc3.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc3.class, workflowOptions);
     waitForProc(WorkflowClient.start(stubP3::proc3, "1", 2, 3));
     TestMultiargsWorkflowsProc4 stubP4 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc4.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc4.class, workflowOptions);
     waitForProc(WorkflowClient.start(stubP4::proc4, "1", 2, 3, 4));
     TestMultiargsWorkflowsProc5 stubP5 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc5.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc5.class, workflowOptions);
     waitForProc(WorkflowClient.start(stubP5::proc5, "1", 2, 3, 4, 5));
     TestMultiargsWorkflowsProc6 stubP6 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc6.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc6.class, workflowOptions);
     waitForProc(WorkflowClient.start(stubP6::proc6, "1", 2, 3, 4, 5, 6));
 
     assertEquals("proc", stubP.query());
@@ -1643,32 +1633,25 @@ public class WorkflowTest {
     assertEquals("123456", WorkflowClient.execute(stubF6::func6, "1", 2, 3, 4, 5, 6).get());
 
     TestMultiargsWorkflowsProc stubP =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc.class, workflowOptions);
     WorkflowClient.execute(stubP::proc).get();
     TestMultiargsWorkflowsProc1 stubP1 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc1.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc1.class, workflowOptions);
     WorkflowClient.execute(stubP1::proc1, "1").get();
     TestMultiargsWorkflowsProc2 stubP2 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc2.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc2.class, workflowOptions);
     WorkflowClient.execute(stubP2::proc2, "1", 2).get();
     TestMultiargsWorkflowsProc3 stubP3 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc3.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc3.class, workflowOptions);
     WorkflowClient.execute(stubP3::proc3, "1", 2, 3).get();
     TestMultiargsWorkflowsProc4 stubP4 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc4.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc4.class, workflowOptions);
     WorkflowClient.execute(stubP4::proc4, "1", 2, 3, 4).get();
     TestMultiargsWorkflowsProc5 stubP5 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc5.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc5.class, workflowOptions);
     WorkflowClient.execute(stubP5::proc5, "1", 2, 3, 4, 5).get();
     TestMultiargsWorkflowsProc6 stubP6 =
-        workflowClientWithOptions.newWorkflowStub(
-            TestMultiargsWorkflowsProc6.class, workflowOptions);
+        workflowClient.newWorkflowStub(TestMultiargsWorkflowsProc6.class, workflowOptions);
     WorkflowClient.execute(stubP6::proc6, "1", 2, 3, 4, 5, 6).get();
 
     assertEquals("proc", stubP.query());
@@ -2422,7 +2405,7 @@ public class WorkflowTest {
     // Test getTrace through replay by a local worker.
     Worker queryWorker;
     if (useExternalService) {
-      Worker.Factory workerFactory = Worker.Factory.newInstance(workflowClientWithOptions);
+      Worker.Factory workerFactory = Worker.Factory.newInstance(workflowClient);
       queryWorker = workerFactory.newWorker(taskList);
     } else {
       queryWorker = testEnvironment.newWorker(taskList);
@@ -2492,11 +2475,11 @@ public class WorkflowTest {
   }
 
   @Test
-  public void testSignalWithStart() throws Exception {
+  public void testSignalWithStart() {
     // Test getTrace through replay by a local worker.
     Worker queryWorker;
     if (useExternalService) {
-      Worker.Factory workerFactory = Worker.Factory.newInstance(workflowClientWithOptions);
+      Worker.Factory workerFactory = Worker.Factory.newInstance(workflowClient);
       queryWorker = workerFactory.newWorker(taskList);
     } else {
       queryWorker = testEnvironment.newWorker(taskList);
@@ -2996,7 +2979,7 @@ public class WorkflowTest {
     options.setTaskList(taskList);
     AtomicReference<String> capturedWorkflowType = new AtomicReference<>();
     WorkflowClientOptions clientOptions =
-        new WorkflowClientOptions.Builder()
+        WorkflowClientOptions.newBuilder()
             .setInterceptors(
                 new WorkflowClientInterceptorBase() {
                   @Override
@@ -3073,7 +3056,7 @@ public class WorkflowTest {
     options.setTaskList(taskList);
     WorkflowClient wc;
     if (useExternalService) {
-      wc = workflowClientWithOptions;
+      wc = workflowClient;
     } else {
       wc = testEnvironment.newWorkflowClient();
     }


### PR DESCRIPTION
This is the first part of a general options and worker dependencies cleanup. After this refactoring, user should follow the sequence below to setup worker and its dependencies:
- IWorkflowService is a client stub for communicating to Cadence Server
- WorkflowClient wraps IWorkflowService and provides higher level API to start, signal, query and wait for completion of workflows.
- WorkerFactory wraps WorkflowClient and can be used to create instances of Workers.
- Worker listens on a single task list and is created by a WorkerFactory.

Ref: https://github.com/temporalio/sdk-java/pull/32 and https://github.com/temporalio/sdk-java/pull/33