### PR TITLE
Add register workflow methods in shadower

### DIFF
--- a/src/main/java/com/uber/cadence/testing/WorkflowShadower.java
+++ b/src/main/java/com/uber/cadence/testing/WorkflowShadower.java
@@ -26,6 +26,8 @@ import com.uber.cadence.shadower.ReplayWorkflowActivityResult;
 import com.uber.cadence.shadower.ScanWorkflowActivityParams;
 import com.uber.cadence.shadower.ScanWorkflowActivityResult;
 import com.uber.cadence.worker.ShadowingOptions;
+import com.uber.cadence.worker.WorkflowImplementationOptions;
+import com.uber.cadence.workflow.Functions;
 import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.Scope;
 import java.time.Duration;
@@ -113,6 +115,28 @@ public final class WorkflowShadower {
         Thread.sleep(SLEEP_INTERVAL);
       }
     } while (nextPageToken != null && options.getShadowMode() == Mode.Normal);
+  }
+
+  public void registerWorkflowImplementationTypes(Class<?>... workflowImplementationClasses) {
+    replayWorkflow.registerWorkflowImplementationTypes(workflowImplementationClasses);
+  }
+
+  public void registerWorkflowImplementationTypes(
+      WorkflowImplementationOptions options, Class<?>... workflowImplementationClasses) {
+    replayWorkflow.registerWorkflowImplementationTypesWithOptions(
+        options, workflowImplementationClasses);
+  }
+
+  public <R> void addWorkflowImplementationFactory(
+      WorkflowImplementationOptions options,
+      Class<R> workflowInterface,
+      Functions.Func<R> factory) {
+    replayWorkflow.addWorkflowImplementationFactoryWithOptions(options, workflowInterface, factory);
+  }
+
+  public <R> void addWorkflowImplementationFactory(
+      Class<R> workflowInterface, Functions.Func<R> factory) {
+    replayWorkflow.addWorkflowImplementationFactory(workflowInterface, factory);
   }
 
   private ShadowingOptions validateShadowingOptions(ShadowingOptions options) {

--- a/src/main/java/com/uber/cadence/testing/WorkflowShadower.java
+++ b/src/main/java/com/uber/cadence/testing/WorkflowShadower.java
@@ -15,6 +15,7 @@
  */
 package com.uber.cadence.testing;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.uber.cadence.internal.shadowing.ReplayWorkflowActivity;
 import com.uber.cadence.internal.shadowing.ReplayWorkflowActivityImpl;
 import com.uber.cadence.internal.shadowing.ReplayWorkflowActivityResult;
@@ -55,6 +56,7 @@ public final class WorkflowShadower {
         new ReplayWorkflowActivityImpl(service, metricsScope, taskList));
   }
 
+  @VisibleForTesting
   public WorkflowShadower(
       ShadowingOptions options,
       ScanWorkflowActivity scanWorkflow,


### PR DESCRIPTION
1. What change?
Add register workflow methods in shadower

2. Why?
User can register the workflow instead of pass the activity instance in.