### PR TITLE
Removing unnecessary openTelemetry bom dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,7 @@ dependencies {
     implementation 'io.grpc:grpc-protobuf:1.28.0'
     implementation 'io.grpc:grpc-stub:1.28.0'
 
-    compile(platform("io.opentelemetry:opentelemetry-bom:1.19.0"))
-    compile("io.opentelemetry:opentelemetry-api")
+    compile("io.opentelemetry:opentelemetry-api:1.19.0")
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'


### PR DESCRIPTION
Removing unecessary openTelemetry bom dependency since is is not needed for libraries. Since libraries should only depend on the opentelemetry-api dependency and users of the library will provide the openTelemetry sdk dependency if they need openTelemetry functionality.