### PR TITLE
Remove reflective objects exception due to failing builds.

### DIFF
--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/EnumMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/EnumMapper.java
@@ -35,7 +35,6 @@ import com.uber.cadence.TaskListKind;
 import com.uber.cadence.TimeoutType;
 import com.uber.cadence.WorkflowExecutionCloseStatus;
 import com.uber.cadence.WorkflowIdReusePolicy;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 class EnumMapper {
 
@@ -270,7 +269,7 @@ class EnumMapper {
       case ENCODING_TYPE_JSON:
         return EncodingType.JSON;
       case ENCODING_TYPE_PROTO3:
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
     throw new IllegalArgumentException("unexpected enum value");
   }


### PR DESCRIPTION
Why this is done?

Multiple people have encountered issues building the project due to this import.

The exception:

error: package sun.reflect.generics.reflectiveObjects is not visible
import sun.reflect.generics.reflectiveObjects.NotImplementedException;
                           ^
  (package sun.reflect.generics.reflectiveObjects is declared in module java.base, which does not export it to the unnamed module)
