### PR TITLE
Fix race condition in BinaryCheksum

### DIFF
--- a/src/main/java/com/uber/cadence/common/BinaryChecksum.java
+++ b/src/main/java/com/uber/cadence/common/BinaryChecksum.java
@@ -23,7 +23,7 @@ public final class BinaryChecksum {
 
   private BinaryChecksum() {}
 
-  public static String getBinaryChecksum() {
+  public static synchronized String getBinaryChecksum() {
     // TODO: should set the binaryChecksum to some auto generated value if it's empty
     return binaryChecksum;
   }


### PR DESCRIPTION
What?

Make getter in BinaryChecksum synchronized.

Why?
To avoid dirty read.