### PR TITLE
Prevent iterator panic and add error log

### DIFF
--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implements decider that relies on replay of a workflow code. An instance of this class is created
- * per decision.
+ * per decision. 
  */
 class ReplayDecider implements Decider {
 

--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -48,6 +48,7 @@ import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -682,7 +683,8 @@ class ReplayDecider implements Decider {
             throw new Error(e);
           }
           if (!current.hasNext()) {
-            log.error("GetWorkflowExecutionHistory return empty history, maybe a bug in server, token:" + request.getNextPageToken());
+            log.error("GetWorkflowExecutionHistory return empty history, maybe a bug in server, token:"
+                    + Arrays.toString(request.getNextPageToken()));
             throw new Error("GetWorkflowExecutionHistory return empty history, maybe a bug in server");
           }
           return current.next();

--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implements decider that relies on replay of a workflow code. An instance of this class is created
- * per decision. 
+ * per decision.  
  */
 class ReplayDecider implements Decider {
 


### PR DESCRIPTION
For https://github.com/uber/cadence-java-client/issues/565
Per discussion in slack channel, we want to add a check and error log for this case. 