### PR TITLE
Add option to dispatch activity tasks locally

### DIFF
--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
@@ -18,6 +18,7 @@
 package com.uber.cadence.internal.metrics;
 
 public class MetricsType {
+
   public static final String CADENCE_METRICS_PREFIX = "cadence-";
   public static final String WORKFLOW_START_COUNTER = CADENCE_METRICS_PREFIX + "workflow-start";
   public static final String WORKFLOW_COMPLETED_COUNTER =
@@ -121,7 +122,7 @@ public class MetricsType {
       CADENCE_METRICS_PREFIX + "local-activity-execution-latency";
   public static final String LOCALLY_DISPATCHED_ACTIVITY_POLL_TOTAL_COUNTER =
       CADENCE_METRICS_PREFIX + "locally-dispatched-activity-poll-total";
-  public static final String LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK__COUNTER =
+  public static final String LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK_COUNTER =
       CADENCE_METRICS_PREFIX + "locally-dispatched-activity-poll-no-task";
   public static final String LOCALLY_DISPATCHED_ACTIVITY_POLL_SUCCEED_COUNTER =
       CADENCE_METRICS_PREFIX + "locally-dispatched-activity-poll-succeed";

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
@@ -119,6 +119,16 @@ public class MetricsType {
       CADENCE_METRICS_PREFIX + "local-activity-panic";
   public static final String LOCAL_ACTIVITY_EXECUTION_LATENCY =
       CADENCE_METRICS_PREFIX + "local-activity-execution-latency";
+  public static final String LOCALLY_DISPATCHED_ACTIVITY_POLL_TOTAL_COUNTER =
+      CADENCE_METRICS_PREFIX + "locally-dispatched-activity-poll-total";
+  public static final String LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK__COUNTER =
+      CADENCE_METRICS_PREFIX + "locally-dispatched-activity-poll-no-task";
+  public static final String LOCALLY_DISPATCHED_ACTIVITY_POLL_SUCCEED_COUNTER =
+      CADENCE_METRICS_PREFIX + "locally-dispatched-activity-poll-succeed";
+  public static final String ACTIVITY_LOCAL_DISPATCH_FAILED_COUNTER =
+      CADENCE_METRICS_PREFIX + "activity-local-dispatch-failed";
+  public static final String ACTIVITY_LOCAL_DISPATCH_SUCCEED_COUNTER =
+      CADENCE_METRICS_PREFIX + "activity-local-dispatch-succeed";
   public static final String WORKER_PANIC_COUNTER = CADENCE_METRICS_PREFIX + "worker-panic";
 
   public static final String TASK_LIST_QUEUE_LATENCY =

--- a/src/main/java/com/uber/cadence/internal/sync/SyncActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncActivityWorker.java
@@ -37,7 +37,9 @@ public class SyncActivityWorker implements SuspendableWorker {
       IWorkflowService service, String domain, String taskList, SingleWorkerOptions options) {
     taskHandler =
         new POJOActivityTaskHandler(service, domain, options.getDataConverter(), heartbeatExecutor);
-    worker = new ActivityWorker(service, domain, taskList, options, taskHandler);
+    worker =
+        new ActivityWorker(
+            service, domain, taskList, options, taskHandler, "Activity Poller taskList=");
   }
 
   public void setActivitiesImplementation(Object... activitiesImplementation) {

--- a/src/main/java/com/uber/cadence/internal/sync/SyncActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncActivityWorker.java
@@ -37,9 +37,7 @@ public class SyncActivityWorker implements SuspendableWorker {
       IWorkflowService service, String domain, String taskList, SingleWorkerOptions options) {
     taskHandler =
         new POJOActivityTaskHandler(service, domain, options.getDataConverter(), heartbeatExecutor);
-    worker =
-        new ActivityWorker(
-            service, domain, taskList, options, taskHandler, "Activity Poller taskList=");
+    worker = new ActivityWorker(service, domain, taskList, options, taskHandler);
   }
 
   public void setActivitiesImplementation(Object... activitiesImplementation) {

--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflowWorker.java
@@ -26,6 +26,7 @@ import com.uber.cadence.internal.replay.DeciderCache;
 import com.uber.cadence.internal.replay.ReplayDecisionTaskHandler;
 import com.uber.cadence.internal.worker.DecisionTaskHandler;
 import com.uber.cadence.internal.worker.LocalActivityWorker;
+import com.uber.cadence.internal.worker.LocallyDispatchedActivityWorker;
 import com.uber.cadence.internal.worker.SingleWorkerOptions;
 import com.uber.cadence.internal.worker.SuspendableWorker;
 import com.uber.cadence.internal.worker.WorkflowWorker;
@@ -49,10 +50,14 @@ public class SyncWorkflowWorker
 
   private final WorkflowWorker workflowWorker;
   private final LocalActivityWorker laWorker;
+  private final LocallyDispatchedActivityWorker ldaWorker;
+
   private final POJOWorkflowImplementationFactory factory;
   private final DataConverter dataConverter;
   private final POJOActivityTaskHandler laTaskHandler;
+  private final POJOActivityTaskHandler ldaTaskHandler;
   private final ScheduledExecutorService heartbeatExecutor = Executors.newScheduledThreadPool(4);
+  private final ScheduledExecutorService ldaHeartbeatExecutor = Executors.newScheduledThreadPool(4);
 
   public SyncWorkflowWorker(
       IWorkflowService service,
@@ -61,6 +66,7 @@ public class SyncWorkflowWorker
       Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory,
       SingleWorkerOptions workflowOptions,
       SingleWorkerOptions localActivityOptions,
+      SingleWorkerOptions locallyDispatchedActivityOptions,
       DeciderCache cache,
       String stickyTaskListName,
       Duration stickyDecisionScheduleToStartTimeout,
@@ -91,6 +97,15 @@ public class SyncWorkflowWorker
             stickyDecisionScheduleToStartTimeout,
             service,
             laWorker.getLocalActivityTaskPoller());
+    ldaTaskHandler =
+        new POJOActivityTaskHandler(
+            service,
+            domain,
+            locallyDispatchedActivityOptions.getDataConverter(),
+            ldaHeartbeatExecutor);
+    ldaWorker =
+        new LocallyDispatchedActivityWorker(
+            service, domain, taskList, locallyDispatchedActivityOptions, ldaTaskHandler);
 
     workflowWorker =
         new WorkflowWorker(
@@ -115,6 +130,10 @@ public class SyncWorkflowWorker
     this.laTaskHandler.setLocalActivitiesImplementation(activitiesImplementation);
   }
 
+  public void setActivitiesImplementationToDispatchLocally(Object... activitiesImplementation) {
+    this.ldaTaskHandler.setActivitiesImplementation(activitiesImplementation);
+  }
+
   @Override
   public void start() {
     workflowWorker.start();
@@ -122,39 +141,43 @@ public class SyncWorkflowWorker
     // to start LocalActivity Worker.
     if (workflowWorker.isStarted()) {
       laWorker.start();
+      ldaWorker.start();
     }
   }
 
   @Override
   public boolean isStarted() {
-    return workflowWorker.isStarted() && laWorker.isStarted();
+    return workflowWorker.isStarted() && laWorker.isStarted() && ldaWorker.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
-    return workflowWorker.isShutdown() && laWorker.isShutdown();
+    return workflowWorker.isShutdown() && laWorker.isShutdown() && ldaWorker.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
-    return workflowWorker.isTerminated() && laWorker.isTerminated();
+    return workflowWorker.isTerminated() && laWorker.isTerminated() && ldaWorker.isTerminated();
   }
 
   @Override
   public void shutdown() {
     laWorker.shutdown();
+    ldaWorker.shutdown();
     workflowWorker.shutdown();
   }
 
   @Override
   public void shutdownNow() {
     laWorker.shutdownNow();
+    ldaWorker.shutdownNow();
     workflowWorker.shutdownNow();
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
     long timeoutMillis = InternalUtils.awaitTermination(laWorker, unit.toMillis(timeout));
+    timeoutMillis = InternalUtils.awaitTermination(ldaWorker, timeoutMillis);
     InternalUtils.awaitTermination(workflowWorker, timeoutMillis);
   }
 
@@ -162,17 +185,19 @@ public class SyncWorkflowWorker
   public void suspendPolling() {
     workflowWorker.suspendPolling();
     laWorker.suspendPolling();
+    ldaWorker.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
     workflowWorker.resumePolling();
     laWorker.resumePolling();
+    ldaWorker.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
-    return workflowWorker.isSuspended() && laWorker.isSuspended();
+    return workflowWorker.isSuspended() && laWorker.isSuspended() && ldaWorker.isSuspended();
   }
 
   public <R> R queryWorkflowExecution(

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityPollTask.java
@@ -25,6 +25,7 @@ import com.uber.cadence.TaskList;
 import com.uber.cadence.TaskListMetadata;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.m3.tally.Stopwatch;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,7 @@ final class ActivityPollTask extends ActivityPollTaskBase {
   @Override
   protected PollForActivityTaskResponse pollTask() throws TException {
     options.getMetricsScope().counter(MetricsType.ACTIVITY_POLL_COUNTER).inc(1);
-
+    Stopwatch sw = options.getMetricsScope().timer(MetricsType.ACTIVITY_POLL_LATENCY).start();
     PollForActivityTaskRequest pollRequest = new PollForActivityTaskRequest();
     pollRequest.setDomain(domain);
     pollRequest.setIdentity(options.getIdentity());
@@ -84,7 +85,7 @@ final class ActivityPollTask extends ActivityPollTaskBase {
     if (log.isTraceEnabled()) {
       log.trace("poll request returned " + result);
     }
-
+    sw.stop();
     return result;
   }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityPollTask.java
@@ -25,33 +25,28 @@ import com.uber.cadence.TaskList;
 import com.uber.cadence.TaskListMetadata;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
-import com.uber.m3.tally.Stopwatch;
-import com.uber.m3.util.Duration;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class ActivityPollTask implements Poller.PollTask<PollForActivityTaskResponse> {
+final class ActivityPollTask extends ActivityPollTaskBase {
 
+  private static final Logger log = LoggerFactory.getLogger(ActivityPollTask.class);
   private final IWorkflowService service;
   private final String domain;
   private final String taskList;
-  private final SingleWorkerOptions options;
-  private static final Logger log = LoggerFactory.getLogger(ActivityPollTask.class);
 
   public ActivityPollTask(
       IWorkflowService service, String domain, String taskList, SingleWorkerOptions options) {
-
+    super(options);
     this.service = service;
     this.domain = domain;
     this.taskList = taskList;
-    this.options = options;
   }
 
   @Override
-  public PollForActivityTaskResponse poll() throws TException {
+  protected PollForActivityTaskResponse pollTask() throws TException {
     options.getMetricsScope().counter(MetricsType.ACTIVITY_POLL_COUNTER).inc(1);
-    Stopwatch sw = options.getMetricsScope().timer(MetricsType.ACTIVITY_POLL_LATENCY).start();
 
     PollForActivityTaskRequest pollRequest = new PollForActivityTaskRequest();
     pollRequest.setDomain(domain);
@@ -90,14 +85,6 @@ final class ActivityPollTask implements Poller.PollTask<PollForActivityTaskRespo
       log.trace("poll request returned " + result);
     }
 
-    options.getMetricsScope().counter(MetricsType.ACTIVITY_POLL_SUCCEED_COUNTER).inc(1);
-    options
-        .getMetricsScope()
-        .timer(MetricsType.ACTIVITY_SCHEDULED_TO_START_LATENCY)
-        .record(
-            Duration.ofNanos(
-                result.getStartedTimestamp() - result.getScheduledTimestampOfThisAttempt()));
-    sw.stop();
     return result;
   }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityPollTaskBase.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityPollTaskBase.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import com.uber.cadence.PollForActivityTaskResponse;
+import com.uber.cadence.internal.metrics.MetricsType;
+import com.uber.m3.tally.Stopwatch;
+import com.uber.m3.util.Duration;
+import org.apache.thrift.TException;
+
+abstract class ActivityPollTaskBase implements Poller.PollTask<PollForActivityTaskResponse> {
+
+  protected final SingleWorkerOptions options;
+
+  public ActivityPollTaskBase(SingleWorkerOptions options) {
+    this.options = options;
+  }
+
+  public PollForActivityTaskResponse poll() throws TException {
+    Stopwatch sw = options.getMetricsScope().timer(MetricsType.ACTIVITY_POLL_LATENCY).start();
+    PollForActivityTaskResponse result = pollTask();
+    if (result == null || result.getTaskToken() == null) {
+      return null;
+    }
+    options.getMetricsScope().counter(MetricsType.ACTIVITY_POLL_SUCCEED_COUNTER).inc(1);
+    options
+        .getMetricsScope()
+        .timer(MetricsType.ACTIVITY_SCHEDULED_TO_START_LATENCY)
+        .record(
+            Duration.ofNanos(
+                result.getStartedTimestamp() - result.getScheduledTimestampOfThisAttempt()));
+    sw.stop();
+    return result;
+  }
+
+  protected abstract PollForActivityTaskResponse pollTask() throws TException;
+}

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityPollTaskBase.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityPollTaskBase.java
@@ -19,7 +19,6 @@ package com.uber.cadence.internal.worker;
 
 import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.internal.metrics.MetricsType;
-import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.Duration;
 import org.apache.thrift.TException;
 
@@ -32,7 +31,7 @@ abstract class ActivityPollTaskBase implements Poller.PollTask<PollForActivityTa
   }
 
   public PollForActivityTaskResponse poll() throws TException {
-    Stopwatch sw = options.getMetricsScope().timer(MetricsType.ACTIVITY_POLL_LATENCY).start();
+
     PollForActivityTaskResponse result = pollTask();
     if (result == null || result.getTaskToken() == null) {
       return null;
@@ -44,7 +43,6 @@ abstract class ActivityPollTaskBase implements Poller.PollTask<PollForActivityTa
         .record(
             Duration.ofNanos(
                 result.getStartedTimestamp() - result.getScheduledTimestampOfThisAttempt()));
-    sw.stop();
     return result;
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
@@ -57,6 +57,15 @@ public class ActivityWorker extends SuspendableWorkerBase {
       String domain,
       String taskList,
       SingleWorkerOptions options,
+      ActivityTaskHandler handler) {
+    this(service, domain, taskList, options, handler, "Activity Poller taskList=");
+  }
+
+  public ActivityWorker(
+      IWorkflowService service,
+      String domain,
+      String taskList,
+      SingleWorkerOptions options,
       ActivityTaskHandler handler,
       String pollThreadNamePrefix) {
     this.service = Objects.requireNonNull(service);

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
@@ -46,16 +46,15 @@ final class LocallyDispatchedActivityPollTask extends ActivityPollTaskBase
       throw new RuntimeException("locally dispatch activity poll task interrupted", e);
     }
     try {
-      task.latch.await();
+      if (!task.await()) {
+        options
+            .getMetricsScope()
+            .counter(MetricsType.LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK__COUNTER)
+            .inc(1);
+        return null;
+      }
     } catch (InterruptedException e) {
       throw new RuntimeException("locally dispatch activity await task interrupted", e);
-    }
-    if (!task.ready) {
-      options
-          .getMetricsScope()
-          .counter(MetricsType.LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK__COUNTER)
-          .inc(1);
-      return null;
     }
     options.getMetricsScope().counter(MetricsType.ACTIVITY_POLL_COUNTER).inc(1);
     options

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
@@ -49,7 +49,7 @@ final class LocallyDispatchedActivityPollTask extends ActivityPollTaskBase
       if (!task.await()) {
         options
             .getMetricsScope()
-            .counter(MetricsType.LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK__COUNTER)
+            .counter(MetricsType.LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK_COUNTER)
             .inc(1);
         return null;
       }

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
@@ -82,6 +82,7 @@ final class LocallyDispatchedActivityPollTask extends ActivityPollTaskBase
 
   @Override
   public Boolean apply(Task task) {
+    // non blocking put to the unbuffered queue
     return pendingTasks.offer(task);
   }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityPollTask.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import com.uber.cadence.PollForActivityTaskResponse;
+import com.uber.cadence.internal.metrics.MetricsType;
+import com.uber.cadence.internal.worker.LocallyDispatchedActivityWorker.Task;
+import java.util.concurrent.SynchronousQueue;
+import java.util.function.Function;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class LocallyDispatchedActivityPollTask extends ActivityPollTaskBase
+    implements Function<Task, Boolean> {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(LocallyDispatchedActivityPollTask.class);
+  private final SynchronousQueue<Task> pendingTasks = new SynchronousQueue<>();
+
+  public LocallyDispatchedActivityPollTask(SingleWorkerOptions options) {
+    super(options);
+  }
+
+  @Override
+  protected PollForActivityTaskResponse pollTask() throws TException {
+    Task task;
+    try {
+      task = pendingTasks.take();
+    } catch (InterruptedException e) {
+      throw new RuntimeException("locally dispatch activity poll task interrupted", e);
+    }
+    try {
+      task.latch.await();
+    } catch (InterruptedException e) {
+      throw new RuntimeException("locally dispatch activity await task interrupted", e);
+    }
+    if (!task.ready) {
+      options
+          .getMetricsScope()
+          .counter(MetricsType.LOCALLY_DISPATCHED_ACTIVITY_POLL_NO_TASK__COUNTER)
+          .inc(1);
+      return null;
+    }
+    options.getMetricsScope().counter(MetricsType.ACTIVITY_POLL_COUNTER).inc(1);
+    options
+        .getMetricsScope()
+        .counter(MetricsType.LOCALLY_DISPATCHED_ACTIVITY_POLL_SUCCEED_COUNTER)
+        .inc(1);
+    PollForActivityTaskResponse result = new PollForActivityTaskResponse();
+    result.activityId = task.activityId;
+    result.activityType = task.activityType;
+    result.header = task.header;
+    result.input = task.input;
+    result.workflowExecution = task.workflowExecution;
+    result.scheduledTimestampOfThisAttempt = task.scheduledTimestampOfThisAttempt;
+    result.scheduledTimestamp = task.scheduledTimestamp;
+    result.scheduleToCloseTimeoutSeconds = task.scheduleToCloseTimeoutSeconds;
+    result.startedTimestamp = task.startedTimestamp;
+    result.startToCloseTimeoutSeconds = task.startToCloseTimeoutSeconds;
+    result.heartbeatTimeoutSeconds = task.heartbeatTimeoutSeconds;
+    result.taskToken = task.taskToken;
+    result.workflowType = task.workflowType;
+    result.workflowDomain = task.workflowDomain;
+    result.attempt = 0;
+    return result;
+  }
+
+  @Override
+  public Boolean apply(Task task) {
+    return pendingTasks.offer(task);
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import com.uber.cadence.ActivityType;
+import com.uber.cadence.Header;
+import com.uber.cadence.PollForActivityTaskResponse;
+import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.WorkflowType;
+import com.uber.cadence.internal.worker.Poller.PollTask;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+
+public final class LocallyDispatchedActivityWorker extends ActivityWorker {
+
+  private LocallyDispatchedActivityPollTask ldaPollTask;
+
+  public LocallyDispatchedActivityWorker(
+      IWorkflowService service,
+      String domain,
+      String taskList,
+      SingleWorkerOptions options,
+      ActivityTaskHandler handler) {
+    super(service, domain, taskList, options, handler);
+  }
+
+  protected PollTask<PollForActivityTaskResponse> createActivityPollTask() {
+    ldaPollTask = new LocallyDispatchedActivityPollTask(options);
+    return ldaPollTask;
+  }
+
+  protected String GetPollThreadNamePrefix() {
+    return "Locally Dispatched Activity Poller taskList=";
+  }
+
+  public Function<Task, Boolean> getLocallyDispatchedActivityTaskPoller() {
+    return ldaPollTask;
+  }
+
+  public static class Task {
+
+    // used to notify the poller the response from server is completed and the task is ready
+    protected final CountDownLatch latch = new CountDownLatch(1);
+    protected final ByteBuffer taskToken;
+    protected final WorkflowExecution workflowExecution;
+    protected final String activityId;
+    protected final ActivityType activityType;
+    protected final ByteBuffer input;
+    protected final long scheduledTimestamp;
+    protected final int scheduleToCloseTimeoutSeconds;
+    protected final long startedTimestamp;
+    protected final int startToCloseTimeoutSeconds;
+    protected final int heartbeatTimeoutSeconds;
+    protected final long scheduledTimestampOfThisAttempt;
+    protected final WorkflowType workflowType;
+    protected final String workflowDomain;
+    protected final Header header;
+    protected boolean ready;
+
+    public Task(
+        ByteBuffer taskToken,
+        WorkflowExecution workflowExecution,
+        String activityId,
+        ActivityType activityType,
+        ByteBuffer input,
+        long scheduledTimestamp,
+        int scheduleToCloseTimeoutSeconds,
+        long startedTimestamp,
+        int startToCloseTimeoutSeconds,
+        int heartbeatTimeoutSeconds,
+        long scheduledTimestampOfThisAttempt,
+        WorkflowType workflowType,
+        String workflowDomain,
+        Header header) {
+      this.taskToken = taskToken;
+      this.workflowExecution = workflowExecution;
+      this.activityId = activityId;
+      this.activityType = activityType;
+      this.input = input;
+      this.scheduledTimestamp = scheduledTimestamp;
+      this.scheduleToCloseTimeoutSeconds = scheduleToCloseTimeoutSeconds;
+      this.startedTimestamp = startedTimestamp;
+      this.startToCloseTimeoutSeconds = startToCloseTimeoutSeconds;
+      this.heartbeatTimeoutSeconds = heartbeatTimeoutSeconds;
+      this.scheduledTimestampOfThisAttempt = scheduledTimestampOfThisAttempt;
+      this.workflowType = workflowType;
+      this.workflowDomain = workflowDomain;
+      this.header = header;
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
@@ -57,7 +57,8 @@ public final class LocallyDispatchedActivityWorker extends ActivityWorker {
   public static class Task {
 
     // used to notify the poller the response from server is completed and the task is ready
-    protected final CountDownLatch latch = new CountDownLatch(1);
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private boolean ready;
     protected final ByteBuffer taskToken;
     protected final WorkflowExecution workflowExecution;
     protected final String activityId;
@@ -72,7 +73,6 @@ public final class LocallyDispatchedActivityWorker extends ActivityWorker {
     protected final WorkflowType workflowType;
     protected final String workflowDomain;
     protected final Header header;
-    protected boolean ready;
 
     public Task(
         ByteBuffer taskToken,
@@ -103,6 +103,16 @@ public final class LocallyDispatchedActivityWorker extends ActivityWorker {
       this.workflowType = workflowType;
       this.workflowDomain = workflowDomain;
       this.header = header;
+    }
+
+    public boolean await() throws InterruptedException {
+      latch.await();
+      return ready;
+    }
+
+    public void notify(boolean ready) {
+      this.ready = ready;
+      latch.countDown();
     }
   }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
@@ -58,7 +58,7 @@ public final class LocallyDispatchedActivityWorker extends ActivityWorker {
 
     // used to notify the poller the response from server is completed and the task is ready
     private final CountDownLatch latch = new CountDownLatch(1);
-    private boolean ready;
+    private volatile boolean ready;
     protected final ByteBuffer taskToken;
     protected final WorkflowExecution workflowExecution;
     protected final String activityId;

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
@@ -38,16 +38,18 @@ public final class LocallyDispatchedActivityWorker extends ActivityWorker {
       String taskList,
       SingleWorkerOptions options,
       ActivityTaskHandler handler) {
-    super(service, domain, taskList, options, handler);
-  }
-
-  protected PollTask<PollForActivityTaskResponse> createActivityPollTask() {
+    super(
+        service,
+        domain,
+        taskList,
+        options,
+        handler,
+        "Locally Dispatched Activity Poller taskList=");
     ldaPollTask = new LocallyDispatchedActivityPollTask(options);
-    return ldaPollTask;
   }
 
-  protected String GetPollThreadNamePrefix() {
-    return "Locally Dispatched Activity Poller taskList=";
+  protected PollTask<PollForActivityTaskResponse> getOrCreateActivityPollTask() {
+    return ldaPollTask;
   }
 
   public Function<Task, Boolean> getLocallyDispatchedActivityTaskPoller() {
@@ -56,50 +58,42 @@ public final class LocallyDispatchedActivityWorker extends ActivityWorker {
 
   public static class Task {
 
-    // used to notify the poller the response from server is completed and the task is ready
-    private final CountDownLatch latch = new CountDownLatch(1);
-    private volatile boolean ready;
-    protected final ByteBuffer taskToken;
     protected final WorkflowExecution workflowExecution;
     protected final String activityId;
     protected final ActivityType activityType;
     protected final ByteBuffer input;
-    protected final long scheduledTimestamp;
     protected final int scheduleToCloseTimeoutSeconds;
-    protected final long startedTimestamp;
     protected final int startToCloseTimeoutSeconds;
     protected final int heartbeatTimeoutSeconds;
-    protected final long scheduledTimestampOfThisAttempt;
     protected final WorkflowType workflowType;
     protected final String workflowDomain;
     protected final Header header;
+    // used to notify the poller the response from server is completed and the task is ready
+    private final CountDownLatch latch = new CountDownLatch(1);
+    protected long scheduledTimestamp;
+    protected long scheduledTimestampOfThisAttempt;
+    protected long startedTimestamp;
+    protected ByteBuffer taskToken;
+    private volatile boolean ready;
 
     public Task(
-        ByteBuffer taskToken,
-        WorkflowExecution workflowExecution,
         String activityId,
         ActivityType activityType,
         ByteBuffer input,
-        long scheduledTimestamp,
         int scheduleToCloseTimeoutSeconds,
-        long startedTimestamp,
         int startToCloseTimeoutSeconds,
         int heartbeatTimeoutSeconds,
-        long scheduledTimestampOfThisAttempt,
         WorkflowType workflowType,
         String workflowDomain,
-        Header header) {
-      this.taskToken = taskToken;
+        Header header,
+        WorkflowExecution workflowExecution) {
       this.workflowExecution = workflowExecution;
       this.activityId = activityId;
       this.activityType = activityType;
       this.input = input;
-      this.scheduledTimestamp = scheduledTimestamp;
       this.scheduleToCloseTimeoutSeconds = scheduleToCloseTimeoutSeconds;
-      this.startedTimestamp = startedTimestamp;
       this.startToCloseTimeoutSeconds = startToCloseTimeoutSeconds;
       this.heartbeatTimeoutSeconds = heartbeatTimeoutSeconds;
-      this.scheduledTimestampOfThisAttempt = scheduledTimestampOfThisAttempt;
       this.workflowType = workflowType;
       this.workflowDomain = workflowDomain;
       this.header = header;

--- a/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocallyDispatchedActivityWorker.java
@@ -105,7 +105,7 @@ public final class LocallyDispatchedActivityWorker extends ActivityWorker {
       this.header = header;
     }
 
-    public boolean await() throws InterruptedException {
+    protected boolean await() throws InterruptedException {
       latch.await();
       return ready;
     }

--- a/src/main/java/com/uber/cadence/worker/Worker.java
+++ b/src/main/java/com/uber/cadence/worker/Worker.java
@@ -124,6 +124,7 @@ public final class Worker implements Suspendable {
             this.options.getInterceptorFactory(),
             workflowOptions,
             localActivityOptions,
+            activityOptions,
             cache,
             stickyTaskListName,
             stickyDecisionScheduleToStartTimeout,
@@ -234,6 +235,7 @@ public final class Worker implements Suspendable {
 
     if (activityWorker != null) {
       activityWorker.setActivitiesImplementation(activityImplementations);
+      workflowWorker.setActivitiesImplementationToDispatchLocally(activityImplementations);
     }
 
     workflowWorker.setLocalActivitiesImplementation(activityImplementations);


### PR DESCRIPTION
The activity dispatch optimization feature to allow worker to dispatch activity tasks through local tunnel after decisions are made. If the activity execution fails the retry(if any) goes the regular path(poll from server).
This is a performance optimization to skip activity scheduling efforts.

The corresponding server pr uber/cadence#3609

How did you test it?
existing integration and load tests
probably we need to update test environment as a follow up

Potential risks
No risk. It gets enabled per domain by server and off by default