### PR TITLE
[TestEnv] populate cronschedule in history start event

### DIFF
--- a/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/StateMachines.java
@@ -549,6 +549,7 @@ class StateMachines {
     if (data.continuedExecutionRunId.isPresent()) {
       a.setContinuedExecutionRunId(data.continuedExecutionRunId.get());
     }
+    a.setCronSchedule(data.cronSchedule);
     a.setLastCompletionResult(data.lastCompletionResult);
     a.setMemo(request.getMemo());
     a.setSearchAttributes((request.getSearchAttributes()));

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -424,6 +424,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
                 .setExecution(executionId.getExecution())
                 .setHistoryLength(history.size())
                 .setStartTime(history.get(0).getTimestamp())
+                .setIsCron(
+                    history.get(0).getWorkflowExecutionStartedEventAttributes().isSetCronSchedule())
                 .setType(
                     history.get(0).getWorkflowExecutionStartedEventAttributes().getWorkflowType());
         result.add(info);
@@ -442,6 +444,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
                 .setExecution(executionId.getExecution())
                 .setHistoryLength(history.size())
                 .setStartTime(history.get(0).getTimestamp())
+                .setIsCron(
+                    history.get(0).getWorkflowExecutionStartedEventAttributes().isSetCronSchedule())
                 .setType(
                     history.get(0).getWorkflowExecutionStartedEventAttributes().getWorkflowType())
                 .setCloseStatus(

--- a/src/test/java/com/uber/cadence/workflow/TestEnvironmentWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/TestEnvironmentWorkflowTest.java
@@ -1,0 +1,103 @@
+package com.uber.cadence.workflow;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.*;
+
+import com.uber.cadence.*;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.common.CronSchedule;
+import com.uber.cadence.testing.TestWorkflowEnvironment;
+import com.uber.cadence.worker.Worker;
+import java.time.Duration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestEnvironmentWorkflowTest {
+  static final String TASK_LIST = "tasklist";
+  static final String CRON_WORKFLOW_ID = "cron_workflow";
+
+  private TestWorkflowEnvironment testEnv;
+  private Worker worker;
+  private WorkflowClient workflowClient;
+
+  public interface CronW {
+    @WorkflowMethod(
+      executionStartToCloseTimeoutSeconds = 10,
+      workflowId = CRON_WORKFLOW_ID,
+      taskList = TASK_LIST
+    )
+    @CronSchedule("* * * * *")
+    void cron();
+  }
+
+  public static class CronWImpl implements CronW {
+    @Override
+    public void cron() {}
+  }
+
+  @Before
+  public void setUp() {
+    testEnv = TestWorkflowEnvironment.newInstance();
+    worker = testEnv.newWorker(TASK_LIST);
+    worker.registerWorkflowImplementationTypes(CronWImpl.class);
+    workflowClient = testEnv.newWorkflowClient();
+
+    testEnv.start();
+  }
+
+  @After
+  public void tearDown() {
+    testEnv.close();
+  }
+
+  @Test
+  public void testCronWorkflow() {
+    CronW workflow = workflowClient.newWorkflowStub(CronW.class);
+    WorkflowExecution execution = WorkflowClient.start(workflow::cron);
+    assertEquals(CRON_WORKFLOW_ID, execution.getWorkflowId());
+
+    // start event should have cron schedule
+    GetWorkflowExecutionHistoryRequest getRequest =
+        new GetWorkflowExecutionHistoryRequest()
+            .setDomain(testEnv.getDomain())
+            .setExecution(
+                new WorkflowExecution()
+                    .setWorkflowId(execution.getWorkflowId())
+                    .setRunId(execution.getRunId()))
+            .setHistoryEventFilterType(HistoryEventFilterType.ALL_EVENT);
+    try {
+      GetWorkflowExecutionHistoryResponse response =
+          workflowClient.getService().GetWorkflowExecutionHistory(getRequest);
+      assertEquals(
+          "* * * * *",
+          response
+              .getHistory()
+              .getEvents()
+              .get(0)
+              .getWorkflowExecutionStartedEventAttributes()
+              .getCronSchedule());
+    } catch (Exception e) {
+      fail("no exception expected: " + e.getMessage());
+    }
+
+    // sleep for 61 seconds on server and should expect 2 completed runs
+    testEnv.sleep(Duration.ofSeconds(61));
+    ListClosedWorkflowExecutionsRequest listRequest =
+        new ListClosedWorkflowExecutionsRequest()
+            .setDomain(testEnv.getDomain())
+            .setExecutionFilter(new WorkflowExecutionFilter().setWorkflowId(CRON_WORKFLOW_ID));
+    try {
+      ListClosedWorkflowExecutionsResponse listResponse =
+          testEnv.getWorkflowService().ListClosedWorkflowExecutions(listRequest);
+      Assert.assertEquals(2, listResponse.getExecutions().size());
+      for (WorkflowExecutionInfo e : listResponse.getExecutions()) {
+        assertTrue(e.isIsCron());
+        assertEquals(WorkflowExecutionCloseStatus.CONTINUED_AS_NEW, e.getCloseStatus());
+      }
+    } catch (Exception e) {
+      fail("no exception expected: " + e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
**Issue**

TestEnv doesn't populate cronschedule in history for cron-workflows. This is blocking testing interceptors. 

**Changes**

* populate cronschedule on the start event
* correct isCron in list workflows

