### PR TITLE
Add binaryChecksum support to JDK

### DIFF
--- a/src/main/java/com/uber/cadence/common/BinaryChecksum.java
+++ b/src/main/java/com/uber/cadence/common/BinaryChecksum.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.common;
+
+public final class BinaryChecksum {
+
+  private static String binaryChecksum;
+
+  private BinaryChecksum() {}
+
+  public static String getBinaryChecksum() {
+    // TODO: should set the binaryChecksum to some auto generated value if it's empty
+    return binaryChecksum;
+  }
+
+  public static synchronized void setBinaryChecksum(String checksum) {
+    if (binaryChecksum != null || checksum == null || checksum.isEmpty()) {
+      return;
+    }
+    binaryChecksum = checksum;
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowPollTask.java
@@ -22,6 +22,7 @@ import com.uber.cadence.PollForDecisionTaskRequest;
 import com.uber.cadence.PollForDecisionTaskResponse;
 import com.uber.cadence.ServiceBusyError;
 import com.uber.cadence.TaskList;
+import com.uber.cadence.common.BinaryChecksum;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
@@ -64,6 +65,7 @@ final class WorkflowPollTask implements Poller.PollTask<PollForDecisionTaskRespo
     PollForDecisionTaskRequest pollRequest = new PollForDecisionTaskRequest();
     pollRequest.setDomain(domain);
     pollRequest.setIdentity(identity);
+    pollRequest.setBinaryChecksum(BinaryChecksum.getBinaryChecksum());
 
     TaskList tl = new TaskList();
     tl.setName(taskList);

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
@@ -33,6 +33,7 @@ import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionStartedEventAttributes;
 import com.uber.cadence.WorkflowQuery;
 import com.uber.cadence.WorkflowType;
+import com.uber.cadence.common.BinaryChecksum;
 import com.uber.cadence.common.WorkflowExecutionHistory;
 import com.uber.cadence.internal.common.RpcRetryer;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
@@ -248,6 +249,7 @@ public final class WorkflowWorker extends SuspendableWorkerBase
       if (taskCompleted != null) {
         taskCompleted.setIdentity(options.getIdentity());
         taskCompleted.setTaskToken(task.getTaskToken());
+        taskCompleted.setBinaryChecksum(BinaryChecksum.getBinaryChecksum());
         RpcRetryer.retry(
             () -> {
               RespondDecisionTaskCompletedResponse taskCompletedResponse = null;
@@ -321,6 +323,7 @@ public final class WorkflowWorker extends SuspendableWorkerBase
         if (taskFailed != null) {
           taskFailed.setIdentity(options.getIdentity());
           taskFailed.setTaskToken(task.getTaskToken());
+          taskFailed.setBinaryChecksum(BinaryChecksum.getBinaryChecksum());
           RpcRetryer.retry(() -> service.RespondDecisionTaskFailed(taskFailed));
         } else {
           RespondQueryTaskCompletedRequest queryCompleted = response.getQueryCompleted();

--- a/src/test/java/com/uber/cadence/common/BinaryChecksumTest.java
+++ b/src/test/java/com/uber/cadence/common/BinaryChecksumTest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BinaryChecksumTest {
+  @Test
+  public void testSetBinaryChecksum() {
+    BinaryChecksum.setBinaryChecksum("123");
+    BinaryChecksum.setBinaryChecksum("456");
+    Assert.assertEquals("123", BinaryChecksum.getBinaryChecksum());
+  }
+}


### PR DESCRIPTION
What?
Set binaryChecksum value in RespondDecisionTaskCompletedRequest, RespondDecisionTaskFailedRequest and PollForDecisionTaskRequest.

Why?
BinaryChecksum is an identifier of application, which is used to help find backward compatibility issue. 

Test?
unit test.