### PR TITLE
fixed bug: Added alreadyStarted workflow case

### DIFF
--- a/src/main/java/com/uber/cadence/migration/MigrationActivities.java
+++ b/src/main/java/com/uber/cadence/migration/MigrationActivities.java
@@ -19,13 +19,23 @@ package com.uber.cadence.migration;
 
 import com.uber.cadence.RequestCancelWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionRequest;
-import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.activity.ActivityMethod;
 
 public interface MigrationActivities {
+  /**
+   * Starts a new workflow execution in a new domain.
+   *
+   * @param request The request to start the workflow in new domain.
+   * @return A response indicating the status of the operation.
+   */
   @ActivityMethod
-  StartWorkflowExecutionResponse startWorkflowInNewDomain(StartWorkflowExecutionRequest request);
+  StartWorkflowInNewResponse startWorkflowInNewDomain(StartWorkflowExecutionRequest request);
 
+  /**
+   * Cancels a workflow execution in the current domain.
+   *
+   * @param request The request to cancel the workflow.
+   */
   @ActivityMethod
   void cancelWorkflowInCurrentDomain(RequestCancelWorkflowExecutionRequest request);
 }

--- a/src/main/java/com/uber/cadence/migration/MigrationActivitiesImpl.java
+++ b/src/main/java/com/uber/cadence/migration/MigrationActivitiesImpl.java
@@ -19,7 +19,7 @@ package com.uber.cadence.migration;
 
 import com.uber.cadence.RequestCancelWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionRequest;
-import com.uber.cadence.StartWorkflowExecutionResponse;
+import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.workflow.Workflow;
 
@@ -33,10 +33,14 @@ public class MigrationActivitiesImpl implements MigrationActivities {
   }
 
   @Override
-  public StartWorkflowExecutionResponse startWorkflowInNewDomain(
+  public StartWorkflowInNewResponse startWorkflowInNewDomain(
       StartWorkflowExecutionRequest request) {
     try {
-      return clientInNewDomain.getService().StartWorkflowExecution(request);
+      return new StartWorkflowInNewResponse(
+          clientInNewDomain.getService().StartWorkflowExecution(request),
+          "New workflow starting successful");
+    } catch (WorkflowExecutionAlreadyStartedError e) {
+      return new StartWorkflowInNewResponse(null, "Workflow already started");
     } catch (Exception e) {
       throw Workflow.wrap(e);
     }

--- a/src/main/java/com/uber/cadence/migration/StartWorkflowInNewResponse.java
+++ b/src/main/java/com/uber/cadence/migration/StartWorkflowInNewResponse.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.migration;
+
+import com.uber.cadence.StartWorkflowExecutionResponse;
+
+public class StartWorkflowInNewResponse {
+  StartWorkflowExecutionResponse startWorkflowExecutionResponse;
+  String status;
+
+  StartWorkflowInNewResponse(StartWorkflowExecutionResponse startWorkflowResponse, String msg) {
+    startWorkflowExecutionResponse = startWorkflowResponse;
+    status = msg;
+  }
+}


### PR DESCRIPTION
If we get WorkflowExecutionAlreadyStartedError while starting workflow in new domain, then we don't require startWorkflowInNew domain again as well as not throw error. Hence, we will inform by giving status as "Workflow already started".