### PR TITLE
Implement WorkerActivitiesPerSecond

### DIFF
--- a/src/main/java/com/uber/cadence/internal/worker/SingleWorkerOptions.java
+++ b/src/main/java/com/uber/cadence/internal/worker/SingleWorkerOptions.java
@@ -31,6 +31,7 @@ public final class SingleWorkerOptions {
 
   public static final class Builder {
 
+    private double workerActivitiesPerSecond;
     private String identity;
     private DataConverter dataConverter;
     private int taskExecutorThreadPoolSize = 100;
@@ -47,6 +48,7 @@ public final class SingleWorkerOptions {
     public Builder() {}
 
     public Builder(SingleWorkerOptions options) {
+      this.workerActivitiesPerSecond = options.getWorkerActivitiesPerSecond();
       this.identity = options.getIdentity();
       this.dataConverter = options.getDataConverter();
       this.pollerOptions = options.getPollerOptions();
@@ -57,6 +59,11 @@ public final class SingleWorkerOptions {
       this.metricsScope = options.getMetricsScope();
       this.enableLoggingInReplay = options.getEnableLoggingInReplay();
       this.contextPropagators = options.getContextPropagators();
+    }
+
+    public Builder setWorkerActivitiesPerSecond(double workerActivitiesPerSecond) {
+      this.workerActivitiesPerSecond = workerActivitiesPerSecond;
+      return this;
     }
 
     public Builder setIdentity(String identity) {
@@ -137,6 +144,7 @@ public final class SingleWorkerOptions {
       }
 
       return new SingleWorkerOptions(
+          workerActivitiesPerSecond,
           identity,
           dataConverter,
           taskExecutorThreadPoolSize,
@@ -150,6 +158,7 @@ public final class SingleWorkerOptions {
     }
   }
 
+  private final double workerActivitiesPerSecond;
   private final String identity;
   private final DataConverter dataConverter;
   private final int taskExecutorThreadPoolSize;
@@ -162,6 +171,7 @@ public final class SingleWorkerOptions {
   private List<ContextPropagator> contextPropagators;
 
   private SingleWorkerOptions(
+      double workerActivitiesPerSecond,
       String identity,
       DataConverter dataConverter,
       int taskExecutorThreadPoolSize,
@@ -172,6 +182,7 @@ public final class SingleWorkerOptions {
       Scope metricsScope,
       boolean enableLoggingInReplay,
       List<ContextPropagator> contextPropagators) {
+    this.workerActivitiesPerSecond = workerActivitiesPerSecond;
     this.identity = identity;
     this.dataConverter = dataConverter;
     this.taskExecutorThreadPoolSize = taskExecutorThreadPoolSize;
@@ -182,6 +193,10 @@ public final class SingleWorkerOptions {
     this.metricsScope = metricsScope;
     this.enableLoggingInReplay = enableLoggingInReplay;
     this.contextPropagators = contextPropagators;
+  }
+
+  double getWorkerActivitiesPerSecond() {
+    return workerActivitiesPerSecond;
   }
 
   public String getIdentity() {

--- a/src/main/java/com/uber/cadence/internal/worker/Throttler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/Throttler.java
@@ -38,7 +38,29 @@ final class Throttler {
 
   private final long rateIntervalMilliseconds;
 
+  /** Default 1s interval when interval per message is less than 1ms */
+  private static final long defaultRateIntervalMilliseconds = 1000L;
+
   private long overslept;
+
+  private static long calculateIntervalMillisecondsPerMessage(double maxRatePerSecond) {
+    return (long) (1 / maxRatePerSecond * 1000.0);
+  }
+
+  /**
+   * Construct throttler.
+   *
+   * @param name Human readable name of the resource being throttled. Used for logging only.
+   * @param maxRatePerSecond maximum rate allowed
+   */
+  public Throttler(String name, double maxRatePerSecond) {
+    this(
+        name,
+        maxRatePerSecond,
+        calculateIntervalMillisecondsPerMessage(maxRatePerSecond) <= 0L
+            ? defaultRateIntervalMilliseconds
+            : calculateIntervalMillisecondsPerMessage(maxRatePerSecond));
+  }
 
   /**
    * Construct throttler.
@@ -69,7 +91,7 @@ final class Throttler {
     int maxMessagesPerRateInterval = (int) (maxRatePerSecond * rateIntervalMilliseconds / 1000);
     if (maxMessagesPerRateInterval == 0) {
       maxMessagesPerRateInterval = 1;
-      rateInterval = (long) (1.0 / maxRatePerSecond * 1000.0);
+      rateInterval = calculateIntervalMillisecondsPerMessage(maxRatePerSecond);
     } else {
       rateInterval = rateIntervalMilliseconds;
     }

--- a/src/main/java/com/uber/cadence/worker/Worker.java
+++ b/src/main/java/com/uber/cadence/worker/Worker.java
@@ -141,6 +141,7 @@ public final class Worker implements Suspendable {
             .put(MetricsTag.TASK_LIST, taskList)
             .build();
     return new SingleWorkerOptions.Builder()
+        .setWorkerActivitiesPerSecond(options.getWorkerActivitiesPerSecond())
         .setDataConverter(options.getDataConverter())
         .setIdentity(options.getIdentity())
         .setPollerOptions(options.getActivityPollerOptions())


### PR DESCRIPTION
Implements WorkerActivitiesPerSecond as per [documentation](https://javadoc.io/doc/com.uber.cadence/cadence-client/latest/com/uber/cadence/worker/WorkerOptions.Builder.html#setWorkerActivitiesPerSecond-double-).
closes https://github.com/uber/cadence-java-client/issues/553

**Key points:**
- Implements WorkerActivitiesPerSecond with Throttler at PollTaskExecutor
- Throttler evaluation interval defaults to 1s when interval per message is less than 1ms (i.e. will implicitly allow more bursts)

**Test results:**
- [X] Unit tests
- [X] Local integration tests with workerActivitiesPerSecond set to 0.00001, 0.3, 0.5, 1, 2, 1000, 2000
- [X] Local integration tests without taskListActivitiesPerSecond set