### PR TITLE
fixing flaky test by increasing the timeout

### DIFF
--- a/src/test/java/com/uber/cadence/internal/replay/ReplayDeciderCacheTests.java
+++ b/src/test/java/com/uber/cadence/internal/replay/ReplayDeciderCacheTests.java
@@ -103,7 +103,7 @@ public class ReplayDeciderCacheTests {
     service.close();
   }
 
-  @Test(timeout = 7000)
+  @Test(timeout = 8000)
   public void whenHistoryIsPartialCachedEntryIsReturned() throws Exception {
     // Arrange
     Map<String, String> tags =


### PR DESCRIPTION
Test: whenHistoryIsPartialCachedEntryIsReturned
- set timeout to 8000