### PR TITLE
Handle workflowCompleted error in java client

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
+++ b/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
@@ -189,11 +189,13 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
           isLocalActivity);
     }
     if (metricsRateLimiter.tryAcquire(1)) {
-        if (isLocalActivity) {
-            metricsScope.gauge(MetricsType.LOCAL_ACTIVITY_ACTIVE_THREAD_COUNT).update(Thread.activeCount());
-        } else {
-            metricsScope.gauge(MetricsType.ACTIVITY_ACTIVE_THREAD_COUNT).update(Thread.activeCount());
-        }
+      if (isLocalActivity) {
+        metricsScope
+            .gauge(MetricsType.LOCAL_ACTIVITY_ACTIVE_THREAD_COUNT)
+            .update(Thread.activeCount());
+      } else {
+        metricsScope.gauge(MetricsType.ACTIVITY_ACTIVE_THREAD_COUNT).update(Thread.activeCount());
+      }
     }
     return activity.execute(activityTask, metricsScope);
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableState.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableState.java
@@ -64,46 +64,57 @@ interface TestWorkflowMutableState {
   StartWorkflowExecutionRequest getStartRequest();
 
   void startDecisionTask(PollForDecisionTaskResponse task, PollForDecisionTaskRequest pollRequest)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void completeDecisionTask(int historySize, RespondDecisionTaskCompletedRequest request)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void completeSignalExternalWorkflowExecution(String signalId, String runId)
-      throws EntityNotExistsError, InternalServiceError, BadRequestError;
+      throws EntityNotExistsError, InternalServiceError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void failSignalExternalWorkflowExecution(
       String signalId, SignalExternalWorkflowExecutionFailedCause cause)
-      throws EntityNotExistsError, InternalServiceError, BadRequestError;
+      throws EntityNotExistsError, InternalServiceError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void failDecisionTask(RespondDecisionTaskFailedRequest request)
       throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
           BadRequestError;
 
   void childWorkflowStarted(ChildWorkflowExecutionStartedEventAttributes a)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void childWorkflowFailed(String workflowId, ChildWorkflowExecutionFailedEventAttributes a)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void childWorkflowTimedOut(String activityId, ChildWorkflowExecutionTimedOutEventAttributes a)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void failStartChildWorkflow(String workflowId, StartChildWorkflowExecutionFailedEventAttributes a)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void childWorkflowCompleted(String workflowId, ChildWorkflowExecutionCompletedEventAttributes a)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void childWorkflowCanceled(String workflowId, ChildWorkflowExecutionCanceledEventAttributes a)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void startWorkflow(
       boolean continuedAsNew, Optional<SignalWorkflowExecutionRequest> signalWithStartSignal)
       throws InternalServiceError, BadRequestError;
 
   void startActivityTask(PollForActivityTaskResponse task, PollForActivityTaskRequest pollRequest)
-      throws InternalServiceError, EntityNotExistsError, BadRequestError;
+      throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,
+          BadRequestError;
 
   void completeActivityTask(String activityId, RespondActivityTaskCompletedRequest request)
       throws InternalServiceError, EntityNotExistsError, WorkflowExecutionAlreadyCompletedError,

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -591,9 +591,6 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
       }
-      if (result.isSetEntityNotExistError()) {
-        throw result.getEntityNotExistError();
-      }
       throw new TException("GetWorkflowExecutionHistory failed with unknown error:" + result);
     } finally {
       if (response != null) {
@@ -704,6 +701,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
       }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
+      }
       if (result.isSetClientVersionNotSupportedError()) {
         throw result.getClientVersionNotSupportedError();
       }
@@ -742,6 +742,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
       }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
+      }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
       }
@@ -750,9 +753,6 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetLimitExceededError()) {
         throw result.getLimitExceededError();
-      }
-      if (result.isSetEntityNotExistError()) {
-        throw result.getEntityNotExistError();
       }
       if (result.isSetClientVersionNotSupportedError()) {
         throw result.getClientVersionNotSupportedError();
@@ -840,6 +840,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
       }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
+      }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
       }
@@ -890,6 +893,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
       }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
+      }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
       }
@@ -936,6 +942,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
+      }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
       }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
@@ -985,6 +994,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
       }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
+      }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
       }
@@ -1031,6 +1043,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
+      }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
       }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
@@ -1080,6 +1095,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
       }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
+      }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
       }
@@ -1126,6 +1144,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
+      }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
       }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
@@ -1174,6 +1195,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
+      }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
       }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
@@ -1224,6 +1248,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
       }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
+      }
       if (result.isSetCancellationAlreadyRequestedError()) {
         throw result.getCancellationAlreadyRequestedError();
       }
@@ -1272,6 +1299,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
+      }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
       }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
@@ -1420,6 +1450,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
+      }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
       }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
@@ -1846,6 +1879,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       }
       if (result.isSetEntityNotExistError()) {
         throw result.getEntityNotExistError();
+      }
+      if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+        throw result.getWorkflowExecutionAlreadyCompletedError();
       }
       if (result.isSetServiceBusyError()) {
         throw result.getServiceBusyError();
@@ -2330,6 +2366,10 @@ public class WorkflowServiceTChannel implements IWorkflowService {
                 }
                 if (result.isSetEntityNotExistError()) {
                   resultHandler.onError(result.getEntityNotExistError());
+                  return;
+                }
+                if (result.isSetWorkflowExecutionAlreadyCompletedError()) {
+                  resultHandler.onError(result.getWorkflowExecutionAlreadyCompletedError());
                   return;
                 }
                 if (result.isSetServiceBusyError()) {

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -30,14 +30,21 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.uber.cadence.BadRequestError;
+import com.uber.cadence.CancellationAlreadyRequestedError;
+import com.uber.cadence.DomainAlreadyExistsError;
+import com.uber.cadence.DomainNotActiveError;
+import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
 import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.Memo;
+import com.uber.cadence.QueryFailedError;
 import com.uber.cadence.QueryRejectCondition;
 import com.uber.cadence.SearchAttributes;
 import com.uber.cadence.SignalExternalWorkflowExecutionFailedCause;
 import com.uber.cadence.TimeoutType;
 import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.WorkflowExecutionAlreadyCompletedError;
 import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
 import com.uber.cadence.WorkflowExecutionCloseStatus;
 import com.uber.cadence.WorkflowIdReusePolicy;
@@ -2430,6 +2437,76 @@ public class WorkflowTest {
         "Hello World!",
         workflowClient.newUntypedWorkflowStub(execution, Optional.empty()).getResult(String.class));
     client2.execute();
+  }
+
+  // Simple workflow completes immediately after it starts. This workflow
+  // will be used to test sending signals to completed workflows
+  public static class TestSimpleWorkflowImpl implements QueryableWorkflow {
+    @Override
+    public String execute() {
+      return "Execution complete";
+    }
+
+    @Override
+    public String getState() {
+      return "simple_state";
+    }
+
+    @Override
+    public void mySignal(String value) {
+      log.info("#### You should never see this line ####");
+    }
+  }
+
+  @Test
+  public void testSignalingCompletedWorkflow() {
+    Worker queryWorker;
+    if (useExternalService) {
+      WorkerFactory workerFactory = WorkerFactory.newInstance(workflowClient);
+      queryWorker = workerFactory.newWorker(taskList);
+    } else {
+      queryWorker = testEnvironment.newWorker(taskList);
+    }
+    queryWorker.registerWorkflowImplementationTypes(TestSimpleWorkflowImpl.class);
+    startWorkerFor(TestSimpleWorkflowImpl.class);
+
+    String workflowId = UUID.randomUUID().toString();
+    WorkflowOptions.Builder optionsBuilder = newWorkflowOptionsBuilder(taskList);
+    RetryOptions workflowRetryOptions =
+        new RetryOptions.Builder()
+            .setInitialInterval(Duration.ofSeconds(1))
+            .setExpiration(Duration.ofSeconds(1))
+            .setMaximumAttempts(1)
+            .setBackoffCoefficient(1.0)
+            .setDoNotRetry(
+                BadRequestError.class,
+                EntityNotExistsError.class,
+                WorkflowExecutionAlreadyCompletedError.class,
+                WorkflowExecutionAlreadyStartedError.class,
+                DomainAlreadyExistsError.class,
+                QueryFailedError.class,
+                DomainNotActiveError.class,
+                CancellationAlreadyRequestedError.class)
+            .build();
+    optionsBuilder.setRetryOptions(workflowRetryOptions);
+    optionsBuilder.setWorkflowId(workflowId);
+    QueryableWorkflow client =
+        workflowClient.newWorkflowStub(QueryableWorkflow.class, optionsBuilder.build());
+
+    // This completes the workflow, workflow won't receive the signal after here
+    client.execute();
+
+    try {
+      client.mySignal("Hello!");
+      assert (false); // Signal call should throw an exception, so fail if it doesn't
+    } catch (Exception e) {
+      if (e.getCause().getClass() != WorkflowExecutionAlreadyCompletedError.class
+          && e.getCause().getClass() != EntityNotExistsError.class // only for legacy servers
+      ) {
+        // Using assertEquals to output the actual error
+        assertEquals(WorkflowExecutionAlreadyCompletedError.class, e.getCause().getClass());
+      }
+    }
   }
 
   public static class TestSignalWithStartWorkflowImpl implements QueryableWorkflow {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
With this PR (https://github.com/uber/cadence-java-client/pull/606) we have been handling WorkflowExecutionAlreadyCompletedError in couple places except for the tchannel. This diff adds tchannel support for this error.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I need some help on how we test java-client changes E2E, sending the PR as the context; will update here once I have the testing strategy


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
