### PR TITLE
Added hook for Google Java Format enforcement

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This hook automatically enforces the Google Java Format style on Java files using the goJF Gradle task.
+
+# Change directory to the root of the repository
+cd "$(git rev-parse --show-toplevel)"
+
+# Run the goJF Gradle task on all Java files that have been modified
+./gradlew goJF --quiet $(git diff --cached --name-only --diff-filter=ACM -- '*.java')
+


### PR DESCRIPTION
 Added pre-commit hook: whenever new code is being pushed, code enforcement will auto format the code.

Once added: please delete any pre-commit file if already exists in .git/hooks and run command (in .git/hooks) : "ln -s ../../hooks/pre-commit pre-commit"  to make a symbolic link pointing to the pre-commit file present in root directory's hooks.