### PR TITLE
fix(sticky): checking get workflow history when sticky decision task

### DIFF
--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecisionTaskHandler.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecisionTaskHandler.java
@@ -274,6 +274,9 @@ public final class ReplayDecisionTaskHandler implements DecisionTaskHandler {
               .setExecution(decisionTask.getWorkflowExecution());
       GetWorkflowExecutionHistoryResponse getHistoryResponse =
           service.GetWorkflowExecutionHistory(getHistoryRequest);
+      if (getHistoryResponse.getHistory().getEventsSize() == 0) {
+        throw new RuntimeException("Failed to get workflow execution history for replay");
+      }
       decisionTask.setHistory(getHistoryResponse.getHistory());
       decisionTask.setNextPageToken(getHistoryResponse.getNextPageToken());
     }


### PR DESCRIPTION
We see NPE in ReplayDecider with line: decisionTask.getHistory().getEvents().get(0).getWorkflowExecutionStartedEventAttributes();

In ReplayDecisionTaskHandler, we have special handling for sticky decision task that has a partial history. But we do not check the returned history. So add a check to get workflow history when sticky decision task