### PR TITLE
Updating link to java docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ or to *build.gradle*:
 
 ## Documentation
 
-The documentation on how to use the Cadence Java client is [here](https://cadenceworkflow.io/docs/06_javaclient/).
+The documentation on how to use the Cadence Java client is [here](https://cadenceworkflow.io/docs/java-client/).
 
 Javadocs for the client API are located [here](https://www.javadoc.io/doc/com.uber.cadence/cadence-client).
 


### PR DESCRIPTION
Link outdated since refresh of public site.
Link now updated to point to correct URL.

Closes #516 