### PR TITLE
Adding ability to override activity options.

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/ActivityInvocationHandler.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityInvocationHandler.java
@@ -24,6 +24,7 @@ import com.uber.cadence.workflow.ActivityStub;
 import com.uber.cadence.workflow.WorkflowInterceptor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.function.Function;
 
 class ActivityInvocationHandler extends ActivityInvocationHandlerBase {
@@ -43,9 +44,30 @@ class ActivityInvocationHandler extends ActivityInvocationHandlerBase {
   @Override
   protected Function<Object[], Object> getActivityFunc(
       Method method, MethodRetry methodRetry, ActivityMethod activityMethod, String activityName) {
+
+    ActivityOptions activityOptionsOverride = null;
+    WorkflowThread workflowThread = WorkflowInternal.getRootWorkflowContext();
+    if (workflowThread.getDecisionContext() != null
+        && workflowThread.getDecisionContext().getWorkflowImplementationOptions() != null) {
+      Map<String, ActivityOptions> activityOptionsMap =
+          workflowThread
+              .getDecisionContext()
+              .getWorkflowImplementationOptions()
+              .getActivityOptions();
+
+      if (activityOptionsMap.containsKey(activityName)) {
+        activityOptionsOverride = activityOptionsMap.get(activityName);
+      }
+    }
+
     Function<Object[], Object> function;
     ActivityOptions mergedOptions = ActivityOptions.merge(activityMethod, methodRetry, options);
-    ActivityStub stub = ActivityStubImpl.newInstance(mergedOptions, activityExecutor);
+    ActivityStub stub;
+    if (activityOptionsOverride == null) {
+      stub = ActivityStubImpl.newInstance(mergedOptions, activityExecutor);
+    } else {
+      stub = ActivityStubImpl.newInstance(activityOptionsOverride, activityExecutor);
+    }
 
     function =
         (a) -> stub.execute(activityName, method.getReturnType(), method.getGenericReturnType(), a);

--- a/src/main/java/com/uber/cadence/internal/sync/ActivityInvocationHandler.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ActivityInvocationHandler.java
@@ -66,7 +66,8 @@ class ActivityInvocationHandler extends ActivityInvocationHandlerBase {
     if (activityOptionsOverride == null) {
       stub = ActivityStubImpl.newInstance(mergedOptions, activityExecutor);
     } else {
-      stub = ActivityStubImpl.newInstance(activityOptionsOverride, activityExecutor);
+      ActivityOptions mergedOverrideOptions = ActivityOptions.merge(activityMethod, methodRetry, activityOptionsOverride);
+      stub = ActivityStubImpl.newInstance(mergedOverrideOptions, activityExecutor);
     }
 
     function =

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -187,7 +187,12 @@ class DeterministicRunnerImpl implements DeterministicRunner {
 
   private static SyncDecisionContext newDummySyncDecisionContext() {
     return new SyncDecisionContext(
-        new DummyDecisionContext(), JsonDataConverter.getInstance(), null, (next) -> next, null);
+        new DummyDecisionContext(),
+        JsonDataConverter.getInstance(),
+        null,
+        (next) -> next,
+        null,
+        null);
   }
 
   SyncDecisionContext getDecisionContext() {

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -40,6 +40,7 @@ import com.uber.cadence.internal.replay.ExecuteActivityParameters;
 import com.uber.cadence.internal.replay.ExecuteLocalActivityParameters;
 import com.uber.cadence.internal.replay.SignalExternalWorkflowParameters;
 import com.uber.cadence.internal.replay.StartChildWorkflowExecutionParameters;
+import com.uber.cadence.worker.WorkflowImplementationOptions;
 import com.uber.cadence.workflow.ActivityException;
 import com.uber.cadence.workflow.ActivityFailureException;
 import com.uber.cadence.workflow.ActivityTimeoutException;
@@ -88,13 +89,15 @@ final class SyncDecisionContext implements WorkflowInterceptor {
   private final WorkflowTimers timers = new WorkflowTimers();
   private final Map<String, Functions.Func1<byte[], byte[]>> queryCallbacks = new HashMap<>();
   private final byte[] lastCompletionResult;
+  private final WorkflowImplementationOptions workflowImplementationOptions;
 
   public SyncDecisionContext(
       DecisionContext context,
       DataConverter converter,
       List<ContextPropagator> contextPropagators,
       Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory,
-      byte[] lastCompletionResult) {
+      byte[] lastCompletionResult,
+      WorkflowImplementationOptions workflowImplementationOptions) {
     this.context = context;
     this.converter = converter;
     this.contextPropagators = contextPropagators;
@@ -105,6 +108,7 @@ final class SyncDecisionContext implements WorkflowInterceptor {
     }
     this.headInterceptor = interceptor;
     this.lastCompletionResult = lastCompletionResult;
+    this.workflowImplementationOptions = workflowImplementationOptions;
   }
 
   /**
@@ -763,5 +767,9 @@ final class SyncDecisionContext implements WorkflowInterceptor {
 
     SearchAttributes attr = InternalUtils.convertMapToSearchAttributes(searchAttributes);
     context.upsertSearchAttributes(attr);
+  }
+
+  public WorkflowImplementationOptions getWorkflowImplementationOptions() {
+    return workflowImplementationOptions;
   }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/SyncWorkflow.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncWorkflow.java
@@ -96,7 +96,8 @@ class SyncWorkflow implements ReplayWorkflow {
             dataConverter,
             contextPropagators,
             interceptorFactory,
-            event.getWorkflowExecutionStartedEventAttributes().getLastCompletionResult());
+            event.getWorkflowExecutionStartedEventAttributes().getLastCompletionResult(),
+            workflowImplementationOptions);
 
     workflowProc =
         new WorkflowRunnable(

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
@@ -390,4 +390,8 @@ public final class WorkflowInternal {
   public static void upsertSearchAttributes(Map<String, Object> searchAttributes) {
     getWorkflowInterceptor().upsertSearchAttributes(searchAttributes);
   }
+
+  public static WorkflowThread getRootWorkflowContext() {
+    return DeterministicRunnerImpl.currentThreadInternal();
+  }
 }

--- a/src/main/java/com/uber/cadence/worker/WorkflowImplementationOptions.java
+++ b/src/main/java/com/uber/cadence/worker/WorkflowImplementationOptions.java
@@ -19,6 +19,9 @@ package com.uber.cadence.worker;
 
 import static com.uber.cadence.worker.NonDeterministicWorkflowPolicy.BlockWorkflow;
 
+import com.uber.cadence.activity.ActivityOptions;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public final class WorkflowImplementationOptions {
@@ -26,6 +29,7 @@ public final class WorkflowImplementationOptions {
   public static final class Builder {
 
     private NonDeterministicWorkflowPolicy nonDeterministicWorkflowPolicy = BlockWorkflow;
+    private Map<String, ActivityOptions> activityOptions = new HashMap<>();
 
     /**
      * Optional: Sets how decision worker deals with non-deterministic history events (presumably
@@ -39,20 +43,43 @@ public final class WorkflowImplementationOptions {
       return this;
     }
 
+    /**
+     * Set overrides for a specific workflow implementation for activity options.
+     *
+     * @param activityOptions a map where the key is the activity name and the value is the activity
+     *     options that should override.
+     */
+    public Builder setActivityOptions(Map<String, ActivityOptions> activityOptions) {
+      this.activityOptions = activityOptions;
+      return this;
+    }
+
     public WorkflowImplementationOptions build() {
-      return new WorkflowImplementationOptions(nonDeterministicWorkflowPolicy);
+      return new WorkflowImplementationOptions(nonDeterministicWorkflowPolicy, activityOptions);
     }
   }
 
   private final NonDeterministicWorkflowPolicy nonDeterministicWorkflowPolicy;
+  private Map<String, ActivityOptions> activityOptions;
 
   public WorkflowImplementationOptions(
       NonDeterministicWorkflowPolicy nonDeterministicWorkflowPolicy) {
     this.nonDeterministicWorkflowPolicy = nonDeterministicWorkflowPolicy;
   }
 
+  public WorkflowImplementationOptions(
+      NonDeterministicWorkflowPolicy nonDeterministicWorkflowPolicy,
+      Map<String, ActivityOptions> activityOptions) {
+    this.nonDeterministicWorkflowPolicy = nonDeterministicWorkflowPolicy;
+    this.activityOptions = activityOptions;
+  }
+
   public NonDeterministicWorkflowPolicy getNonDeterministicWorkflowPolicy() {
     return nonDeterministicWorkflowPolicy;
+  }
+
+  public Map<String, ActivityOptions> getActivityOptions() {
+    return activityOptions;
   }
 
   @Override
@@ -60,6 +87,7 @@ public final class WorkflowImplementationOptions {
     return "WorkflowImplementationOptions{"
         + "nonDeterministicWorkflowPolicy="
         + nonDeterministicWorkflowPolicy
+        + activityOptions
         + '}';
   }
 
@@ -68,11 +96,12 @@ public final class WorkflowImplementationOptions {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     WorkflowImplementationOptions that = (WorkflowImplementationOptions) o;
-    return nonDeterministicWorkflowPolicy == that.nonDeterministicWorkflowPolicy;
+    return nonDeterministicWorkflowPolicy == that.nonDeterministicWorkflowPolicy
+        && Objects.equals(activityOptions, that.activityOptions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(nonDeterministicWorkflowPolicy);
+    return Objects.hash(nonDeterministicWorkflowPolicy, activityOptions);
   }
 }

--- a/src/main/java/com/uber/cadence/worker/WorkflowImplementationOptions.java
+++ b/src/main/java/com/uber/cadence/worker/WorkflowImplementationOptions.java
@@ -29,7 +29,7 @@ public final class WorkflowImplementationOptions {
   public static final class Builder {
 
     private NonDeterministicWorkflowPolicy nonDeterministicWorkflowPolicy = BlockWorkflow;
-    private Map<String, ActivityOptions> activityOptions = new HashMap<>();
+    private Map<String, ActivityOptions> activityOptionOverrides = new HashMap<>();
 
     /**
      * Optional: Sets how decision worker deals with non-deterministic history events (presumably
@@ -46,16 +46,16 @@ public final class WorkflowImplementationOptions {
     /**
      * Set overrides for a specific workflow implementation for activity options.
      *
-     * @param activityOptions a map where the key is the activity name and the value is the activity
-     *     options that should override.
+     * @param activityOptionOverrides a map where the key is the activity name and the value is the activity
+     *     options that should override existing activity configuration that comes from @ActivityMethod annotation.
      */
-    public Builder setActivityOptions(Map<String, ActivityOptions> activityOptions) {
-      this.activityOptions = activityOptions;
+    public Builder setActivityOptionOverrides(Map<String, ActivityOptions> activityOptionOverrides) {
+      this.activityOptionOverrides = activityOptionOverrides;
       return this;
     }
 
     public WorkflowImplementationOptions build() {
-      return new WorkflowImplementationOptions(nonDeterministicWorkflowPolicy, activityOptions);
+      return new WorkflowImplementationOptions(nonDeterministicWorkflowPolicy, activityOptionOverrides);
     }
   }
 

--- a/src/test/java/com/uber/cadence/internal/sync/DeterministicRunnerTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/DeterministicRunnerTest.java
@@ -727,7 +727,7 @@ public class DeterministicRunnerTest {
         new DeterministicRunnerImpl(
             threadPool,
             new SyncDecisionContext(
-                decisionContext, JsonDataConverter.getInstance(), null, next -> next, null),
+                decisionContext, JsonDataConverter.getInstance(), null, next -> next, null, null),
             () -> 0L, // clock override
             () -> {
               Promise<Void> thread =
@@ -752,7 +752,7 @@ public class DeterministicRunnerTest {
         new DeterministicRunnerImpl(
             threadPool,
             new SyncDecisionContext(
-                decisionContext, JsonDataConverter.getInstance(), null, next -> next, null),
+                decisionContext, JsonDataConverter.getInstance(), null, next -> next, null, null),
             () -> 0L, // clock override
             () -> {
               Promise<Void> thread =

--- a/src/test/java/com/uber/cadence/internal/sync/SyncDecisionContextTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/SyncDecisionContextTest.java
@@ -38,7 +38,7 @@ public class SyncDecisionContextTest {
   public void setUp() {
     this.context =
         new SyncDecisionContext(
-            mockDecisionContext, JsonDataConverter.getInstance(), null, (next) -> next, null);
+            mockDecisionContext, JsonDataConverter.getInstance(), null, (next) -> next, null, null);
   }
 
   @Test

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -6339,7 +6339,7 @@ public class WorkflowTest {
             .build());
 
     startWorkerFor(
-        new WorkflowImplementationOptions.Builder().setActivityOptions(activityOptionsMap).build(),
+        new WorkflowImplementationOptions.Builder().setActivityOptionOverrides(activityOptionsMap).build(),
         TestWorkflowActivityOptionOverride.class);
 
     TestWorkflow1 workflowStub =


### PR DESCRIPTION
Adding ability to override activity options by passing a map with keys that are activityName and the value is the activityOption.

This will allow to override the activityOptions for different implementations of an activity interface. Please check the accompanying WorkflowTest written to see the functionality. For example:

You have activity interface I and implementations A,B. You may want to have different StartToClose timeouts for A and B and before that was not possible so this feature will allow to do it.