### PR TITLE
Added initialization of contextPropagators from passed options

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
@@ -59,7 +59,7 @@ public final class WorkflowClientOptions {
     private DataConverter dataConverter = JsonDataConverter.getInstance();
     private WorkflowClientInterceptor[] interceptors = EMPTY_INTERCEPTOR_ARRAY;
     private Scope metricsScope = NoopScope.getInstance();
-    private String identity = ManagementFactory.getRuntimeMXBean().getName();;
+    private String identity = ManagementFactory.getRuntimeMXBean().getName();
     private List<ContextPropagator> contextPropagators = EMPTY_CONTEXT_PROPAGATORS;
     private QueryRejectCondition queryRejectCondition;
 
@@ -72,6 +72,7 @@ public final class WorkflowClientOptions {
       metricsScope = options.getMetricsScope();
       identity = options.getIdentity();
       queryRejectCondition = options.getQueryRejectCondition();
+      contextPropagators = options.getContextPropagators();
     }
 
     public Builder setDomain(String domain) {

--- a/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClientOptions.java
@@ -71,8 +71,8 @@ public final class WorkflowClientOptions {
       interceptors = options.getInterceptors();
       metricsScope = options.getMetricsScope();
       identity = options.getIdentity();
-      queryRejectCondition = options.getQueryRejectCondition();
       contextPropagators = options.getContextPropagators();
+      queryRejectCondition = options.getQueryRejectCondition();
     }
 
     public Builder setDomain(String domain) {


### PR DESCRIPTION
Previously `contextPropagators` field was not initialised from passed `WorkflowClientOptions` instance. This pull request presents a fix for that