### PR TITLE
Adding poller autoscaler, to dynamically resize number of pollers.

### DIFF
--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScaler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScaler.java
@@ -1,0 +1,111 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PollerAutoScaler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PollerAutoScaler.class);
+
+  private Duration coolDownTime;
+  private PollerUsageEstimator pollerUsageEstimator;
+  private Recommender recommender;
+  private ResizableSemaphore semaphore;
+  private int semaphoreSize;
+  private boolean shutingDown;
+
+  public PollerAutoScaler(
+      Duration coolDownTime, PollerUsageEstimator pollerUsageEstimator, Recommender recommender) {
+    this.coolDownTime = coolDownTime;
+    this.pollerUsageEstimator = pollerUsageEstimator;
+    this.recommender = recommender;
+    this.semaphore = new ResizableSemaphore(recommender.getUpperValue());
+    this.semaphoreSize = recommender.getUpperValue();
+  }
+
+  public void start() {
+    Executors.newSingleThreadExecutor()
+        .submit(
+            new Runnable() {
+              @Override
+              public void run() {
+                while (!shutingDown) {
+                  try {
+                    Thread.sleep(coolDownTime.toMillis());
+                    if (!shutingDown) {
+                      resizePollers();
+                    }
+                  } catch (InterruptedException e) {
+                  }
+                }
+              }
+            });
+  }
+
+  public void stop() {
+    LOGGER.info("shutting down poller autoscaler");
+    shutingDown = true;
+  }
+
+  protected void resizePollers() {
+    PollerUsage pollerUsage = pollerUsageEstimator.estimate();
+    int pollerCount =
+        recommender.recommend(this.semaphoreSize, pollerUsage.getPollerUtilizationRate());
+
+    int diff = this.semaphoreSize - pollerCount;
+    if (diff < 0) {
+      semaphore.release(diff * -1);
+    } else {
+      semaphore.decreasePermits(diff);
+    }
+
+    LOGGER.info(String.format("resized pollers to: %d", pollerCount));
+    this.semaphoreSize = pollerCount;
+  }
+
+  public int getLowerPollerAmount() {
+    return recommender.getLowerValue();
+  }
+
+  public int getUpperPollerAmount() {
+    return recommender.getUpperValue();
+  }
+
+  public PollerUsageEstimator getPollerUsageEstimator() {
+    return pollerUsageEstimator;
+  }
+
+  public Recommender getRecommender() {
+    return recommender;
+  }
+
+  public void acquire() throws InterruptedException {
+    semaphore.acquire();
+  }
+
+  public void release() {
+    semaphore.release();
+  }
+
+  // For testing
+  protected int getSemaphoreSize() {
+    return semaphoreSize;
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScaler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScaler.java
@@ -81,14 +81,6 @@ public class PollerAutoScaler {
     this.semaphoreSize = pollerCount;
   }
 
-  public int getLowerPollerAmount() {
-    return recommender.getLowerValue();
-  }
-
-  public int getUpperPollerAmount() {
-    return recommender.getUpperValue();
-  }
-
   public void acquire() throws InterruptedException {
     semaphore.acquire();
   }

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsage.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsage.java
@@ -1,0 +1,29 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+public class PollerUsage {
+
+  private final float pollerUtilizationRate;
+
+  public PollerUsage(float pollerUtilizationRate) {
+    this.pollerUtilizationRate = pollerUtilizationRate;
+  }
+
+  public float getPollerUtilizationRate() {
+    return pollerUtilizationRate;
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimator.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimator.java
@@ -41,7 +41,7 @@ public class PollerUsageEstimator {
     return result;
   }
 
-  public void reset() {
+  private void reset() {
     noopTaskCount.set(0);
     actionableTaskCount.set(0);
   }

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimator.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimator.java
@@ -1,0 +1,45 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+public class PollerUsageEstimator {
+
+  private int noopTaskCount;
+  private int actionableTaskCount;
+
+  public void increaseNoopTaskCount() {
+    noopTaskCount += 1;
+  }
+
+  public void increaseActionableTaskCount() {
+    actionableTaskCount += 1;
+  }
+
+  public PollerUsage estimate() {
+    if (noopTaskCount + actionableTaskCount == 0) {
+      return new PollerUsage(0);
+    }
+    PollerUsage result =
+        new PollerUsage((actionableTaskCount * 1f) / (noopTaskCount + actionableTaskCount));
+    reset();
+    return result;
+  }
+
+  public void reset() {
+    noopTaskCount = 0;
+    actionableTaskCount = 0;
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimator.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimator.java
@@ -15,31 +15,34 @@
 
 package com.uber.cadence.internal.worker.autoscaler;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class PollerUsageEstimator {
 
-  private int noopTaskCount;
-  private int actionableTaskCount;
+  private AtomicInteger noopTaskCount = new AtomicInteger();
+  private AtomicInteger actionableTaskCount = new AtomicInteger();
 
   public void increaseNoopTaskCount() {
-    noopTaskCount += 1;
+    noopTaskCount.addAndGet(1);
   }
 
   public void increaseActionableTaskCount() {
-    actionableTaskCount += 1;
+    actionableTaskCount.addAndGet(1);
   }
 
   public PollerUsage estimate() {
-    if (noopTaskCount + actionableTaskCount == 0) {
+    int actionableTasks = actionableTaskCount.get();
+    int noopTasks = noopTaskCount.get();
+    if (noopTasks + actionableTasks == 0) {
       return new PollerUsage(0);
     }
-    PollerUsage result =
-        new PollerUsage((actionableTaskCount * 1f) / (noopTaskCount + actionableTaskCount));
+    PollerUsage result = new PollerUsage((actionableTasks * 1f) / (noopTasks + actionableTasks));
     reset();
     return result;
   }
 
   public void reset() {
-    noopTaskCount = 0;
-    actionableTaskCount = 0;
+    noopTaskCount.set(0);
+    actionableTaskCount.set(0);
   }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/Recommender.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/Recommender.java
@@ -28,16 +28,12 @@ public class Recommender {
   }
 
   public int recommend(int currentPollers, float pollerUtilizationRate) {
-    int recommended = 0;
-
     if (pollerUtilizationRate == 1) {
       return upperValue;
     }
 
     float r = currentPollers * pollerUtilizationRate / targetPollerUtilRate;
-    r = Math.min(upperValue, Math.max(lowerValue, r));
-    recommended += r;
-    return recommended;
+    return Math.round(Math.min(upperValue, Math.max(lowerValue, r)));
   }
 
   public int getUpperValue() {

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/Recommender.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/Recommender.java
@@ -1,0 +1,50 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+public class Recommender {
+
+  private final float targetPollerUtilRate;
+  private final int upperValue;
+  private final int lowerValue;
+
+  public Recommender(float targetPollerUtilRate, int upperValue, int lowerValue) {
+    this.targetPollerUtilRate = targetPollerUtilRate;
+    this.upperValue = upperValue;
+    this.lowerValue = lowerValue;
+  }
+
+  public int recommend(int currentPollers, float pollerUtilizationRate) {
+    int recommended = 0;
+
+    if (pollerUtilizationRate == 1) {
+      return upperValue;
+    }
+
+    float r = currentPollers * pollerUtilizationRate / targetPollerUtilRate;
+    r = Math.min(upperValue, Math.max(lowerValue, r));
+    recommended += r;
+    return recommended;
+  }
+
+  public int getUpperValue() {
+    return upperValue;
+  }
+
+  public int getLowerValue() {
+    return lowerValue;
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/ResizableSemaphore.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/ResizableSemaphore.java
@@ -1,0 +1,28 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+import java.util.concurrent.Semaphore;
+
+public class ResizableSemaphore extends Semaphore {
+  public ResizableSemaphore(int permits) {
+    super(permits);
+  }
+
+  public void decreasePermits(int reduction) {
+    reducePermits(reduction);
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScalerTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScalerTest.java
@@ -1,0 +1,33 @@
+package com.uber.cadence.internal.worker.autoscaler;
+
+import static org.junit.Assert.*;
+
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PollerAutoScalerTest {
+
+  @Test
+  public void testAutoScalerScalesPollers() {
+    PollerUsageEstimator pollerUsageEstimator = new PollerUsageEstimator();
+    Recommender recommender = new Recommender(0.5f, 100, 10, "test");
+    PollerAutoScaler pollerAutoScaler =
+        new PollerAutoScaler(Duration.ofSeconds(1), pollerUsageEstimator, recommender);
+
+    assertEquals(100, pollerAutoScaler.getSemaphoreSize());
+
+    pollerUsageEstimator.increaseActionableTaskCount();
+    pollerAutoScaler.resizePollers();
+
+    assertEquals(100, pollerAutoScaler.getSemaphoreSize());
+
+    pollerUsageEstimator.increaseNoopTaskCount();
+
+    pollerAutoScaler.resizePollers();
+
+    assertEquals(10, pollerAutoScaler.getSemaphoreSize());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScalerTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScalerTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.internal.worker.autoscaler;
 
 import static org.junit.Assert.*;
@@ -13,7 +28,7 @@ public class PollerAutoScalerTest {
   @Test
   public void testAutoScalerScalesPollers() {
     PollerUsageEstimator pollerUsageEstimator = new PollerUsageEstimator();
-    Recommender recommender = new Recommender(0.5f, 100, 10, "test");
+    Recommender recommender = new Recommender(0.5f, 100, 10);
     PollerAutoScaler pollerAutoScaler =
         new PollerAutoScaler(Duration.ofSeconds(1), pollerUsageEstimator, recommender);
 

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimatorTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimatorTest.java
@@ -1,7 +1,24 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.internal.worker.autoscaler;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -47,5 +64,31 @@ public class PollerUsageEstimatorTest {
 
     pollerUsage = pollerUsageEstimator.estimate();
     assertEquals(0f, pollerUsage.getPollerUtilizationRate(), 0);
+  }
+
+  @Test
+  public void testThreadSafety() throws Exception {
+    PollerUsageEstimator pollerUsageEstimator = new PollerUsageEstimator();
+    List<Thread> threadList = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      threadList.add(
+          new Thread(
+              new Runnable() {
+                @Override
+                public void run() {
+                  for (int i = 0; i < 100; i++) {
+                    pollerUsageEstimator.increaseActionableTaskCount();
+                  }
+                }
+              }));
+    }
+
+    threadList.forEach(Thread::start);
+    for (Thread thread : threadList) {
+      thread.join();
+    }
+
+    pollerUsageEstimator.increaseNoopTaskCount();
+    assertEquals(10000f / 10001, pollerUsageEstimator.estimate().getPollerUtilizationRate(), 0);
   }
 }

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimatorTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/PollerUsageEstimatorTest.java
@@ -1,0 +1,51 @@
+package com.uber.cadence.internal.worker.autoscaler;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PollerUsageEstimatorTest {
+
+  @Test
+  public void testUsageIsZero() {
+    PollerUsageEstimator pollerUsageEstimator = new PollerUsageEstimator();
+    PollerUsage pollerUsage = pollerUsageEstimator.estimate();
+    assertEquals(0f, pollerUsage.getPollerUtilizationRate(), 0);
+  }
+
+  @Test
+  public void testUsagesIs100Percent() {
+    PollerUsageEstimator pollerUsageEstimator = new PollerUsageEstimator();
+    pollerUsageEstimator.increaseActionableTaskCount();
+    pollerUsageEstimator.increaseActionableTaskCount();
+    PollerUsage pollerUsage = pollerUsageEstimator.estimate();
+    assertEquals(1f, pollerUsage.getPollerUtilizationRate(), 0);
+  }
+
+  @Test
+  public void testUsageCalculatedCorrectly() {
+    PollerUsageEstimator pollerUsageEstimator = new PollerUsageEstimator();
+    pollerUsageEstimator.increaseNoopTaskCount();
+    pollerUsageEstimator.increaseActionableTaskCount();
+    pollerUsageEstimator.increaseNoopTaskCount();
+    pollerUsageEstimator.increaseNoopTaskCount();
+
+    PollerUsage pollerUsage = pollerUsageEstimator.estimate();
+    assertEquals(0.25f, pollerUsage.getPollerUtilizationRate(), 0);
+  }
+
+  @Test
+  public void estimationIsReset() {
+    PollerUsageEstimator pollerUsageEstimator = new PollerUsageEstimator();
+    pollerUsageEstimator.increaseActionableTaskCount();
+
+    PollerUsage pollerUsage = pollerUsageEstimator.estimate();
+    assertEquals(1f, pollerUsage.getPollerUtilizationRate(), 0);
+
+    pollerUsage = pollerUsageEstimator.estimate();
+    assertEquals(0f, pollerUsage.getPollerUtilizationRate(), 0);
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/RecommenderTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/RecommenderTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.internal.worker.autoscaler;
 
 import static org.junit.Assert.*;

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/RecommenderTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/RecommenderTest.java
@@ -1,0 +1,57 @@
+package com.uber.cadence.internal.worker.autoscaler;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RecommenderTest {
+
+  @Test
+  public void pollerUnderutilizedShouldReduceToLowerBound() {
+    Recommender recommender = new Recommender(0.5f, 100, 1);
+
+    int recommendedPollerCount = recommender.recommend(100, 0);
+    assertEquals(1, recommendedPollerCount);
+  }
+
+  @Test
+  public void pollerUnderUtilsedShouldReduce() {
+    Recommender recommender = new Recommender(0.5f, 100, 1);
+
+    int recommendedPollerCount = recommender.recommend(100, 0.1f);
+    assertEquals(20, recommendedPollerCount);
+  }
+
+  @Test
+  public void polleratTargetRateShouldRemainUnchanged() {
+    Recommender recommender = new Recommender(0.5f, 100, 1);
+    int recommendedPollerCount = recommender.recommend(25, 0.5f);
+    assertEquals(25, recommendedPollerCount);
+  }
+
+  @Test
+  public void pollerOverUtilised100PercentShouldAddPollersToMax() {
+    Recommender recommender = new Recommender(0.5f, 100, 1);
+
+    int recommendedPollerCount = recommender.recommend(5, 1);
+    assertEquals(100, recommendedPollerCount);
+  }
+
+  @Test
+  public void pollerOverUtilisedShouldAddPollers() {
+    Recommender recommender = new Recommender(0.4f, 100, 1);
+    int recommendedPollerCount = recommender.recommend(10, 0.8f);
+    assertEquals(20, recommendedPollerCount);
+  }
+
+  @Test
+  public void pollerOverUtilisedUpperBound() {
+    Recommender recommender = new Recommender(0.5f, 100, 1);
+
+    int recommendedPollerCount = recommender.recommend(99, 1);
+    assertEquals(100, recommendedPollerCount);
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/ResizableSemaphoreTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/ResizableSemaphoreTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.uber.cadence.internal.worker.autoscaler;
 
 import static org.junit.Assert.*;

--- a/src/test/java/com/uber/cadence/internal/worker/autoscaler/ResizableSemaphoreTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/autoscaler/ResizableSemaphoreTest.java
@@ -1,0 +1,29 @@
+package com.uber.cadence.internal.worker.autoscaler;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResizableSemaphoreTest {
+
+  @Test
+  public void releaseIncreasesNumberOfAvailablePermits() {
+    ResizableSemaphore resizableSemaphore = new ResizableSemaphore(10);
+
+    resizableSemaphore.release(2);
+
+    assertEquals(12, resizableSemaphore.availablePermits());
+  }
+
+  @Test
+  public void decreasePermitsDecreasesNumberOfAvailablePermits() {
+    ResizableSemaphore resizableSemaphore = new ResizableSemaphore(10);
+
+    resizableSemaphore.decreasePermits(2);
+
+    assertEquals(8, resizableSemaphore.availablePermits());
+  }
+}


### PR DESCRIPTION
Initial implementation for poller autoscaler.

How it works:
Feature will be under feature flag.
If enabled, every 60 seconds it will recalculate the optimal number of pollers based on the amount of empty polls vs polls that return tasks. 

the pollerThreadCount is treated as the defined maximum so autoscaler can only scale between 1poller and the defined poller amount.

Resizable semaphore is used for controlling number of polls allowed.