### PR TITLE
Supporting graceful shutdown based on SIGTERM handler.

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -33,7 +33,9 @@ import com.uber.cadence.internal.external.ManualActivityCompletionClientFactory;
 import com.uber.cadence.internal.external.ManualActivityCompletionClientFactoryImpl;
 import com.uber.cadence.internal.metrics.ClientVersionEmitter;
 import com.uber.cadence.internal.sync.WorkflowInvocationHandler.InvocationType;
+import com.uber.cadence.internal.worker.WorkerShutDownHandler;
 import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.cadence.worker.WorkerFactory;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.QueryMethod;
 import com.uber.cadence.workflow.WorkflowMethod;
@@ -71,6 +73,8 @@ public final class WorkflowClientInternal implements WorkflowClient {
     Objects.requireNonNull(options);
 
     emitClientVersion(options);
+    WorkerShutDownHandler.registerHandler();
+
     return new WorkflowClientInternal(service, options);
   }
 

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -71,7 +71,6 @@ public final class WorkflowClientInternal implements WorkflowClient {
     Objects.requireNonNull(options);
 
     emitClientVersion(options);
-    WorkerShutDownHandler.registerHandler();
 
     return new WorkflowClientInternal(service, options);
   }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -35,7 +35,6 @@ import com.uber.cadence.internal.metrics.ClientVersionEmitter;
 import com.uber.cadence.internal.sync.WorkflowInvocationHandler.InvocationType;
 import com.uber.cadence.internal.worker.WorkerShutDownHandler;
 import com.uber.cadence.serviceclient.IWorkflowService;
-import com.uber.cadence.worker.WorkerFactory;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.QueryMethod;
 import com.uber.cadence.workflow.WorkflowMethod;
@@ -48,7 +47,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.thrift.TException;
 
 public final class WorkflowClientInternal implements WorkflowClient {
@@ -412,7 +410,7 @@ public final class WorkflowClientInternal implements WorkflowClient {
     return execute(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
   }
 
-  private synchronized static void emitClientVersion(WorkflowClientOptions options) {
+  private static synchronized void emitClientVersion(WorkflowClientOptions options) {
     if (emittingClientVersion) {
       return;
     }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -33,7 +33,6 @@ import com.uber.cadence.internal.external.ManualActivityCompletionClientFactory;
 import com.uber.cadence.internal.external.ManualActivityCompletionClientFactoryImpl;
 import com.uber.cadence.internal.metrics.ClientVersionEmitter;
 import com.uber.cadence.internal.sync.WorkflowInvocationHandler.InvocationType;
-import com.uber.cadence.internal.worker.WorkerShutDownHandler;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.QueryMethod;

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.thrift.TException;
 
 public final class WorkflowClientInternal implements WorkflowClient {
@@ -70,7 +71,6 @@ public final class WorkflowClientInternal implements WorkflowClient {
     Objects.requireNonNull(options);
 
     emitClientVersion(options);
-
     return new WorkflowClientInternal(service, options);
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/WorkerShutDownHandler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkerShutDownHandler.java
@@ -1,6 +1,5 @@
 /*
- *  Modifications Copyright (c) 2017-2020 Uber Technologies Inc.
- *  Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+ *  Modifications Copyright (c) 2020-2022 Uber Technologies Inc.
  *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"). You may not

--- a/src/main/java/com/uber/cadence/internal/worker/WorkerShutDownHandler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkerShutDownHandler.java
@@ -1,0 +1,42 @@
+package com.uber.cadence.internal.worker;
+
+import com.uber.cadence.worker.WorkerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class WorkerShutDownHandler {
+
+    private static final List<WorkerFactory> workerFactories = new ArrayList<>();
+    private static boolean registered = false;
+
+    public static void registerHandler() {
+        if (!registered) {
+            registered = true;
+            Runtime.getRuntime().addShutdownHook(new Thread("SHUTDOWN_WORKERS") {
+                @Override
+                public void run() {
+                    for (WorkerFactory workerFactory : workerFactories) {
+                        workerFactory.suspendPolling();
+                    }
+
+                    for (WorkerFactory workerFactory : workerFactories) {
+                        workerFactory.shutdownNow();
+                    }
+
+                    for (WorkerFactory workerFactory: workerFactories) {
+                        workerFactory.awaitTermination(1, TimeUnit.SECONDS);
+                    }
+                }
+            });
+        }
+    }
+
+
+    public static void registerWorkerFactory(WorkerFactory workerFactory) {
+        if (workerFactory != null) {
+            workerFactories.add(workerFactory);
+        }
+    }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/WorkerShutDownHandler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkerShutDownHandler.java
@@ -1,42 +1,61 @@
+/*
+ *  Modifications Copyright (c) 2017-2020 Uber Technologies Inc.
+ *  Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.internal.worker;
 
 import com.uber.cadence.worker.WorkerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class WorkerShutDownHandler {
 
-    private static final List<WorkerFactory> workerFactories = new ArrayList<>();
-    private static boolean registered = false;
+  private static final List<WorkerFactory> workerFactories = new ArrayList<>();
+  private static boolean registered = false;
 
-    public static void registerHandler() {
-        if (!registered) {
-            registered = true;
-            Runtime.getRuntime().addShutdownHook(new Thread("SHUTDOWN_WORKERS") {
-                @Override
-                public void run() {
-                    for (WorkerFactory workerFactory : workerFactories) {
-                        workerFactory.suspendPolling();
-                    }
+  public static void registerHandler() {
+    if (registered) {
+      return;
+    }
 
-                    for (WorkerFactory workerFactory : workerFactories) {
-                        workerFactory.shutdownNow();
-                    }
-
-                    for (WorkerFactory workerFactory: workerFactories) {
-                        workerFactory.awaitTermination(1, TimeUnit.SECONDS);
-                    }
+    registered = true;
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread("SHUTDOWN_WORKERS") {
+              @Override
+              public void run() {
+                for (WorkerFactory workerFactory : workerFactories) {
+                  workerFactory.suspendPolling();
                 }
+
+                for (WorkerFactory workerFactory : workerFactories) {
+                  workerFactory.shutdownNow();
+                }
+
+                for (WorkerFactory workerFactory : workerFactories) {
+                  workerFactory.awaitTermination(1, TimeUnit.SECONDS);
+                }
+              }
             });
-        }
-    }
+  }
 
-
-    public static void registerWorkerFactory(WorkerFactory workerFactory) {
-        if (workerFactory != null) {
-            workerFactories.add(workerFactory);
-        }
+  public static synchronized void registerWorkerFactory(WorkerFactory workerFactory) {
+    if (workerFactory != null) {
+      workerFactories.add(workerFactory);
     }
+  }
 }

--- a/src/main/java/com/uber/cadence/worker/WorkerFactory.java
+++ b/src/main/java/com/uber/cadence/worker/WorkerFactory.java
@@ -58,7 +58,10 @@ public final class WorkerFactory {
 
   public static WorkerFactory newInstance(
       WorkflowClient workflowClient, WorkerFactoryOptions options) {
-    return new WorkerFactory(workflowClient, options);
+    WorkerShutDownHandler.registerHandler();
+    WorkerFactory workerFactory = new WorkerFactory(workflowClient, options);
+    WorkerShutDownHandler.registerWorkerFactory(workerFactory);
+    return workerFactory;
   }
 
   private final List<Worker> workers = new ArrayList<>();
@@ -137,8 +140,6 @@ public final class WorkerFactory {
                 .setPollThreadCount(this.factoryOptions.getStickyPollerCount())
                 .build(),
             stickyScope);
-
-    WorkerShutDownHandler.registerWorkerFactory(this);
   }
 
   /**

--- a/src/main/java/com/uber/cadence/worker/WorkerFactory.java
+++ b/src/main/java/com/uber/cadence/worker/WorkerFactory.java
@@ -30,6 +30,7 @@ import com.uber.cadence.internal.replay.DeciderCache;
 import com.uber.cadence.internal.worker.PollDecisionTaskDispatcher;
 import com.uber.cadence.internal.worker.Poller;
 import com.uber.cadence.internal.worker.PollerOptions;
+import com.uber.cadence.internal.worker.WorkerShutDownHandler;
 import com.uber.cadence.internal.worker.WorkflowPollTaskFactory;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
@@ -136,6 +137,8 @@ public final class WorkerFactory {
                 .setPollThreadCount(this.factoryOptions.getStickyPollerCount())
                 .build(),
             stickyScope);
+
+    WorkerShutDownHandler.registerWorkerFactory(this);
   }
 
   /**

--- a/src/test/java/com/uber/cadence/internal/worker/WorkerShutDownHandlerTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/WorkerShutDownHandlerTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.cadence.worker.WorkerFactory;
+import com.uber.m3.tally.NoopScope;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkerShutDownHandlerTest {
+
+    @Mock
+    private WorkflowClient mockClient;
+
+    @Mock
+    private IWorkflowService mockService;
+
+    @Before
+    public void setup() {
+        WorkflowClientOptions clientOptions =
+                WorkflowClientOptions.newBuilder().setMetricsScope(new NoopScope()).build();
+        when(mockClient.getOptions()).thenReturn(clientOptions);
+        when(mockClient.getService()).thenReturn(mockService);
+    }
+
+    @Test
+    public void shutDownHookShutsDownFactories() {
+        WorkerShutDownHandler.registerHandler();
+
+        WorkerFactory workerFactory = WorkerFactory.newInstance(mockClient);
+        workerFactory.newWorker("TL1");
+        workerFactory.newWorker("TL2");
+
+        WorkerFactory workerFactory2 = WorkerFactory.newInstance(mockClient);
+        workerFactory2.newWorker("TL3");
+
+        WorkerShutDownHandler.execute();
+
+        assertTrue(workerFactory.isShutdown());
+        assertTrue(workerFactory2.isShutdown());
+    }
+
+}

--- a/src/test/java/com/uber/cadence/internal/worker/WorkerShutDownHandlerTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/WorkerShutDownHandlerTest.java
@@ -17,6 +17,9 @@
 
 package com.uber.cadence.internal.worker;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
@@ -28,41 +31,34 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
 @RunWith(MockitoJUnitRunner.class)
 public class WorkerShutDownHandlerTest {
 
-    @Mock
-    private WorkflowClient mockClient;
+  @Mock private WorkflowClient mockClient;
 
-    @Mock
-    private IWorkflowService mockService;
+  @Mock private IWorkflowService mockService;
 
-    @Before
-    public void setup() {
-        WorkflowClientOptions clientOptions =
-                WorkflowClientOptions.newBuilder().setMetricsScope(new NoopScope()).build();
-        when(mockClient.getOptions()).thenReturn(clientOptions);
-        when(mockClient.getService()).thenReturn(mockService);
-    }
+  @Before
+  public void setup() {
+    WorkflowClientOptions clientOptions =
+        WorkflowClientOptions.newBuilder().setMetricsScope(new NoopScope()).build();
+    when(mockClient.getOptions()).thenReturn(clientOptions);
+    when(mockClient.getService()).thenReturn(mockService);
+  }
 
-    @Test
-    public void shutDownHookShutsDownFactories() {
-        WorkerShutDownHandler.registerHandler();
+  @Test
+  public void shutDownHookShutsDownFactories() {
 
-        WorkerFactory workerFactory = WorkerFactory.newInstance(mockClient);
-        workerFactory.newWorker("TL1");
-        workerFactory.newWorker("TL2");
+    WorkerFactory workerFactory = WorkerFactory.newInstance(mockClient);
+    workerFactory.newWorker("TL1");
+    workerFactory.newWorker("TL2");
 
-        WorkerFactory workerFactory2 = WorkerFactory.newInstance(mockClient);
-        workerFactory2.newWorker("TL3");
+    WorkerFactory workerFactory2 = WorkerFactory.newInstance(mockClient);
+    workerFactory2.newWorker("TL3");
 
-        WorkerShutDownHandler.execute();
+    WorkerShutDownHandler.execute();
 
-        assertTrue(workerFactory.isShutdown());
-        assertTrue(workerFactory2.isShutdown());
-    }
-
+    assertTrue(workerFactory.isShutdown());
+    assertTrue(workerFactory2.isShutdown());
+  }
 }

--- a/src/test/java/com/uber/cadence/worker/ShadowingWorkerTest.java
+++ b/src/test/java/com/uber/cadence/worker/ShadowingWorkerTest.java
@@ -51,7 +51,7 @@ public class ShadowingWorkerTest {
   @Before
   public void init() {
     WorkflowClientOptions clientOptions =
-        WorkflowClientOptions.newBuilder().setMetricsScope(new NoopScope()).build();
+            WorkflowClientOptions.newBuilder().setMetricsScope(new NoopScope()).build();
     when(mockClient.getOptions()).thenReturn(clientOptions);
     when(mockClient.getService()).thenReturn(mockService);
   }

--- a/src/test/java/com/uber/cadence/worker/ShadowingWorkerTest.java
+++ b/src/test/java/com/uber/cadence/worker/ShadowingWorkerTest.java
@@ -51,7 +51,7 @@ public class ShadowingWorkerTest {
   @Before
   public void init() {
     WorkflowClientOptions clientOptions =
-            WorkflowClientOptions.newBuilder().setMetricsScope(new NoopScope()).build();
+        WorkflowClientOptions.newBuilder().setMetricsScope(new NoopScope()).build();
     when(mockClient.getOptions()).thenReturn(clientOptions);
     when(mockClient.getService()).thenReturn(mockService);
   }


### PR DESCRIPTION
Adding handler for graceful shutdown. Since uDeploy sends a signal 10 seconds before turning off the service. We want to avoid abruptly stopping any activity or workflow executions.