### PR TITLE
Support Delay Start in Java Client

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowOptions.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowOptions.java
@@ -400,7 +400,7 @@ public final class WorkflowOptions {
         && Objects.equals(memo, that.memo)
         && Objects.equals(searchAttributes, that.searchAttributes)
         && Objects.equals(contextPropagators, that.contextPropagators)
-        && delayStart.equals(that.delayStart);
+        && Objects.equals(delayStart, that.delayStart);
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/client/WorkflowOptions.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowOptions.java
@@ -66,6 +66,7 @@ public final class WorkflowOptions {
         .setMemo(o.getMemo())
         .setSearchAttributes(o.getSearchAttributes())
         .setContextPropagators(o.getContextPropagators())
+        .setDelayStart(o.delayStart)
         .validateBuildWithDefaults();
   }
 
@@ -91,6 +92,8 @@ public final class WorkflowOptions {
 
     private List<ContextPropagator> contextPropagators;
 
+    private Duration delayStart;
+
     public Builder() {}
 
     public Builder(WorkflowOptions o) {
@@ -107,6 +110,7 @@ public final class WorkflowOptions {
       this.memo = o.memo;
       this.searchAttributes = o.searchAttributes;
       this.contextPropagators = o.contextPropagators;
+      this.delayStart = o.delayStart;
     }
 
     /**
@@ -214,6 +218,11 @@ public final class WorkflowOptions {
       return this;
     }
 
+    public Builder setDelayStart(Duration delayStart) {
+      this.delayStart = delayStart;
+      return this;
+    }
+
     public WorkflowOptions build() {
       return new WorkflowOptions(
           workflowId,
@@ -225,7 +234,8 @@ public final class WorkflowOptions {
           cronSchedule,
           memo,
           searchAttributes,
-          contextPropagators);
+          contextPropagators,
+          delayStart);
     }
 
     /**
@@ -261,6 +271,13 @@ public final class WorkflowOptions {
         cron.validate();
       }
 
+      if (delayStart != null) {
+        if (delayStart.getSeconds() < 0) {
+          throw new IllegalArgumentException(
+              "Delay start (in seconds) value cannot be lower than zero");
+        }
+      }
+
       return new WorkflowOptions(
           workflowId,
           policy,
@@ -272,7 +289,8 @@ public final class WorkflowOptions {
           cronSchedule,
           memo,
           searchAttributes,
-          contextPropagators);
+          contextPropagators,
+          delayStart);
     }
   }
 
@@ -296,6 +314,8 @@ public final class WorkflowOptions {
 
   private List<ContextPropagator> contextPropagators;
 
+  private Duration delayStart;
+
   private WorkflowOptions(
       String workflowId,
       WorkflowIdReusePolicy workflowIdReusePolicy,
@@ -306,7 +326,8 @@ public final class WorkflowOptions {
       String cronSchedule,
       Map<String, Object> memo,
       Map<String, Object> searchAttributes,
-      List<ContextPropagator> contextPropagators) {
+      List<ContextPropagator> contextPropagators,
+      Duration delayStart) {
     this.workflowId = workflowId;
     this.workflowIdReusePolicy = workflowIdReusePolicy;
     this.executionStartToCloseTimeout = executionStartToCloseTimeout;
@@ -317,6 +338,7 @@ public final class WorkflowOptions {
     this.memo = memo;
     this.searchAttributes = searchAttributes;
     this.contextPropagators = contextPropagators;
+    this.delayStart = delayStart;
   }
 
   public String getWorkflowId() {
@@ -359,6 +381,10 @@ public final class WorkflowOptions {
     return contextPropagators;
   }
 
+  public Duration getDelayStart() {
+    return delayStart;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -373,7 +399,8 @@ public final class WorkflowOptions {
         && Objects.equals(cronSchedule, that.cronSchedule)
         && Objects.equals(memo, that.memo)
         && Objects.equals(searchAttributes, that.searchAttributes)
-        && Objects.equals(contextPropagators, that.contextPropagators);
+        && Objects.equals(contextPropagators, that.contextPropagators)
+        && delayStart.equals(that.delayStart);
   }
 
   @Override
@@ -388,7 +415,8 @@ public final class WorkflowOptions {
         cronSchedule,
         memo,
         searchAttributes,
-        contextPropagators);
+        contextPropagators,
+        delayStart);
   }
 
   @Override
@@ -418,6 +446,9 @@ public final class WorkflowOptions {
         + searchAttributes
         + ", contextPropagators='"
         + contextPropagators
+        + '\''
+        + ", delayStart='"
+        + delayStart
         + '\''
         + '}';
   }

--- a/src/main/java/com/uber/cadence/internal/common/StartWorkflowExecutionParameters.java
+++ b/src/main/java/com/uber/cadence/internal/common/StartWorkflowExecutionParameters.java
@@ -54,6 +54,8 @@ public final class StartWorkflowExecutionParameters {
 
   private Map<String, byte[]> context;
 
+  private Duration delayStart;
+
   /**
    * Returns the value of the WorkflowId property for this object.
    *
@@ -307,6 +309,14 @@ public final class StartWorkflowExecutionParameters {
     this.context = context;
   }
 
+  public void setDelayStart(Duration delayStart) {
+    this.delayStart = delayStart;
+  }
+
+  public Duration getDelayStart() {
+    return delayStart;
+  }
+
   public StartWorkflowExecutionParameters withRetryParameters(RetryParameters retryParameters) {
     this.retryParameters = retryParameters;
     return this;
@@ -383,6 +393,8 @@ public final class StartWorkflowExecutionParameters {
         + searchAttributes
         + ", context='"
         + context
+        + ", delayStart='"
+        + delayStart
         + '\''
         + '}';
   }
@@ -403,7 +415,8 @@ public final class StartWorkflowExecutionParameters {
         && Objects.equals(cronSchedule, that.cronSchedule)
         && Objects.equals(memo, that.memo)
         && Objects.equals(searchAttributes, that.searchAttributes)
-        && Objects.equals(context, that.context);
+        && Objects.equals(context, that.context)
+        && Objects.equals(delayStart, that.delayStart);
   }
 
   @Override
@@ -420,7 +433,8 @@ public final class StartWorkflowExecutionParameters {
             cronSchedule,
             memo,
             searchAttributes,
-            context);
+            context,
+            delayStart);
     result = 31 * result + Arrays.hashCode(input);
     return result;
   }

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
@@ -210,6 +210,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     request.setMemo(toMemoThrift(startParameters.getMemo()));
     request.setSearchAttributes(toSearchAttributesThrift(startParameters.getSearchAttributes()));
     request.setHeader(toHeaderThrift(startParameters.getContext()));
+    if (startParameters.getDelayStart() != null) {
+      request.setDelayStartSeconds((int) startParameters.getDelayStart().getSeconds());
+    }
 
     return request;
   }
@@ -378,6 +381,9 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
     }
     if (!Strings.isNullOrEmpty(startParameters.getCronSchedule())) {
       request.setCronSchedule(startParameters.getCronSchedule());
+    }
+    if (startParameters.getDelayStart() != null) {
+      request.setDelayStartSeconds((int) startParameters.getDelayStart().getSeconds());
     }
     StartWorkflowExecutionResponse result;
     try {

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
@@ -169,6 +169,7 @@ class WorkflowStubImpl implements WorkflowStub {
     p.setMemo(convertMemoFromObjectToBytes(o.getMemo()));
     p.setSearchAttributes(convertSearchAttributesFromObjectToBytes(o.getSearchAttributes()));
     p.setContext(extractContextsAndConvertToBytes(o.getContextPropagators()));
+    p.setDelayStart(o.getDelayStart());
     return p;
   }
 

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -4467,6 +4467,29 @@ public class WorkflowTest {
         "executeActivity customActivity1");
   }
 
+  @Test
+  public void testDelayStart() {
+    Assume.assumeTrue("skipping for non docker tests", useExternalService);
+
+    int delaySeconds = 5;
+    startWorkerFor(TestGetVersionWorkflowImpl.class);
+    WorkflowOptions options =
+        newWorkflowOptionsBuilder(taskList).setDelayStart(Duration.ofSeconds(delaySeconds)).build();
+
+    LocalDateTime start = LocalDateTime.now();
+    System.out.printf("\n\nSTART: %s \n\n", start.toString());
+
+    TestWorkflow1 workflowStub = workflowClient.newWorkflowStub(TestWorkflow1.class, options);
+    String result = workflowStub.execute(taskList);
+
+    System.out.printf("\n\nRESULT: %s \n\n", result.toString());
+    LocalDateTime end = LocalDateTime.now();
+    System.out.printf("\n\nEND: %s \n\n", end.toString());
+
+    assertTrue(
+        "end time should be at least +10 seconds", start.plusSeconds(delaySeconds).isBefore(end));
+  }
+
   public static class TestGetVersionWorkflow2Impl implements TestWorkflow1 {
 
     @Override


### PR DESCRIPTION
This feature was implemented for Go client for a while back. This PR adds it to the Java client. 

Test: 

Window1: 
```
~/cadence$ ./cadence-server start
```

Window2:
```
~/cadence-java-client$ USE_DOCKER_SERVICE=true ./gradlew test --tests "*.testDelayStart*"
```

Also tested with HelloActivity from java samples