### PR TITLE
Migration interceptor fix

### DIFF
--- a/src/main/java/com/uber/cadence/migration/MigrationActivitiesImpl.java
+++ b/src/main/java/com/uber/cadence/migration/MigrationActivitiesImpl.java
@@ -17,18 +17,37 @@
 
 package com.uber.cadence.migration;
 
+import com.uber.cadence.RequestCancelWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.workflow.Workflow;
 
 public class MigrationActivitiesImpl implements MigrationActivities {
-  private final WorkflowClient clientInNewDomain;
+  private final WorkflowClient clientInCurrDomain, clientInNewDomain;
 
-  public MigrationActivitiesImpl(WorkflowClient clientInNewDomain) {
+  public MigrationActivitiesImpl(
+      WorkflowClient clientInCurrDomain, WorkflowClient clientInNewDomain) {
+    this.clientInCurrDomain = clientInCurrDomain;
     this.clientInNewDomain = clientInNewDomain;
   }
 
   @Override
-  public StartNewWorkflowExecutionResponse startWorkflowInNewDomain(
-      StartNewWorkflowRequest request) {
-    return null;
+  public StartWorkflowExecutionResponse startWorkflowInNewDomain(
+      StartWorkflowExecutionRequest request) {
+    try {
+      return clientInNewDomain.getService().StartWorkflowExecution(request);
+    } catch (Exception e) {
+      throw Workflow.wrap(e);
+    }
+  }
+
+  @Override
+  public void cancelWorkflowInCurrentDomain(RequestCancelWorkflowExecutionRequest request) {
+    try {
+      clientInCurrDomain.getService().RequestCancelWorkflowExecution(request);
+    } catch (Exception e) {
+      throw Workflow.wrap(e);
+    }
   }
 }

--- a/src/main/java/com/uber/cadence/migration/MigrationIWorkflowService.java
+++ b/src/main/java/com/uber/cadence/migration/MigrationIWorkflowService.java
@@ -35,7 +35,7 @@ public class MigrationIWorkflowService extends DummyIWorkflowService {
   private static final String _scanWorkflow = "_scanWorkflow";
   byte[] _marker = "to".getBytes();
 
-  MigrationIWorkflowService(
+  public MigrationIWorkflowService(
       IWorkflowService serviceOld,
       String domainOld,
       IWorkflowService serviceNew,

--- a/src/main/java/com/uber/cadence/migration/MigrationInterceptorFactory.java
+++ b/src/main/java/com/uber/cadence/migration/MigrationInterceptorFactory.java
@@ -17,15 +17,20 @@
 
 package com.uber.cadence.migration;
 
-import com.uber.cadence.RequestCancelWorkflowExecutionRequest;
-import com.uber.cadence.StartWorkflowExecutionRequest;
-import com.uber.cadence.StartWorkflowExecutionResponse;
-import com.uber.cadence.activity.ActivityMethod;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.workflow.WorkflowInterceptor;
+import java.util.function.Function;
 
-public interface MigrationActivities {
-  @ActivityMethod
-  StartWorkflowExecutionResponse startWorkflowInNewDomain(StartWorkflowExecutionRequest request);
+public class MigrationInterceptorFactory
+    implements Function<WorkflowInterceptor, WorkflowInterceptor> {
+  private final WorkflowClient clientInNewDomain;
 
-  @ActivityMethod
-  void cancelWorkflowInCurrentDomain(RequestCancelWorkflowExecutionRequest request);
+  public MigrationInterceptorFactory(WorkflowClient clientInNewDomain) {
+    this.clientInNewDomain = clientInNewDomain;
+  }
+
+  @Override
+  public WorkflowInterceptor apply(WorkflowInterceptor next) {
+    return new MigrationInterceptor(next, this.clientInNewDomain);
+  }
 }

--- a/src/test/java/com/uber/cadence/workflow/WorkflowMigrationTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowMigrationTest.java
@@ -1,0 +1,201 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.workflow;
+
+import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
+import static com.uber.cadence.workflow.WorkflowTest.DOMAIN2;
+import static junit.framework.TestCase.fail;
+
+import com.uber.cadence.*;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.client.WorkflowOptions;
+import com.uber.cadence.common.CronSchedule;
+import com.uber.cadence.internal.worker.PollerOptions;
+import com.uber.cadence.migration.MigrationActivitiesImpl;
+import com.uber.cadence.migration.MigrationIWorkflowService;
+import com.uber.cadence.migration.MigrationInterceptorFactory;
+import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
+import com.uber.cadence.worker.Worker;
+import com.uber.cadence.worker.WorkerFactory;
+import com.uber.cadence.worker.WorkerFactoryOptions;
+import com.uber.cadence.worker.WorkerOptions;
+import com.uber.cadence.workflow.interceptors.TracingWorkflowInterceptorFactory;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WorkflowMigrationTest {
+  private WorkflowClient migrationWorkflowClient, workflowClientCurr, workflowClientNew;
+  private boolean useDockerService = Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
+  private static final String TASKLIST = "TASKLIST";
+  private TracingWorkflowInterceptorFactory tracer;
+  WorkerFactory factoryCurr, factoryNew;
+  Worker workerCurr, workerNew;
+
+  @Before
+  public void setUp() {
+    IWorkflowService service =
+        new WorkflowServiceTChannel(
+            ClientOptions.newBuilder()
+                .setFeatureFlags(
+                    new FeatureFlags().setWorkflowExecutionAlreadyCompletedErrorEnabled(true))
+                .build());
+    workflowClientCurr =
+        WorkflowClient.newInstance(
+            service, WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build());
+    workflowClientNew =
+        WorkflowClient.newInstance(
+            service, WorkflowClientOptions.newBuilder().setDomain(DOMAIN2).build());
+    MigrationIWorkflowService migrationService =
+        new MigrationIWorkflowService(
+            service, DOMAIN,
+            service, DOMAIN2);
+    migrationWorkflowClient =
+        WorkflowClient.newInstance(
+            migrationService, WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build());
+    WorkerFactoryOptions factoryOptions = WorkerFactoryOptions.newBuilder().build();
+
+    // tracer interceptor Factory
+    tracer = new TracingWorkflowInterceptorFactory();
+
+    // migration interceptor
+    MigrationInterceptorFactory migrator = new MigrationInterceptorFactory(workflowClientNew);
+
+    // current domain worker
+    factoryCurr = new WorkerFactory(workflowClientCurr, factoryOptions);
+    workerCurr =
+        factoryCurr.newWorker(
+            TASKLIST,
+            WorkerOptions.newBuilder()
+                .setActivityPollerOptions(PollerOptions.newBuilder().setPollThreadCount(5).build())
+                .setMaxConcurrentActivityExecutionSize(1000)
+                .setInterceptorFactory(migrator.andThen(tracer))
+                .build());
+    workerCurr.registerWorkflowImplementationTypes(
+        CronWorkflowImpl.class, ContinueAsNewWorkflowImpl.class);
+    workerCurr.registerActivitiesImplementations(
+        new MigrationActivitiesImpl(workflowClientCurr, workflowClientNew));
+    factoryCurr.start();
+
+    // new domain worker
+    factoryNew = new WorkerFactory(workflowClientNew, factoryOptions);
+    workerNew =
+        factoryNew.newWorker(
+            TASKLIST,
+            WorkerOptions.newBuilder()
+                .setActivityPollerOptions(PollerOptions.newBuilder().setPollThreadCount(5).build())
+                .setMaxConcurrentActivityExecutionSize(1000)
+                .setInterceptorFactory(tracer)
+                .build());
+    workerNew.registerWorkflowImplementationTypes(
+        CronWorkflowImpl.class, ContinueAsNewWorkflowImpl.class);
+    factoryNew.start();
+  }
+
+  @After
+  public void tearDown() throws Throwable {
+    factoryCurr.shutdown();
+    factoryNew.shutdown();
+  }
+
+  public interface CronWorkflow {
+    @WorkflowMethod(
+      taskList = TASKLIST,
+      workflowIdReusePolicy = WorkflowIdReusePolicy.RejectDuplicate,
+      executionStartToCloseTimeoutSeconds = 10
+    )
+    @CronSchedule("* * * * *")
+    String execute(String testName);
+  }
+
+  public static class CronWorkflowImpl implements CronWorkflow {
+    @Override
+    public String execute(String testName) {
+      return "Cron Workflow Completed";
+    }
+  }
+
+  public interface ContinueAsNewWorkflow {
+    @WorkflowMethod(
+      taskList = TASKLIST,
+      workflowIdReusePolicy = WorkflowIdReusePolicy.RejectDuplicate,
+      executionStartToCloseTimeoutSeconds = 10
+    )
+    void execute(int iter);
+  }
+
+  public static class ContinueAsNewWorkflowImpl implements ContinueAsNewWorkflow {
+    @Override
+    public void execute(int iter) {
+      Workflow.continueAsNew(iter + 1);
+    }
+  }
+
+  @Test
+  public void whenUseDockerService_cronWorkflowMigration() {
+    Assume.assumeTrue(useDockerService);
+    String workflowID = UUID.randomUUID().toString();
+    try {
+      workflowClientCurr
+          .newWorkflowStub(
+              CronWorkflow.class, new WorkflowOptions.Builder().setWorkflowId(workflowID).build())
+          .execute("for test");
+    } catch (CancellationException e) {
+      try {
+        describeWorkflowExecution(workflowClientNew, workflowID);
+      } catch (Exception eDesc) {
+        fail("fail to describe workflow execution in new domain: " + eDesc);
+      }
+    }
+  }
+
+  @Test
+  public void whenUseDockerService_continueAsNewWorkflowMigration() {
+    Assume.assumeTrue(useDockerService);
+    String workflowID = UUID.randomUUID().toString();
+    try {
+      workflowClientCurr
+          .newWorkflowStub(
+              ContinueAsNewWorkflow.class,
+              new WorkflowOptions.Builder().setWorkflowId(workflowID).build())
+          .execute(0);
+    } catch (CancellationException e) {
+      try {
+        describeWorkflowExecution(workflowClientNew, workflowID);
+      } catch (Exception eDesc) {
+        fail("fail to describe workflow execution in new domain: " + eDesc);
+      }
+    }
+  }
+
+  private DescribeWorkflowExecutionResponse describeWorkflowExecution(
+      WorkflowClient wc, String workflowID) throws TException {
+    return wc.getService()
+        .DescribeWorkflowExecution(
+            new DescribeWorkflowExecutionRequest()
+                .setExecution(new WorkflowExecution().setWorkflowId(workflowID))
+                .setDomain(wc.getOptions().getDomain()));
+  }
+}

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -62,10 +62,8 @@ import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.converter.JsonDataConverter;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.sync.DeterministicRunnerTest;
-import com.uber.cadence.internal.sync.SyncWorkflowDefinition;
 import com.uber.cadence.internal.sync.TestWorkflowEnvironmentInternal;
 import com.uber.cadence.internal.worker.PollerOptions;
-import com.uber.cadence.internal.worker.WorkflowExecutionException;
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
@@ -73,8 +71,7 @@ import com.uber.cadence.testing.TestEnvironmentOptions;
 import com.uber.cadence.testing.TestWorkflowEnvironment;
 import com.uber.cadence.testing.WorkflowReplayer;
 import com.uber.cadence.worker.*;
-import com.uber.cadence.workflow.Functions.Func;
-import com.uber.cadence.workflow.Functions.Func1;
+import com.uber.cadence.workflow.interceptors.TracingWorkflowInterceptorFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -82,7 +79,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
-import java.lang.reflect.Type;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -114,9 +110,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiPredicate;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -5083,37 +5076,6 @@ public class WorkflowTest {
     }
   }
 
-  private static class TracingWorkflowInterceptorFactory
-      implements Function<WorkflowInterceptor, WorkflowInterceptor> {
-
-    private final FilteredTrace trace = new FilteredTrace();
-    private List<String> expected;
-
-    @Override
-    public WorkflowInterceptor apply(WorkflowInterceptor next) {
-      return new TracingWorkflowInterceptor(trace, next);
-    }
-
-    public String getTrace() {
-      return String.join("\n", trace.getImpl());
-    }
-
-    public void setExpected(String... expected) {
-      this.expected = Arrays.asList(expected);
-    }
-
-    public void assertExpected() {
-      if (expected != null) {
-        List<String> traceElements = trace.getImpl();
-        for (int i = 0; i < traceElements.size(); i++) {
-          String t = traceElements.get(i);
-          String expectedRegExp = expected.get(i);
-          Assert.assertTrue(t + " doesn't match " + expectedRegExp, t.matches(expectedRegExp));
-        }
-      }
-    }
-  }
-
   public static class TestUUIDAndRandom implements TestWorkflow1 {
 
     @Override
@@ -5887,23 +5849,6 @@ public class WorkflowTest {
         "timerfiring.json", TimerFiringWorkflowImpl.class);
   }
 
-  private static class FilteredTrace {
-
-    private final List<String> impl = Collections.synchronizedList(new ArrayList<>());
-
-    public boolean add(String s) {
-      log.trace("FilteredTrace isReplaying=" + Workflow.isReplaying());
-      if (!Workflow.isReplaying()) {
-        return impl.add(s);
-      }
-      return true;
-    }
-
-    List<String> getImpl() {
-      return impl;
-    }
-  }
-
   public interface TestCompensationWorkflow {
     @WorkflowMethod
     void compensate();
@@ -6146,152 +6091,6 @@ public class WorkflowTest {
     String result = parent.func();
     String expected = String.format("%s - %s", null, workflowId);
     assertEquals(expected, result);
-  }
-
-  private static class TracingWorkflowInterceptor implements WorkflowInterceptor {
-
-    private final FilteredTrace trace;
-    private final WorkflowInterceptor next;
-
-    private TracingWorkflowInterceptor(FilteredTrace trace, WorkflowInterceptor next) {
-      this.trace = trace;
-      this.next = Objects.requireNonNull(next);
-    }
-
-    @Override
-    public byte[] executeWorkflow(
-        SyncWorkflowDefinition workflowDefinition, WorkflowExecuteInput input)
-        throws CancellationException, WorkflowExecutionException {
-      trace.add("executeWorkflow: " + input.getWorkflowType().getName());
-      return next.executeWorkflow(workflowDefinition, input);
-    }
-
-    @Override
-    public <R> Promise<R> executeActivity(
-        String activityName,
-        Class<R> resultClass,
-        Type resultType,
-        Object[] args,
-        ActivityOptions options) {
-      trace.add("executeActivity " + activityName);
-      return next.executeActivity(activityName, resultClass, resultType, args, options);
-    }
-
-    @Override
-    public <R> Promise<R> executeLocalActivity(
-        String activityName,
-        Class<R> resultClass,
-        Type resultType,
-        Object[] args,
-        LocalActivityOptions options) {
-      trace.add("executeLocalActivity " + activityName);
-      return next.executeLocalActivity(activityName, resultClass, resultType, args, options);
-    }
-
-    @Override
-    public <R> WorkflowResult<R> executeChildWorkflow(
-        String workflowType,
-        Class<R> resultClass,
-        Type resultType,
-        Object[] args,
-        ChildWorkflowOptions options) {
-      trace.add("executeChildWorkflow " + workflowType);
-      return next.executeChildWorkflow(workflowType, resultClass, resultType, args, options);
-    }
-
-    @Override
-    public Random newRandom() {
-      trace.add("newRandom");
-      return next.newRandom();
-    }
-
-    @Override
-    public Promise<Void> signalExternalWorkflow(
-        String domain, WorkflowExecution execution, String signalName, Object[] args) {
-      trace.add("signalExternalWorkflow " + execution.getWorkflowId() + " " + signalName);
-      return next.signalExternalWorkflow(domain, execution, signalName, args);
-    }
-
-    @Override
-    public Promise<Void> signalExternalWorkflow(
-        WorkflowExecution execution, String signalName, Object[] args) {
-      trace.add("signalExternalWorkflow " + execution.getWorkflowId() + " " + signalName);
-      return next.signalExternalWorkflow(execution, signalName, args);
-    }
-
-    @Override
-    public Promise<Void> cancelWorkflow(WorkflowExecution execution) {
-      trace.add("cancelWorkflow " + execution.getWorkflowId());
-      return next.cancelWorkflow(execution);
-    }
-
-    @Override
-    public void sleep(Duration duration) {
-      trace.add("sleep " + duration);
-      next.sleep(duration);
-    }
-
-    @Override
-    public boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition) {
-      trace.add("await " + timeout + " " + reason);
-      return next.await(timeout, reason, unblockCondition);
-    }
-
-    @Override
-    public void await(String reason, Supplier<Boolean> unblockCondition) {
-      trace.add("await " + reason);
-      next.await(reason, unblockCondition);
-    }
-
-    @Override
-    public Promise<Void> newTimer(Duration duration) {
-      trace.add("newTimer " + duration);
-      return next.newTimer(duration);
-    }
-
-    @Override
-    public <R> R sideEffect(Class<R> resultClass, Type resultType, Func<R> func) {
-      trace.add("sideEffect");
-      return next.sideEffect(resultClass, resultType, func);
-    }
-
-    @Override
-    public <R> R mutableSideEffect(
-        String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
-      trace.add("mutableSideEffect");
-      return next.mutableSideEffect(id, resultClass, resultType, updated, func);
-    }
-
-    @Override
-    public int getVersion(String changeID, int minSupported, int maxSupported) {
-      trace.add("getVersion");
-      return next.getVersion(changeID, minSupported, maxSupported);
-    }
-
-    @Override
-    public void continueAsNew(
-        Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
-      trace.add("continueAsNew");
-      next.continueAsNew(workflowType, options, args);
-    }
-
-    @Override
-    public void registerQuery(String queryType, Type[] argTypes, Func1<Object[], Object> callback) {
-      trace.add("registerQuery " + queryType);
-      next.registerQuery(queryType, argTypes, callback);
-    }
-
-    @Override
-    public UUID randomUUID() {
-      trace.add("randomUUID");
-      return next.randomUUID();
-    }
-
-    @Override
-    public void upsertSearchAttributes(Map<String, Object> searchAttributes) {
-      trace.add("upsertSearchAttributes");
-      next.upsertSearchAttributes(searchAttributes);
-    }
   }
 
   public static class TestGetVersionWorkflowRetryImpl implements TestWorkflow3 {

--- a/src/test/java/com/uber/cadence/workflow/interceptors/TracingWorkflowInterceptorFactory.java
+++ b/src/test/java/com/uber/cadence/workflow/interceptors/TracingWorkflowInterceptorFactory.java
@@ -1,0 +1,236 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.workflow.interceptors;
+
+import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.activity.ActivityOptions;
+import com.uber.cadence.activity.LocalActivityOptions;
+import com.uber.cadence.internal.sync.SyncWorkflowDefinition;
+import com.uber.cadence.internal.worker.WorkflowExecutionException;
+import com.uber.cadence.workflow.*;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TracingWorkflowInterceptorFactory
+    implements Function<WorkflowInterceptor, WorkflowInterceptor> {
+
+  private final FilteredTrace trace = new FilteredTrace();
+  private List<String> expected;
+  private static final Logger log =
+      LoggerFactory.getLogger(TracingWorkflowInterceptorFactory.class);
+
+  @Override
+  public WorkflowInterceptor apply(WorkflowInterceptor next) {
+    return new TracingWorkflowInterceptor(trace, next);
+  }
+
+  public String getTrace() {
+    return String.join("\n", trace.getImpl());
+  }
+
+  public void setExpected(String... expected) {
+    this.expected = Arrays.asList(expected);
+  }
+
+  public void assertExpected() {
+    if (expected != null) {
+      List<String> traceElements = trace.getImpl();
+      for (int i = 0; i < traceElements.size(); i++) {
+        String t = traceElements.get(i);
+        String expectedRegExp = expected.get(i);
+        Assert.assertTrue(t + " doesn't match " + expectedRegExp, t.matches(expectedRegExp));
+      }
+    }
+  }
+
+  private static class FilteredTrace {
+
+    private final List<String> impl = Collections.synchronizedList(new ArrayList<>());
+
+    public boolean add(String s) {
+      log.trace("FilteredTrace isReplaying=" + Workflow.isReplaying());
+      if (!Workflow.isReplaying()) {
+        return impl.add(s);
+      }
+      return true;
+    }
+
+    List<String> getImpl() {
+      return impl;
+    }
+  }
+
+  private static class TracingWorkflowInterceptor implements WorkflowInterceptor {
+
+    private final FilteredTrace trace;
+    private final WorkflowInterceptor next;
+
+    private TracingWorkflowInterceptor(FilteredTrace trace, WorkflowInterceptor next) {
+      this.trace = trace;
+      this.next = Objects.requireNonNull(next);
+    }
+
+    @Override
+    public byte[] executeWorkflow(
+        SyncWorkflowDefinition workflowDefinition, WorkflowExecuteInput input)
+        throws CancellationException, WorkflowExecutionException {
+      trace.add("executeWorkflow: " + input.getWorkflowType().getName());
+      return next.executeWorkflow(workflowDefinition, input);
+    }
+
+    @Override
+    public <R> Promise<R> executeActivity(
+        String activityName,
+        Class<R> resultClass,
+        Type resultType,
+        Object[] args,
+        ActivityOptions options) {
+      trace.add("executeActivity " + activityName);
+      return next.executeActivity(activityName, resultClass, resultType, args, options);
+    }
+
+    @Override
+    public <R> Promise<R> executeLocalActivity(
+        String activityName,
+        Class<R> resultClass,
+        Type resultType,
+        Object[] args,
+        LocalActivityOptions options) {
+      trace.add("executeLocalActivity " + activityName);
+      return next.executeLocalActivity(activityName, resultClass, resultType, args, options);
+    }
+
+    @Override
+    public <R> WorkflowResult<R> executeChildWorkflow(
+        String workflowType,
+        Class<R> resultClass,
+        Type resultType,
+        Object[] args,
+        ChildWorkflowOptions options) {
+      trace.add("executeChildWorkflow " + workflowType);
+      return next.executeChildWorkflow(workflowType, resultClass, resultType, args, options);
+    }
+
+    @Override
+    public Random newRandom() {
+      trace.add("newRandom");
+      return next.newRandom();
+    }
+
+    @Override
+    public Promise<Void> signalExternalWorkflow(
+        String domain, WorkflowExecution execution, String signalName, Object[] args) {
+      trace.add("signalExternalWorkflow " + execution.getWorkflowId() + " " + signalName);
+      return next.signalExternalWorkflow(domain, execution, signalName, args);
+    }
+
+    @Override
+    public Promise<Void> signalExternalWorkflow(
+        WorkflowExecution execution, String signalName, Object[] args) {
+      trace.add("signalExternalWorkflow " + execution.getWorkflowId() + " " + signalName);
+      return next.signalExternalWorkflow(execution, signalName, args);
+    }
+
+    @Override
+    public Promise<Void> cancelWorkflow(WorkflowExecution execution) {
+      trace.add("cancelWorkflow " + execution.getWorkflowId());
+      return next.cancelWorkflow(execution);
+    }
+
+    @Override
+    public void sleep(Duration duration) {
+      trace.add("sleep " + duration);
+      next.sleep(duration);
+    }
+
+    @Override
+    public boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition) {
+      trace.add("await " + timeout + " " + reason);
+      return next.await(timeout, reason, unblockCondition);
+    }
+
+    @Override
+    public void await(String reason, Supplier<Boolean> unblockCondition) {
+      trace.add("await " + reason);
+      next.await(reason, unblockCondition);
+    }
+
+    @Override
+    public Promise<Void> newTimer(Duration duration) {
+      trace.add("newTimer " + duration);
+      return next.newTimer(duration);
+    }
+
+    @Override
+    public <R> R sideEffect(Class<R> resultClass, Type resultType, Functions.Func<R> func) {
+      trace.add("sideEffect");
+      return next.sideEffect(resultClass, resultType, func);
+    }
+
+    @Override
+    public <R> R mutableSideEffect(
+        String id,
+        Class<R> resultClass,
+        Type resultType,
+        BiPredicate<R, R> updated,
+        Functions.Func<R> func) {
+      trace.add("mutableSideEffect");
+      return next.mutableSideEffect(id, resultClass, resultType, updated, func);
+    }
+
+    @Override
+    public int getVersion(String changeID, int minSupported, int maxSupported) {
+      trace.add("getVersion");
+      return next.getVersion(changeID, minSupported, maxSupported);
+    }
+
+    @Override
+    public void continueAsNew(
+        Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
+      trace.add("continueAsNew");
+      next.continueAsNew(workflowType, options, args);
+    }
+
+    @Override
+    public void registerQuery(
+        String queryType, Type[] argTypes, Functions.Func1<Object[], Object> callback) {
+      trace.add("registerQuery " + queryType);
+      next.registerQuery(queryType, argTypes, callback);
+    }
+
+    @Override
+    public UUID randomUUID() {
+      trace.add("randomUUID");
+      return next.randomUUID();
+    }
+
+    @Override
+    public void upsertSearchAttributes(Map<String, Object> searchAttributes) {
+      trace.add("upsertSearchAttributes");
+      next.upsertSearchAttributes(searchAttributes);
+    }
+  }
+}


### PR DESCRIPTION
**Why**

Current java client does not support cancel workflow from itself. The workaround would be to start CANCEL activity in a detached cancellation scope to cancel its own workflow from server. 

**Changes**

* fix migration interceptor cancel logic
* move out the TracingInterceptorFactory to a separate class

**Test**

Write integration test to assert the current workflow is canceled and a new workflow is started. 
