### PR TITLE
Making dynamic poller configurable.

### DIFF
--- a/src/main/java/com/uber/cadence/internal/worker/Poller.java
+++ b/src/main/java/com/uber/cadence/internal/worker/Poller.java
@@ -26,11 +26,6 @@ import com.uber.cadence.internal.worker.autoscaler.PollerAutoScaler;
 import com.uber.cadence.internal.worker.autoscaler.PollerUsageEstimator;
 import com.uber.cadence.internal.worker.autoscaler.Recommender;
 import com.uber.m3.tally.Scope;
-import org.apache.thrift.TException;
-import org.apache.thrift.transport.TTransportException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -38,6 +33,10 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class Poller<T> implements SuspendableWorker {
 
@@ -98,10 +97,13 @@ public final class Poller<T> implements SuspendableWorker {
     if (pollerOptions.getPollerAutoScalerOptions() != null) {
       PollerAutoScalerOptions autoScalerOptions = pollerOptions.getPollerAutoScalerOptions();
       this.pollerAutoScaler =
-              new PollerAutoScaler(
-                      autoScalerOptions.getPollerScalingInterval(),
-                      new PollerUsageEstimator(),
-                      new Recommender(autoScalerOptions.getTargetPollerUtilisation(), pollerOptions.getPollThreadCount(), autoScalerOptions.getMinConcurrentPollers()));
+          new PollerAutoScaler(
+              autoScalerOptions.getPollerScalingInterval(),
+              new PollerUsageEstimator(),
+              new Recommender(
+                  autoScalerOptions.getTargetPollerUtilisation(),
+                  pollerOptions.getPollThreadCount(),
+                  autoScalerOptions.getMinConcurrentPollers()));
     } else {
       this.pollerAutoScaler = new NoopAutoScaler();
     }

--- a/src/main/java/com/uber/cadence/internal/worker/PollerAutoScalerOptions.java
+++ b/src/main/java/com/uber/cadence/internal/worker/PollerAutoScalerOptions.java
@@ -1,0 +1,101 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public class PollerAutoScalerOptions {
+
+    private Duration pollerScalingInterval;
+    private int minConcurrentPollers;
+    private float targetPollerUtilisation;
+
+    private PollerAutoScalerOptions() {
+    }
+
+    public static class Builder {
+
+        private Duration pollerScalingInterval = Duration.ofMinutes(1);
+        private int minConcurrentPollers = 1;
+        private float targetPollerUtilisation = 0.6f;
+
+        private Builder() {
+        }
+
+        public static Builder newBuilder() {
+            return new Builder();
+        }
+
+        public Builder setPollerScalingInterval(Duration duration) {
+            this.pollerScalingInterval = duration;
+            return this;
+        }
+
+        public Builder setMinConcurrentPollers(int minConcurrentPollers) {
+            this.minConcurrentPollers = minConcurrentPollers;
+            return this;
+        }
+
+        public Builder setTargetPollerUtilisation(float targetPollerUtilisation) {
+            this.targetPollerUtilisation = targetPollerUtilisation;
+            return this;
+        }
+
+        public PollerAutoScalerOptions build() {
+            PollerAutoScalerOptions pollerAutoScalerOptions = new PollerAutoScalerOptions();
+            pollerAutoScalerOptions.pollerScalingInterval = this.pollerScalingInterval;
+            pollerAutoScalerOptions.minConcurrentPollers = this.minConcurrentPollers;
+            pollerAutoScalerOptions.targetPollerUtilisation = this.targetPollerUtilisation;
+            return pollerAutoScalerOptions;
+        }
+    }
+
+    public Duration getPollerScalingInterval() {
+        return pollerScalingInterval;
+    }
+
+    public int getMinConcurrentPollers() {
+        return minConcurrentPollers;
+    }
+
+    public float getTargetPollerUtilisation() {
+        return targetPollerUtilisation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PollerAutoScalerOptions that = (PollerAutoScalerOptions) o;
+        return minConcurrentPollers == that.minConcurrentPollers && Float.compare(that.targetPollerUtilisation, targetPollerUtilisation) == 0 &&
+                Objects.equals(pollerScalingInterval, that.pollerScalingInterval);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pollerScalingInterval, minConcurrentPollers, targetPollerUtilisation);
+    }
+
+    @Override
+    public String toString() {
+        return "PollerAutoScalerOptions{" +
+                "pollerScalingInterval=" + pollerScalingInterval +
+                ", minConcurrentPollers=" + minConcurrentPollers +
+                ", targetPollerUtilisation=" + targetPollerUtilisation +
+                '}';
+    }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/PollerAutoScalerOptions.java
+++ b/src/main/java/com/uber/cadence/internal/worker/PollerAutoScalerOptions.java
@@ -20,82 +20,84 @@ import java.util.Objects;
 
 public class PollerAutoScalerOptions {
 
-    private Duration pollerScalingInterval;
-    private int minConcurrentPollers;
-    private float targetPollerUtilisation;
+  private Duration pollerScalingInterval;
+  private int minConcurrentPollers;
+  private float targetPollerUtilisation;
 
-    private PollerAutoScalerOptions() {
+  private PollerAutoScalerOptions() {}
+
+  public static class Builder {
+
+    private Duration pollerScalingInterval = Duration.ofMinutes(1);
+    private int minConcurrentPollers = 1;
+    private float targetPollerUtilisation = 0.6f;
+
+    private Builder() {}
+
+    public static Builder newBuilder() {
+      return new Builder();
     }
 
-    public static class Builder {
-
-        private Duration pollerScalingInterval = Duration.ofMinutes(1);
-        private int minConcurrentPollers = 1;
-        private float targetPollerUtilisation = 0.6f;
-
-        private Builder() {
-        }
-
-        public static Builder newBuilder() {
-            return new Builder();
-        }
-
-        public Builder setPollerScalingInterval(Duration duration) {
-            this.pollerScalingInterval = duration;
-            return this;
-        }
-
-        public Builder setMinConcurrentPollers(int minConcurrentPollers) {
-            this.minConcurrentPollers = minConcurrentPollers;
-            return this;
-        }
-
-        public Builder setTargetPollerUtilisation(float targetPollerUtilisation) {
-            this.targetPollerUtilisation = targetPollerUtilisation;
-            return this;
-        }
-
-        public PollerAutoScalerOptions build() {
-            PollerAutoScalerOptions pollerAutoScalerOptions = new PollerAutoScalerOptions();
-            pollerAutoScalerOptions.pollerScalingInterval = this.pollerScalingInterval;
-            pollerAutoScalerOptions.minConcurrentPollers = this.minConcurrentPollers;
-            pollerAutoScalerOptions.targetPollerUtilisation = this.targetPollerUtilisation;
-            return pollerAutoScalerOptions;
-        }
+    public Builder setPollerScalingInterval(Duration duration) {
+      this.pollerScalingInterval = duration;
+      return this;
     }
 
-    public Duration getPollerScalingInterval() {
-        return pollerScalingInterval;
+    public Builder setMinConcurrentPollers(int minConcurrentPollers) {
+      this.minConcurrentPollers = minConcurrentPollers;
+      return this;
     }
 
-    public int getMinConcurrentPollers() {
-        return minConcurrentPollers;
+    public Builder setTargetPollerUtilisation(float targetPollerUtilisation) {
+      this.targetPollerUtilisation = targetPollerUtilisation;
+      return this;
     }
 
-    public float getTargetPollerUtilisation() {
-        return targetPollerUtilisation;
+    public PollerAutoScalerOptions build() {
+      PollerAutoScalerOptions pollerAutoScalerOptions = new PollerAutoScalerOptions();
+      pollerAutoScalerOptions.pollerScalingInterval = this.pollerScalingInterval;
+      pollerAutoScalerOptions.minConcurrentPollers = this.minConcurrentPollers;
+      pollerAutoScalerOptions.targetPollerUtilisation = this.targetPollerUtilisation;
+      return pollerAutoScalerOptions;
     }
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PollerAutoScalerOptions that = (PollerAutoScalerOptions) o;
-        return minConcurrentPollers == that.minConcurrentPollers && Float.compare(that.targetPollerUtilisation, targetPollerUtilisation) == 0 &&
-                Objects.equals(pollerScalingInterval, that.pollerScalingInterval);
-    }
+  public Duration getPollerScalingInterval() {
+    return pollerScalingInterval;
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(pollerScalingInterval, minConcurrentPollers, targetPollerUtilisation);
-    }
+  public int getMinConcurrentPollers() {
+    return minConcurrentPollers;
+  }
 
-    @Override
-    public String toString() {
-        return "PollerAutoScalerOptions{" +
-                "pollerScalingInterval=" + pollerScalingInterval +
-                ", minConcurrentPollers=" + minConcurrentPollers +
-                ", targetPollerUtilisation=" + targetPollerUtilisation +
-                '}';
-    }
+  public float getTargetPollerUtilisation() {
+    return targetPollerUtilisation;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PollerAutoScalerOptions that = (PollerAutoScalerOptions) o;
+    return minConcurrentPollers == that.minConcurrentPollers
+        && Float.compare(that.targetPollerUtilisation, targetPollerUtilisation) == 0
+        && Objects.equals(pollerScalingInterval, that.pollerScalingInterval);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pollerScalingInterval, minConcurrentPollers, targetPollerUtilisation);
+  }
+
+  @Override
+  public String toString() {
+    return "PollerAutoScalerOptions{"
+        + "pollerScalingInterval="
+        + pollerScalingInterval
+        + ", minConcurrentPollers="
+        + minConcurrentPollers
+        + ", targetPollerUtilisation="
+        + targetPollerUtilisation
+        + '}';
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/PollerOptions.java
+++ b/src/main/java/com/uber/cadence/internal/worker/PollerOptions.java
@@ -167,7 +167,7 @@ public final class PollerOptions {
           uncaughtExceptionHandler,
           pollThreadNamePrefix,
           pollOnlyIfExecutorHasCapacity,
-              pollerAutoScalerOptions);
+          pollerAutoScalerOptions);
     }
   }
 
@@ -192,16 +192,16 @@ public final class PollerOptions {
   private final PollerAutoScalerOptions pollerAutoScalerOptions;
 
   private PollerOptions(
-          int maximumPollRateIntervalMilliseconds,
-          double maximumPollRatePerSecond,
-          double pollBackoffCoefficient,
-          Duration pollBackoffInitialInterval,
-          Duration pollBackoffMaximumInterval,
-          int pollThreadCount,
-          Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
-          String pollThreadNamePrefix,
-          boolean pollOnlyIfExecutorHasCapacity,
-          PollerAutoScalerOptions pollerAutoScalerOptions) {
+      int maximumPollRateIntervalMilliseconds,
+      double maximumPollRatePerSecond,
+      double pollBackoffCoefficient,
+      Duration pollBackoffInitialInterval,
+      Duration pollBackoffMaximumInterval,
+      int pollThreadCount,
+      Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
+      String pollThreadNamePrefix,
+      boolean pollOnlyIfExecutorHasCapacity,
+      PollerAutoScalerOptions pollerAutoScalerOptions) {
     this.maximumPollRateIntervalMilliseconds = maximumPollRateIntervalMilliseconds;
     this.maximumPollRatePerSecond = maximumPollRatePerSecond;
     this.pollBackoffCoefficient = pollBackoffCoefficient;

--- a/src/main/java/com/uber/cadence/internal/worker/PollerOptions.java
+++ b/src/main/java/com/uber/cadence/internal/worker/PollerOptions.java
@@ -64,6 +64,8 @@ public final class PollerOptions {
 
     private Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
 
+    private PollerAutoScalerOptions pollerAutoScalerOptions;
+
     private Builder() {}
 
     private Builder(PollerOptions o) {
@@ -79,6 +81,7 @@ public final class PollerOptions {
       this.pollThreadNamePrefix = o.getPollThreadNamePrefix();
       this.pollOnlyIfExecutorHasCapacity = o.getPollOnlyIfExecutorHasCapacity();
       this.uncaughtExceptionHandler = o.getUncaughtExceptionHandler();
+      this.pollerAutoScalerOptions = o.getPollerAutoScalerOptions();
     }
 
     /** Defines interval for measuring poll rate. Larger the interval more spiky can be the load. */
@@ -145,6 +148,11 @@ public final class PollerOptions {
       return this;
     }
 
+    public Builder setPollerAutoScalerOptions(PollerAutoScalerOptions pollerAutoScalerOptions) {
+      this.pollerAutoScalerOptions = pollerAutoScalerOptions;
+      return this;
+    }
+
     public PollerOptions build() {
       if (uncaughtExceptionHandler == null) {
         uncaughtExceptionHandler = (t, e) -> log.error("uncaught exception", e);
@@ -158,7 +166,8 @@ public final class PollerOptions {
           pollThreadCount,
           uncaughtExceptionHandler,
           pollThreadNamePrefix,
-          pollOnlyIfExecutorHasCapacity);
+          pollOnlyIfExecutorHasCapacity,
+              pollerAutoScalerOptions);
     }
   }
 
@@ -180,16 +189,19 @@ public final class PollerOptions {
 
   private final Boolean pollOnlyIfExecutorHasCapacity;
 
+  private final PollerAutoScalerOptions pollerAutoScalerOptions;
+
   private PollerOptions(
-      int maximumPollRateIntervalMilliseconds,
-      double maximumPollRatePerSecond,
-      double pollBackoffCoefficient,
-      Duration pollBackoffInitialInterval,
-      Duration pollBackoffMaximumInterval,
-      int pollThreadCount,
-      Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
-      String pollThreadNamePrefix,
-      boolean pollOnlyIfExecutorHasCapacity) {
+          int maximumPollRateIntervalMilliseconds,
+          double maximumPollRatePerSecond,
+          double pollBackoffCoefficient,
+          Duration pollBackoffInitialInterval,
+          Duration pollBackoffMaximumInterval,
+          int pollThreadCount,
+          Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
+          String pollThreadNamePrefix,
+          boolean pollOnlyIfExecutorHasCapacity,
+          PollerAutoScalerOptions pollerAutoScalerOptions) {
     this.maximumPollRateIntervalMilliseconds = maximumPollRateIntervalMilliseconds;
     this.maximumPollRatePerSecond = maximumPollRatePerSecond;
     this.pollBackoffCoefficient = pollBackoffCoefficient;
@@ -199,6 +211,7 @@ public final class PollerOptions {
     this.uncaughtExceptionHandler = uncaughtExceptionHandler;
     this.pollThreadNamePrefix = pollThreadNamePrefix;
     this.pollOnlyIfExecutorHasCapacity = pollOnlyIfExecutorHasCapacity;
+    this.pollerAutoScalerOptions = pollerAutoScalerOptions;
   }
 
   public int getMaximumPollRateIntervalMilliseconds() {
@@ -237,6 +250,10 @@ public final class PollerOptions {
     return pollOnlyIfExecutorHasCapacity;
   }
 
+  public PollerAutoScalerOptions getPollerAutoScalerOptions() {
+    return pollerAutoScalerOptions;
+  }
+
   @Override
   public String toString() {
     return "PollerOptions{"
@@ -256,6 +273,8 @@ public final class PollerOptions {
         + pollThreadNamePrefix
         + ", pollOnlyIfExecutorHasCapacity='"
         + pollOnlyIfExecutorHasCapacity
+        + ", pollerAutoScalerOptions='"
+        + pollerAutoScalerOptions
         + '\''
         + '}';
   }

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/AutoScaler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/AutoScaler.java
@@ -1,0 +1,39 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+/**
+ * Poller autoscaler interface for acquiring and releasing locks. In order to control number of concurrent operations.
+ */
+public interface AutoScaler {
+
+    void start();
+    void stop();
+
+    /**
+     * Reduce the number of available locks. Intended to be blocking operation until lock is acquired.
+     */
+    void acquire() throws InterruptedException;
+
+    /**
+     * Releases lock into the autoscaler pool. Release should be always called in same process, failing to do so is considered a usage error.
+     */
+    void release();
+
+    void increaseNoopPollCount();
+
+    void increaseActionablePollCount();
+}

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/AutoScaler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/AutoScaler.java
@@ -16,24 +16,27 @@
 package com.uber.cadence.internal.worker.autoscaler;
 
 /**
- * Poller autoscaler interface for acquiring and releasing locks. In order to control number of concurrent operations.
+ * Poller autoscaler interface for acquiring and releasing locks. In order to control number of
+ * concurrent operations.
  */
 public interface AutoScaler {
 
-    void start();
-    void stop();
+  void start();
 
-    /**
-     * Reduce the number of available locks. Intended to be blocking operation until lock is acquired.
-     */
-    void acquire() throws InterruptedException;
+  void stop();
 
-    /**
-     * Releases lock into the autoscaler pool. Release should be always called in same process, failing to do so is considered a usage error.
-     */
-    void release();
+  /**
+   * Reduce the number of available locks. Intended to be blocking operation until lock is acquired.
+   */
+  void acquire() throws InterruptedException;
 
-    void increaseNoopPollCount();
+  /**
+   * Releases lock into the autoscaler pool. Release should be always called in same process,
+   * failing to do so is considered a usage error.
+   */
+  void release();
 
-    void increaseActionablePollCount();
+  void increaseNoopPollCount();
+
+  void increaseActionablePollCount();
 }

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/AutoScalerFactory.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/AutoScalerFactory.java
@@ -1,0 +1,45 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+import com.uber.cadence.internal.worker.PollerAutoScalerOptions;
+import com.uber.cadence.internal.worker.PollerOptions;
+
+public class AutoScalerFactory {
+
+  private static final AutoScalerFactory INSTANCE = new AutoScalerFactory();
+
+  private AutoScalerFactory() {}
+
+  public AutoScaler createAutoScaler(PollerOptions pollerOptions) {
+    if (pollerOptions == null || pollerOptions.getPollerAutoScalerOptions() == null) {
+      return new NoopAutoScaler();
+    }
+
+    PollerAutoScalerOptions autoScalerOptions = pollerOptions.getPollerAutoScalerOptions();
+    return new PollerAutoScaler(
+        autoScalerOptions.getPollerScalingInterval(),
+        new PollerUsageEstimator(),
+        new Recommender(
+            autoScalerOptions.getTargetPollerUtilisation(),
+            pollerOptions.getPollThreadCount(),
+            autoScalerOptions.getMinConcurrentPollers()));
+  }
+
+  public static AutoScalerFactory getInstance() {
+    return INSTANCE;
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/NoopAutoScaler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/NoopAutoScaler.java
@@ -16,33 +16,33 @@
 package com.uber.cadence.internal.worker.autoscaler;
 
 public class NoopAutoScaler implements AutoScaler {
-    @Override
-    public void start() {
-        // NOOP
-    }
+  @Override
+  public void start() {
+    // NOOP
+  }
 
-    @Override
-    public void stop() {
-        // NOOP
-    }
+  @Override
+  public void stop() {
+    // NOOP
+  }
 
-    @Override
-    public void acquire() throws InterruptedException {
-        // NOOP
-    }
+  @Override
+  public void acquire() throws InterruptedException {
+    // NOOP
+  }
 
-    @Override
-    public void release() {
-        // NOOP
-    }
+  @Override
+  public void release() {
+    // NOOP
+  }
 
-    @Override
-    public void increaseNoopPollCount() {
-        // NOOP
-    }
+  @Override
+  public void increaseNoopPollCount() {
+    // NOOP
+  }
 
-    @Override
-    public void increaseActionablePollCount() {
-        // NOOP
-    }
+  @Override
+  public void increaseActionablePollCount() {
+    // NOOP
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/NoopAutoScaler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/NoopAutoScaler.java
@@ -1,0 +1,48 @@
+/*
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.worker.autoscaler;
+
+public class NoopAutoScaler implements AutoScaler {
+    @Override
+    public void start() {
+        // NOOP
+    }
+
+    @Override
+    public void stop() {
+        // NOOP
+    }
+
+    @Override
+    public void acquire() throws InterruptedException {
+        // NOOP
+    }
+
+    @Override
+    public void release() {
+        // NOOP
+    }
+
+    @Override
+    public void increaseNoopPollCount() {
+        // NOOP
+    }
+
+    @Override
+    public void increaseActionablePollCount() {
+        // NOOP
+    }
+}

--- a/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScaler.java
+++ b/src/main/java/com/uber/cadence/internal/worker/autoscaler/PollerAutoScaler.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PollerAutoScaler {
+public class PollerAutoScaler implements AutoScaler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PollerAutoScaler.class);
 
@@ -87,6 +87,16 @@ public class PollerAutoScaler {
 
   public void release() {
     semaphore.release();
+  }
+
+  @Override
+  public void increaseNoopPollCount() {
+    pollerUsageEstimator.increaseNoopTaskCount();
+  }
+
+  @Override
+  public void increaseActionablePollCount() {
+    pollerUsageEstimator.increaseActionableTaskCount();
   }
 
   // For testing


### PR DESCRIPTION
Starting to use dynamic poller and making it configurable.

Initial dynamic poller implementation:

https://github.com/uber/cadence-java-client/pull/761

**Why dynamic poller is needed?**

Dynamic poller allows lowering the amount of polls for bursty traffic (when there are no workflows we downsize the poller amount to ease the load on the server)

**Testing**

This was tested by running cadence-java-sample

Observing pollers dropping to 1 because there are no tasks available.
Executing 100 workflows 
Seeing pollers increase to handle the available tasks
Then observing again poller amount decreasing since there are no more workflows left to process.

Additionally unit tests are available for the different components like Recommender, UsageEstimator.

