### PR TITLE
Make client to be Java 11 compatible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This doc is intended for contributors to `cadence-java-client` (hopefully that's
 
 ## Development Environment
 
-* Java 8.
+* Java 11 (currently, we use Java 11 to compile Java 8 code).
 * Thrift 0.9.3
 * Gradle build tool
 * Docker

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ java {
 
 dependencies {
     errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-    errorprone('com.google.errorprone:error_prone_core:2.3.3')
+    errorprone('com.google.errorprone:error_prone_core:2.3.4')
 
     compile group: 'com.uber.tchannel', name: 'tchannel-core', version: '0.8.5'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
@@ -61,6 +61,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '28.1-jre'
     compile group: 'com.cronutils', name: 'cron-utils', version: '9.0.0'
     compile group: 'io.micrometer', name: 'micrometer-core', version: '1.1.2'
+    compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM adoptopenjdk/openjdk11:alpine
 
 # Apache Thrift version
 ENV APACHE_THRIFT_VERSION=0.9.3
@@ -6,7 +6,7 @@ ENV APACHE_THRIFT_VERSION=0.9.3
 # Install dependencies using apk
 RUN apk update && apk add --virtual wget ca-certificates wget && apk add --virtual build-dependencies build-base gcc
 # Git is needed in order to update the dls submodule
-RUN apk add --virtual git
+RUN apk add git libstdc++
 
 # Compile source
 RUN set -ex ;\

--- a/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
+++ b/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
@@ -189,11 +189,13 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
           isLocalActivity);
     }
     if (metricsRateLimiter.tryAcquire(1)) {
-        if (isLocalActivity) {
-            metricsScope.gauge(MetricsType.LOCAL_ACTIVITY_ACTIVE_THREAD_COUNT).update(Thread.activeCount());
-        } else {
-            metricsScope.gauge(MetricsType.ACTIVITY_ACTIVE_THREAD_COUNT).update(Thread.activeCount());
-        }
+      if (isLocalActivity) {
+        metricsScope
+            .gauge(MetricsType.LOCAL_ACTIVITY_ACTIVE_THREAD_COUNT)
+            .update(Thread.activeCount());
+      } else {
+        metricsScope.gauge(MetricsType.ACTIVITY_ACTIVE_THREAD_COUNT).update(Thread.activeCount());
+      }
     }
     return activity.execute(activityTask, metricsScope);
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/DecisionTaskToken.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/DecisionTaskToken.java
@@ -33,7 +33,7 @@ final class DecisionTaskToken {
 
   DecisionTaskToken(ExecutionId executionId, int historySize) {
     this.executionId = Objects.requireNonNull(executionId);
-    this.historySize = Objects.requireNonNull(historySize);
+    this.historySize = historySize;
   }
 
   ExecutionId getExecutionId() {

--- a/src/test/java/com/uber/cadence/converter/JsonDataConverterTest.java
+++ b/src/test/java/com/uber/cadence/converter/JsonDataConverterTest.java
@@ -260,7 +260,7 @@ public class JsonDataConverterTest {
     assertNotNull(causeFromConverted);
     assertEquals(DataConverterException.class, causeFromConverted.getClass());
     assertNotNull(causeFromConverted.getCause());
-    assertEquals(StackOverflowError.class, causeFromConverted.getCause().getClass());
+    assertEquals(IllegalArgumentException.class, causeFromConverted.getCause().getClass());
 
     assertNotNull(causeFromConverted.getSuppressed());
     assertEquals(1, causeFromConverted.getSuppressed().length);

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -965,7 +965,7 @@ public class WorkflowTest {
     WorkflowStub workflowStub =
         workflowClient.newUntypedWorkflowStub(
             "TestWorkflow1::execute", newWorkflowOptionsBuilder(taskList).build());
-    Long timeout = new Long(200);
+    Long timeout = Long.valueOf(200);
     CompletableFuture<WorkflowExecution> future =
         workflowStub.startAsyncWithTimeout(timeout, TimeUnit.MILLISECONDS, taskList);
     testUntypedAndStackTraceHelper(workflowStub, future.get());
@@ -3309,7 +3309,7 @@ public class WorkflowTest {
     CompletableFuture<WorkflowExecution> future = workflowStub.startAsync(taskList);
     future.get();
 
-    Long timeout = new Long(200);
+    Long timeout = Long.valueOf(200);
     String testSignalInput = "hello";
     CompletableFuture<String> resultFuture =
         workflowStub


### PR DESCRIPTION
what?

Make client to be Java 11 compatible. Use Java 11 to compile Java 8 code and release Java 8 bytecode to prepare for future migartion.

