### PR TITLE
add all missing version marker before upsert searchattributes

### DIFF
--- a/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionsHelper.java
@@ -558,6 +558,8 @@ class DecisionsHelper {
   }
 
   void upsertSearchAttributes(SearchAttributes searchAttributes) {
+    addAllMissingVersionMarker(false, Optional.empty());
+
     UpsertWorkflowSearchAttributesDecisionAttributes decisionAttr =
         new UpsertWorkflowSearchAttributesDecisionAttributes()
             .setSearchAttributes(searchAttributes);


### PR DESCRIPTION
why?

We allow user to remove `getversion` call in their workflows. Current implementation throws a non-deterministic error if the `getversion` call before `upsertsearchattributes` is removed

test?
new unit test