### PR TITLE
Add metric tag to differentiate long-poll and normal request

### DIFF
--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsTag.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsTag.java
@@ -32,4 +32,5 @@ public class MetricsTag {
   public static final String WORKER_TYPE = "WorkerType";
   public static final String SIDE_EFFECT_ID = "SideEffectID";
   public static final String CHILD_WORKFLOW_ID = "ChildWorkflowID";
+  public static final String RequestType = "RequestType";
 }

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsTag.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsTag.java
@@ -32,5 +32,5 @@ public class MetricsTag {
   public static final String WORKER_TYPE = "WorkerType";
   public static final String SIDE_EFFECT_ID = "SideEffectID";
   public static final String CHILD_WORKFLOW_ID = "ChildWorkflowID";
-  public static final String RequestType = "RequestType";
+  public static final String REQUEST_TYPE = "RequestType";
 }

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsTagValue.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsTagValue.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.metrics;
+
+public class MetricsTagValue {
+  public static final String REQUEST_TYPE_NORMAL = "normal";
+  public static final String REQUEST_TYPE_LONG_POLL = "long-poll";
+}

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -126,6 +126,9 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.uber.cadence.internal.metrics.MetricsTagValue.REQUEST_TYPE_LONG_POLL;
+import static com.uber.cadence.internal.metrics.MetricsTagValue.REQUEST_TYPE_NORMAL;
+
 public class WorkflowServiceTChannel implements IWorkflowService {
   private static final Logger log = LoggerFactory.getLogger(WorkflowServiceTChannel.class);
 
@@ -361,7 +364,7 @@ public class WorkflowServiceTChannel implements IWorkflowService {
 
   private <T> T measureRemoteCallWithTags(String scopeName, RemoteCall<T> call, Map<String, String> tags) throws TException {
     Scope scope = options.getMetricsScope().subScope(scopeName);
-    if (tags != null){
+    if (tags != null) {
       scope = scope.tagged(tags);
     }
     scope.counter(MetricsType.CADENCE_REQUEST).inc(1);
@@ -673,9 +676,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   @Override
   public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistoryWithTimeout(
       GetWorkflowExecutionHistoryRequest request, Long timeoutInMillis) throws TException {
-    Map<String, String> tags = ImmutableMap.of(MetricsTag.RequestType, "normal");
+    Map<String, String> tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_NORMAL);
     if (request.isWaitForNewEvent()){
-      tags = ImmutableMap.of(MetricsTag.RequestType, "long-poll");
+      tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_LONG_POLL);
     }
     return measureRemoteCallWithTags(
         ServiceMethod.GET_WORKFLOW_EXECUTION_HISTORY,
@@ -686,9 +689,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   @Override
   public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(
       GetWorkflowExecutionHistoryRequest request) throws TException {
-    Map<String, String> tags = ImmutableMap.of(MetricsTag.RequestType, "normal");
+    Map<String, String> tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_NORMAL);
     if (request.isWaitForNewEvent()){
-      tags = ImmutableMap.of(MetricsTag.RequestType, "long-poll");
+      tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_LONG_POLL);
     }
     return measureRemoteCallWithTags(
             ServiceMethod.GET_WORKFLOW_EXECUTION_HISTORY,

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -110,6 +110,12 @@ import com.uber.tchannel.errors.ErrorType;
 import com.uber.tchannel.messages.ThriftRequest;
 import com.uber.tchannel.messages.ThriftResponse;
 import com.uber.tchannel.messages.generated.Meta;
+import org.apache.thrift.TException;
+import org.apache.thrift.async.AsyncMethodCallback;
+import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -120,11 +126,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import org.apache.thrift.TException;
-import org.apache.thrift.async.AsyncMethodCallback;
-import org.apache.thrift.transport.TTransportException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.uber.cadence.internal.metrics.MetricsTagValue.REQUEST_TYPE_LONG_POLL;
 import static com.uber.cadence.internal.metrics.MetricsTagValue.REQUEST_TYPE_NORMAL;
@@ -676,23 +677,17 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   @Override
   public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistoryWithTimeout(
       GetWorkflowExecutionHistoryRequest request, Long timeoutInMillis) throws TException {
-    Map<String, String> tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_NORMAL);
-    if (request.isWaitForNewEvent()){
-      tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_LONG_POLL);
-    }
+    Map<String, String> tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, request.isWaitForNewEvent() ? REQUEST_TYPE_LONG_POLL : REQUEST_TYPE_NORMAL);
     return measureRemoteCallWithTags(
-        ServiceMethod.GET_WORKFLOW_EXECUTION_HISTORY,
-        () -> getWorkflowExecutionHistory(request, timeoutInMillis),
-        tags);
+            ServiceMethod.GET_WORKFLOW_EXECUTION_HISTORY,
+            () -> getWorkflowExecutionHistory(request, timeoutInMillis),
+            tags);
   }
 
   @Override
   public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(
       GetWorkflowExecutionHistoryRequest request) throws TException {
-    Map<String, String> tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_NORMAL);
-    if (request.isWaitForNewEvent()){
-      tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, REQUEST_TYPE_LONG_POLL);
-    }
+    Map<String, String> tags = ImmutableMap.of(MetricsTag.REQUEST_TYPE, request.isWaitForNewEvent() ? REQUEST_TYPE_LONG_POLL : REQUEST_TYPE_NORMAL);
     return measureRemoteCallWithTags(
             ServiceMethod.GET_WORKFLOW_EXECUTION_HISTORY,
             () -> getWorkflowExecutionHistory(request, null),


### PR DESCRIPTION
For https://github.com/uber/cadence-java-client/issues/649