### PR TITLE
Add isolation group header to service client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 ## 3.8.0
 - Graceful shutdown based on sigterm handler
 - Adding cross domain signal/child workflow creation support

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
@@ -15,6 +15,7 @@
  */
 package com.uber.cadence.internal.compatibility.proto.serviceclient;
 
+import com.google.common.base.Strings;
 import com.uber.cadence.api.v1.DomainAPIGrpc;
 import com.uber.cadence.api.v1.MetaAPIGrpc;
 import com.uber.cadence.api.v1.MetaAPIGrpc.MetaAPIBlockingStub;
@@ -61,6 +62,8 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
       Metadata.Key.of("cadence-client-feature-version", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> CLIENT_IMPL_HEADER_KEY =
       Metadata.Key.of("cadence-client-name", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> ISOLATION_GROUP_HEADER_KEY =
+      Metadata.Key.of("cadence-client-isolation-group", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> RPC_SERVICE_NAME_HEADER_KEY =
       Metadata.Key.of("rpc-service", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> RPC_CALLER_NAME_HEADER_KEY =
@@ -105,6 +108,9 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
     headers.put(RPC_SERVICE_NAME_HEADER_KEY, options.getServiceName());
     headers.put(RPC_CALLER_NAME_HEADER_KEY, CLIENT_IMPL_HEADER_VALUE);
     headers.put(RPC_ENCODING_HEADER_KEY, "proto");
+    if (!Strings.isNullOrEmpty(options.getIsolationGroup())) {
+      headers.put(ISOLATION_GROUP_HEADER_KEY, options.getIsolationGroup());
+    }
     Channel interceptedChannel =
         ClientInterceptors.intercept(
             channel,

--- a/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
+++ b/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
@@ -79,6 +79,8 @@ public class ClientOptions {
   private final IAuthorizationProvider authProvider;
   /** Optional Feature flags to turn on/off some Cadence features */
   private final FeatureFlags featureFlags;
+  /** Optional isolation group of the service if tasklist isolation is enabled */
+  private final String isolationGroup;
 
   private ClientOptions(Builder builder) {
     if (Strings.isNullOrEmpty(builder.host)) {
@@ -123,6 +125,7 @@ public class ClientOptions {
       this.headers = ImmutableMap.of();
     }
     this.authProvider = builder.authProvider;
+    this.isolationGroup = builder.isolationGroup;
   }
 
   public static ClientOptions defaultInstance() {
@@ -194,6 +197,10 @@ public class ClientOptions {
     return this.featureFlags;
   }
 
+  public String getIsolationGroup() {
+    return this.isolationGroup;
+  }
+
   /**
    * Builder is the builder for ClientOptions.
    *
@@ -216,6 +223,7 @@ public class ClientOptions {
     private Map<String, String> headers;
     private IAuthorizationProvider authProvider;
     private FeatureFlags featureFlags;
+    private String isolationGroup;
 
     private Builder() {}
 
@@ -347,6 +355,17 @@ public class ClientOptions {
 
     public Builder setHeaders(Map<String, String> headers) {
       this.headers = headers;
+      return this;
+    }
+
+    /**
+     * Sets the isolation group to be used for matching.
+     *
+     * @param isolationGroup
+     * @return Builder for ClentOptions
+     */
+    public Builder setIsolationGroup(String isolationGroup) {
+      this.isolationGroup = isolationGroup;
       return this;
     }
 

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -20,6 +20,7 @@ package com.uber.cadence.serviceclient;
 import static com.uber.cadence.internal.metrics.MetricsTagValue.REQUEST_TYPE_LONG_POLL;
 import static com.uber.cadence.internal.metrics.MetricsTagValue.REQUEST_TYPE_NORMAL;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -150,6 +151,10 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       Gson gson = gsonBuilder.create();
       String serialized = gson.toJson(options.getFeatureFlags());
       builder.put("cadence-client-feature-flags", serialized);
+    }
+
+    if (!Strings.isNullOrEmpty(options.getIsolationGroup())) {
+      builder.put("cadence-client-isolation-group", options.getIsolationGroup());
     }
 
     return builder.build();


### PR DESCRIPTION
What?
Add a new header to thrift and grpc client to specify the isolation group of the client.