### PR TITLE
Fix Java Client Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,9 +87,8 @@ task updateDlsSubmodule(type: Exec) {
 
 compileThrift {
     dependsOn updateDlsSubmodule
-    sourceItems "${projectDir}/src/main/idls/thrift/cadence.thrift","${projectDir}/src/main/idls/thrift/shared.thrift","${projectDir}/src/main/idls/thrift/shadower.thrift"
-
-    nowarn true
+    verbose true
+    sourceItems "./src/main/idls/thrift/cadence.thrift","./src/main/idls/thrift/shared.thrift","./src/main/idls/thrift/shadower.thrift"
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ task updateDlsSubmodule(type: Exec) {
 compileThrift {
     dependsOn updateDlsSubmodule
     verbose true
-    sourceItems "./src/main/idls/thrift/cadence.thrift","./src/main/idls/thrift/shared.thrift","./src/main/idls/thrift/shadower.thrift"
+    sourceItems "${projectDir}/src/main/idls/thrift/cadence.thrift","${projectDir}/src/main/idls/thrift/shared.thrift","${projectDir}/src/main/idls/thrift/shadower.thrift"
 }
 
 compileJava {

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,3 +1,6 @@
+# Always use a release version or a specific commit hash below. Don't use
+# a branch name since we'd keep getting updates as long as there are new
+# commits to that branch and one of them can break the build
 FROM adoptopenjdk/openjdk11@sha256:13475f4be7d6701a2ebd0516c4c929f2fa78ea773b4483bb580a36a04975e9f9
 
 # Apache Thrift version

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,7 +1,7 @@
 # Always use a release version or a specific commit hash below. Don't use
 # a branch name since we'd keep getting updates as long as there are new
 # commits to that branch and one of them can break the build
-FROM adoptopenjdk/openjdk11@sha256:13475f4be7d6701a2ebd0516c4c929f2fa78ea773b4483bb580a36a04975e9f9
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
 
 # Apache Thrift version
 ENV APACHE_THRIFT_VERSION=0.9.3
@@ -18,7 +18,6 @@ RUN set -ex ;\
 	rm thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
 	cd thrift-${APACHE_THRIFT_VERSION}/ && \
 	./configure --enable-libs=no --enable-tests=no --enable-tutorial=no --with-cpp=no --with-c_glib=no --with-java=yes --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no --with-python=no && \
-  touch config.h && \
 	make && \
 	make install && \
 	cd .. && \

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine
+FROM adoptopenjdk/openjdk11@sha256:13475f4be7d6701a2ebd0516c4c929f2fa78ea773b4483bb580a36a04975e9f9
 
 # Apache Thrift version
 ENV APACHE_THRIFT_VERSION=0.9.3
@@ -10,13 +10,16 @@ RUN apk add git libstdc++
 
 # Compile source
 RUN set -ex ;\
-	wget http://www-us.apache.org/dist/thrift/${APACHE_THRIFT_VERSION}/thrift-${APACHE_THRIFT_VERSION}.tar.gz ;\
-	tar -xvf thrift-${APACHE_THRIFT_VERSION}.tar.gz ;\
-	rm thrift-${APACHE_THRIFT_VERSION}.tar.gz ;\
-	cd thrift-${APACHE_THRIFT_VERSION}/ ;\
-	./configure --enable-libs=no --enable-tests=no --enable-tutorial=no --with-cpp=no --with-c_glib=no --with-java=yes --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no --with-python=no ;\
-	make -j2 && make install ;\
-	cd .. && rm -rf thrift-${APACHE_THRIFT_VERSION}
+	wget https://downloads.apache.org/thrift/${APACHE_THRIFT_VERSION}/thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
+	tar -xvf thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
+	rm thrift-${APACHE_THRIFT_VERSION}.tar.gz && \
+	cd thrift-${APACHE_THRIFT_VERSION}/ && \
+	./configure --enable-libs=no --enable-tests=no --enable-tutorial=no --with-cpp=no --with-c_glib=no --with-java=yes --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no --with-python=no && \
+  touch config.h && \
+	make && \
+	make install && \
+	cd .. && \
+	rm -rf thrift-${APACHE_THRIFT_VERSION}
 
 # Cleanup packages and remove cache
 RUN apk del build-dependencies wget && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Java client started using java11:alpine in April. Since we were using the branch instead of a specific commit, we have been getting updates for jdk. One of those updates 15 days ago ended up breaking the build and all the subsequent builds failed: https://buildkite.com/uberopensource/cadence-java-client/builds?branch=master&page=2 

This change freezes the jdk version to a specific hash so we won't have similar breakages in the future.

I also switched to using paths with no variables like $projectDir; this was because usage of it initially mislead us to think the issue was with the projectDir variable. I'm fine with either way but this way we wouldn't really suspect if there's any issue with the variables.