### PR TITLE
Adding cross domain signaling.

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/ChildWorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ChildWorkflowStubImpl.java
@@ -25,6 +25,7 @@ import com.uber.cadence.workflow.ChildWorkflowStub;
 import com.uber.cadence.workflow.CompletablePromise;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.SignalExternalWorkflowException;
+import com.uber.cadence.workflow.SignalOptions;
 import com.uber.cadence.workflow.Workflow;
 import com.uber.cadence.workflow.WorkflowInterceptor;
 import com.uber.cadence.workflow.WorkflowInterceptor.WorkflowResult;
@@ -115,9 +116,10 @@ class ChildWorkflowStubImpl implements ChildWorkflowStub {
   }
 
   @Override
-  public void signalCrossDomain(String signalName, String domain, Object... args) {
+  public void signal(SignalOptions signalOptions, Object... args) {
     Promise<Void> signaled =
-            decisionContext.signalExternalWorkflow(domain, execution.get(), signalName, args);
+        decisionContext.signalExternalWorkflow(
+            signalOptions.getDomain(), execution.get(), signalOptions.getSignalName(), args);
     if (AsyncInternal.isAsync()) {
       AsyncInternal.setAsyncResult(signaled);
       return;

--- a/src/main/java/com/uber/cadence/internal/sync/ChildWorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ChildWorkflowStubImpl.java
@@ -113,4 +113,22 @@ class ChildWorkflowStubImpl implements ChildWorkflowStub {
       throw e;
     }
   }
+
+  @Override
+  public void signalCrossDomain(String signalName, String domain, Object... args) {
+    Promise<Void> signaled =
+            decisionContext.signalExternalWorkflow(domain, execution.get(), signalName, args);
+    if (AsyncInternal.isAsync()) {
+      AsyncInternal.setAsyncResult(signaled);
+      return;
+    }
+    try {
+      signaled.get();
+    } catch (SignalExternalWorkflowException e) {
+      // Reset stack to the current one. Otherwise it is very confusing to see a stack of
+      // an event handling method.
+      e.setStackTrace(Thread.currentThread().getStackTrace());
+      throw e;
+    }
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/ExternalWorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ExternalWorkflowStubImpl.java
@@ -22,6 +22,7 @@ import com.uber.cadence.workflow.CancelExternalWorkflowException;
 import com.uber.cadence.workflow.ExternalWorkflowStub;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.SignalExternalWorkflowException;
+import com.uber.cadence.workflow.SignalOptions;
 import com.uber.cadence.workflow.WorkflowInterceptor;
 import java.util.Objects;
 
@@ -60,9 +61,10 @@ class ExternalWorkflowStubImpl implements ExternalWorkflowStub {
   }
 
   @Override
-  public void signalCrossDomain(String signalName, String domain, Object... args) {
+  public void signal(SignalOptions signalOptions, Object... args) {
     Promise<Void> signaled =
-        decisionContext.signalExternalWorkflow(domain, execution, signalName, args);
+        decisionContext.signalExternalWorkflow(
+            signalOptions.getDomain(), execution, signalOptions.getSignalName(), args);
     if (AsyncInternal.isAsync()) {
       AsyncInternal.setAsyncResult(signaled);
       return;

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -634,10 +634,17 @@ final class SyncDecisionContext implements WorkflowInterceptor {
   @Override
   public Promise<Void> signalExternalWorkflow(
       WorkflowExecution execution, String signalName, Object[] args) {
+    return this.signalExternalWorkflow(null, execution, signalName, args);
+  }
+
+  @Override
+  public Promise<Void> signalExternalWorkflow(
+      String domain, WorkflowExecution execution, String signalName, Object[] args) {
     SignalExternalWorkflowParameters parameters = new SignalExternalWorkflowParameters();
     parameters.setSignalName(signalName);
     parameters.setWorkflowId(execution.getWorkflowId());
     parameters.setRunId(execution.getRunId());
+    parameters.setDomain(domain);
     byte[] input = getDataConverter().toData(args);
     parameters.setInput(input);
     CompletablePromise<Void> result = Workflow.newPromise();

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -193,6 +193,12 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
 
     @Override
     public Promise<Void> signalExternalWorkflow(
+        String domain, WorkflowExecution execution, String signalName, Object[] args) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Promise<Void> signalExternalWorkflow(
         WorkflowExecution execution, String signalName, Object[] args) {
       throw new UnsupportedOperationException("not implemented");
     }

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -121,16 +121,23 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
   private final WorkflowServiceWrapper service;
   private final WorkerFactory workerFactory;
 
-  public TestWorkflowEnvironmentInternal(TestEnvironmentOptions options) {
+  public TestWorkflowEnvironmentInternal(
+      WorkflowServiceWrapper workflowServiceWrapper, TestEnvironmentOptions options) {
     if (options == null) {
       this.testEnvironmentOptions = new TestEnvironmentOptions.Builder().build();
     } else {
       this.testEnvironmentOptions = options;
     }
-    service = new WorkflowServiceWrapper();
-    service.lockTimeSkipping("TestWorkflowEnvironmentInternal constructor");
+
+    if (workflowServiceWrapper == null) {
+      this.service = new WorkflowServiceWrapper();
+    } else {
+      this.service = workflowServiceWrapper;
+    }
+
+    this.service.lockTimeSkipping("TestWorkflowEnvironmentInternal constructor");
     WorkflowClient client =
-        WorkflowClient.newInstance(service, testEnvironmentOptions.getWorkflowClientOptions());
+        WorkflowClient.newInstance(this.service, testEnvironmentOptions.getWorkflowClientOptions());
     workerFactory =
         WorkerFactory.newInstance(client, testEnvironmentOptions.getWorkerFactoryOptions());
   }
@@ -253,11 +260,11 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     return workerFactory;
   }
 
-  private static class WorkflowServiceWrapper implements IWorkflowService {
+  public static class WorkflowServiceWrapper implements IWorkflowService {
 
     private final TestWorkflowService impl;
 
-    private WorkflowServiceWrapper() {
+    public WorkflowServiceWrapper() {
       impl = new TestWorkflowService();
     }
 

--- a/src/main/java/com/uber/cadence/testing/TestWorkflowEnvironment.java
+++ b/src/main/java/com/uber/cadence/testing/TestWorkflowEnvironment.java
@@ -93,11 +93,17 @@ import java.util.function.Function;
 public interface TestWorkflowEnvironment {
 
   static TestWorkflowEnvironment newInstance() {
-    return new TestWorkflowEnvironmentInternal(new TestEnvironmentOptions.Builder().build());
+    return new TestWorkflowEnvironmentInternal(null, new TestEnvironmentOptions.Builder().build());
   }
 
   static TestWorkflowEnvironment newInstance(TestEnvironmentOptions options) {
-    return new TestWorkflowEnvironmentInternal(options);
+    return new TestWorkflowEnvironmentInternal(null, options);
+  }
+
+  static TestWorkflowEnvironment newInstance(
+      TestWorkflowEnvironmentInternal.WorkflowServiceWrapper workflowService,
+      TestEnvironmentOptions options) {
+    return new TestWorkflowEnvironmentInternal(workflowService, options);
   }
 
   /**

--- a/src/main/java/com/uber/cadence/workflow/ChildWorkflowStub.java
+++ b/src/main/java/com/uber/cadence/workflow/ChildWorkflowStub.java
@@ -45,5 +45,5 @@ public interface ChildWorkflowStub {
 
   void signal(String signalName, Object... args);
 
-  void signalCrossDomain(String signalName, String domain, Object... args);
+  void signal(SignalOptions signalOptions, Object... args);
 }

--- a/src/main/java/com/uber/cadence/workflow/ChildWorkflowStub.java
+++ b/src/main/java/com/uber/cadence/workflow/ChildWorkflowStub.java
@@ -44,4 +44,6 @@ public interface ChildWorkflowStub {
   <R> Promise<R> executeAsync(Class<R> resultClass, Type resultType, Object... args);
 
   void signal(String signalName, Object... args);
+
+  void signalCrossDomain(String signalName, String domain, Object... args);
 }

--- a/src/main/java/com/uber/cadence/workflow/ExternalWorkflowStub.java
+++ b/src/main/java/com/uber/cadence/workflow/ExternalWorkflowStub.java
@@ -32,5 +32,7 @@ public interface ExternalWorkflowStub {
 
   void signal(String signalName, Object... args);
 
+  void signalCrossDomain(String signalName, String domain, Object... args);
+
   void cancel();
 }

--- a/src/main/java/com/uber/cadence/workflow/ExternalWorkflowStub.java
+++ b/src/main/java/com/uber/cadence/workflow/ExternalWorkflowStub.java
@@ -32,7 +32,7 @@ public interface ExternalWorkflowStub {
 
   void signal(String signalName, Object... args);
 
-  void signalCrossDomain(String signalName, String domain, Object... args);
+  void signal(SignalOptions signalOptions, Object... args);
 
   void cancel();
 }

--- a/src/main/java/com/uber/cadence/workflow/SignalOptions.java
+++ b/src/main/java/com/uber/cadence/workflow/SignalOptions.java
@@ -1,3 +1,18 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.workflow;
 
 public class SignalOptions {

--- a/src/main/java/com/uber/cadence/workflow/SignalOptions.java
+++ b/src/main/java/com/uber/cadence/workflow/SignalOptions.java
@@ -1,0 +1,53 @@
+package com.uber.cadence.workflow;
+
+public class SignalOptions {
+
+  private String domain;
+  private String signalName;
+
+  private SignalOptions() {}
+
+  public static SignalOptions.Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private SignalOptions signalOptions = new SignalOptions();
+
+    public SignalOptions.Builder setDomain(String domain) {
+      signalOptions.setDomain(domain);
+      return this;
+    }
+
+    public SignalOptions.Builder setSignalName(String signalName) {
+      signalOptions.setSignalName(signalName);
+      return this;
+    }
+
+    public SignalOptions build() {
+      if (signalOptions.getSignalName() == null) {
+        throw new IllegalArgumentException("Signal name must be provided");
+      }
+
+      return signalOptions;
+    }
+  }
+
+  public SignalOptions setDomain(String domain) {
+    this.domain = domain;
+    return this;
+  }
+
+  public String getDomain() {
+    return this.domain;
+  }
+
+  public SignalOptions setSignalName(String signalName) {
+    this.signalName = signalName;
+    return this;
+  }
+
+  public String getSignalName() {
+    return this.signalName;
+  }
+}

--- a/src/main/java/com/uber/cadence/workflow/WorkflowInterceptor.java
+++ b/src/main/java/com/uber/cadence/workflow/WorkflowInterceptor.java
@@ -77,6 +77,9 @@ public interface WorkflowInterceptor {
   Promise<Void> signalExternalWorkflow(
       WorkflowExecution execution, String signalName, Object[] args);
 
+  Promise<Void> signalExternalWorkflow(
+      String domain, WorkflowExecution execution, String signalName, Object[] args);
+
   Promise<Void> cancelWorkflow(WorkflowExecution execution);
 
   void sleep(Duration duration);

--- a/src/main/java/com/uber/cadence/workflow/WorkflowInterceptorBase.java
+++ b/src/main/java/com/uber/cadence/workflow/WorkflowInterceptorBase.java
@@ -82,6 +82,12 @@ public class WorkflowInterceptorBase implements WorkflowInterceptor {
   }
 
   @Override
+  public Promise<Void> signalExternalWorkflow(
+      String domain, WorkflowExecution execution, String signalName, Object[] args) {
+    return next.signalExternalWorkflow(domain, execution, signalName, args);
+  }
+
+  @Override
   public Promise<Void> cancelWorkflow(WorkflowExecution execution) {
     return next.cancelWorkflow(execution);
   }

--- a/src/test/java/com/uber/cadence/RegisterTestDomain.java
+++ b/src/test/java/com/uber/cadence/RegisterTestDomain.java
@@ -1,6 +1,7 @@
 package com.uber.cadence;
 
 import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
+import static com.uber.cadence.workflow.WorkflowTest.DOMAIN2;
 
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
@@ -18,8 +19,14 @@ public class RegisterTestDomain {
     }
 
     IWorkflowService service = new WorkflowServiceTChannel(ClientOptions.defaultInstance());
+    registerDomain(service, DOMAIN);
+    registerDomain(service, DOMAIN2);
+    System.exit(0);
+  }
+
+  private static void registerDomain(IWorkflowService service, String domain) throws InterruptedException {
     RegisterDomainRequest request =
-        new RegisterDomainRequest().setName(DOMAIN).setWorkflowExecutionRetentionPeriodInDays(1);
+        new RegisterDomainRequest().setName(domain).setWorkflowExecutionRetentionPeriodInDays(1);
     while (true) {
       try {
         service.RegisterDomain(request);
@@ -40,6 +47,5 @@ public class RegisterTestDomain {
         System.exit(1);
       }
     }
-    System.exit(0);
   }
 }

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -6021,6 +6021,13 @@ public class WorkflowTest {
 
     @Override
     public Promise<Void> signalExternalWorkflow(
+        String domain, WorkflowExecution execution, String signalName, Object[] args) {
+      trace.add("signalExternalWorkflow " + execution.getWorkflowId() + " " + signalName);
+      return next.signalExternalWorkflow(domain, execution, signalName, args);
+    }
+
+    @Override
+    public Promise<Void> signalExternalWorkflow(
         WorkflowExecution execution, String signalName, Object[] args) {
       trace.add("signalExternalWorkflow " + execution.getWorkflowId() + " " + signalName);
       return next.signalExternalWorkflow(execution, signalName, args);

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -62,6 +62,7 @@ import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.converter.JsonDataConverter;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.sync.DeterministicRunnerTest;
+import com.uber.cadence.internal.sync.TestWorkflowEnvironmentInternal;
 import com.uber.cadence.internal.worker.PollerOptions;
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
@@ -148,6 +149,8 @@ public class WorkflowTest {
   private static final boolean useDockerService =
       Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
 
+  private TestWorkflowEnvironmentInternal.WorkflowServiceWrapper wfService;
+
   private static final boolean stickyOff = Boolean.parseBoolean(System.getenv("STICKY_OFF"));
 
   @Parameters(name = "{1}")
@@ -192,6 +195,7 @@ public class WorkflowTest {
   public boolean disableStickyExecution;
 
   public static final String DOMAIN = "UnitTest";
+  public static final String DOMAIN2 = "UnitTest2";
   private static final Logger log = LoggerFactory.getLogger(WorkflowTest.class);
 
   private static String UUID_REGEXP =
@@ -270,6 +274,7 @@ public class WorkflowTest {
 
   @Before
   public void setUp() {
+    this.wfService = new TestWorkflowEnvironmentInternal.WorkflowServiceWrapper();
     String testMethod = testName.getMethodName();
     if (testMethod.startsWith("testExecute") || testMethod.startsWith("testStart")) {
       taskList = ANNOTATION_TASK_LIST;
@@ -305,7 +310,7 @@ public class WorkflowTest {
                       .setDisableStickyExecution(disableStickyExecution)
                       .build())
               .build();
-      testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
+      testEnvironment = TestWorkflowEnvironment.newInstance(wfService, testOptions);
       worker = testEnvironment.newWorker(taskList);
       workflowClient = testEnvironment.newWorkflowClient();
     }
@@ -391,6 +396,12 @@ public class WorkflowTest {
     String execute(String taskList);
   }
 
+  public interface TestWorkflowCrossDomain {
+
+    @WorkflowMethod
+    String execute(String workflowId);
+  }
+
   public interface TestWorkflowSignaled {
 
     @WorkflowMethod
@@ -428,6 +439,26 @@ public class WorkflowTest {
 
     @QueryMethod()
     String query();
+  }
+
+  public static class TestWorkflowSignaledSimple implements TestWorkflowSignaled {
+
+    List<String> messageQueue = new ArrayList<>(10);
+
+    @Override
+    @WorkflowMethod
+    public String execute() {
+      Workflow.await(() -> !messageQueue.isEmpty());
+      messageQueue.remove(0);
+      System.out.print("Simple workflow signaled");
+      return "Simple workflow signaled";
+    }
+
+    @Override
+    @SignalMethod
+    public void signal1(String arg) {
+      messageQueue.add("arg");
+    }
   }
 
   public static class TestSyncWorkflowImpl implements TestWorkflow1 {
@@ -3300,6 +3331,18 @@ public class WorkflowTest {
     }
   }
 
+  public static class TestWorkflowCrossDomainImpl implements TestWorkflowCrossDomain {
+
+    @Override
+    @WorkflowMethod
+    public String execute(String wfId) {
+      ExternalWorkflowStub externalWorkflow = Workflow.newUntypedExternalWorkflowStub(wfId);
+      externalWorkflow.signalCrossDomain("testSignal", DOMAIN2, "World");
+      System.out.println("Signaled External Workflow");
+      return "Signaled External workflow";
+    }
+  }
+
   public static class UntypedSignalingChildImpl implements SignalingChild {
 
     @Override
@@ -3320,6 +3363,53 @@ public class WorkflowTest {
     TestWorkflowSignaled client =
         workflowClient.newWorkflowStub(TestWorkflowSignaled.class, options.build());
     assertEquals("Hello World!", client.execute());
+  }
+
+  @Test
+  public void testSignalCrossDomainExternalWorkflow() {
+    WorkflowClientOptions clientOptions =
+        WorkflowClientOptions.newBuilder().setDomain(DOMAIN2).build();
+
+    TestEnvironmentOptions testOptions =
+        new TestEnvironmentOptions.Builder()
+            .setWorkflowClientOptions(clientOptions)
+            .setInterceptorFactory(tracer)
+            .setWorkerFactoryOptions(
+                WorkerFactoryOptions.newBuilder()
+                    .setDisableStickyExecution(disableStickyExecution)
+                    .build())
+            .build();
+    TestWorkflowEnvironment testEnvironment2 =
+        TestWorkflowEnvironment.newInstance(wfService, testOptions);
+    Worker worker2 = testEnvironment2.newWorker(taskList + "2");
+    WorkflowClient workflowClient2 = testEnvironment2.newWorkflowClient();
+
+    startWorkerFor(TestWorkflowCrossDomainImpl.class);
+    worker2.registerWorkflowImplementationTypes(TestWorkflowSignaledSimple.class);
+    testEnvironment2.start();
+
+    WorkflowOptions.Builder options = new WorkflowOptions.Builder();
+    options.setExecutionStartToCloseTimeout(Duration.ofSeconds(30));
+    options.setTaskStartToCloseTimeout(Duration.ofSeconds(30));
+    options.setTaskList(taskList);
+
+    WorkflowOptions.Builder options2 = new WorkflowOptions.Builder();
+    String wfId = UUID.randomUUID().toString();
+    options2.setWorkflowId(wfId);
+    options2.setExecutionStartToCloseTimeout(Duration.ofSeconds(30));
+    options2.setTaskStartToCloseTimeout(Duration.ofSeconds(30));
+    options2.setTaskList(taskList + "2");
+
+    TestWorkflowCrossDomain wf =
+        workflowClient.newWorkflowStub(TestWorkflowCrossDomain.class, options.build());
+
+    TestWorkflowSignaled simpleWorkflow =
+        workflowClient2.newWorkflowStub(TestWorkflowSignaled.class, options2.build());
+
+    WorkflowExecution execution = WorkflowClient.start(simpleWorkflow::execute);
+    testEnvironment.sleep(Duration.ofSeconds(1));
+    assertEquals("Signaled External workflow", wf.execute(wfId));
+    tracer.setExpected("await await", "signalExternalWorkflow " + wfId + " testSignal");
   }
 
   public static class TestSignalExternalWorkflowFailure implements TestWorkflow1 {

--- a/src/test/java/com/uber/cadence/workflow/interceptors/SignalWorkflowInterceptor.java
+++ b/src/test/java/com/uber/cadence/workflow/interceptors/SignalWorkflowInterceptor.java
@@ -84,6 +84,16 @@ public class SignalWorkflowInterceptor implements WorkflowInterceptor {
 
   @Override
   public Promise<Void> signalExternalWorkflow(
+      String domain, WorkflowExecution execution, String signalName, Object[] args) {
+    if (args != null && args.length > 0) {
+      args = new Object[] {"corrupted signal"};
+    }
+    return next.signalExternalWorkflow(
+        domain, execution, overrideSignalName.apply(signalName), overrideArgs.apply(args));
+  }
+
+  @Override
+  public Promise<Void> signalExternalWorkflow(
       WorkflowExecution execution, String signalName, Object[] args) {
     if (args != null && args.length > 0) {
       args = new Object[] {"corrupted signal"};


### PR DESCRIPTION
Example use:

WorkflowExecution workflowExecution = new WorkflowExecution().setWorkflowId(workflowId);
      ExternalWorkflowStub workflowStub =
          Workflow.newUntypedExternalWorkflowStub(workflowExecution);
      workflowStub.signalCrossDomain("FareWellWorkflow::waitForName", "testdomain2", "Mindaugas");