### PR TITLE
Update thrift dependency to 0.19.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This doc is intended for contributors to `cadence-java-client` (hopefully that's
 ## Development Environment
 
 * Java 11 (currently, we use Java 11 to compile Java 8 code).
-* Thrift 0.9.3 (use [homebrew](https://formulae.brew.sh/formula/thrift@0.9) or [distribution](https://downloads.apache.org/thrift/0.9.3/))
+* Thrift 0.19.0 (use [homebrew](https://formulae.brew.sh/formula/thrift@0.9) or [distribution](https://downloads.apache.org/thrift/0.19.0/))
 * Gradle build tool [6.x](https://github.com/uber/cadence-java-client/blob/master/gradle/wrapper/gradle-wrapper.properties)
 * Docker
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ This doc is intended for contributors to `cadence-java-client` (hopefully that's
 ## Development Environment
 
 * Java 11 (currently, we use Java 11 to compile Java 8 code).
-* Thrift 0.19.0 (use [homebrew](https://formulae.brew.sh/formula/thrift@0.9) or [distribution](https://downloads.apache.org/thrift/0.19.0/))
+* Thrift 0.19.0 (use [homebrew](https://formulae.brew.sh/formula/thrift@0.19) or [distribution](https://downloads.apache.org/thrift/0.19.0/))
 * Gradle build tool [6.x](https://github.com/uber/cadence-java-client/blob/master/gradle/wrapper/gradle-wrapper.properties)
 * Docker
 
-:warning: Note 1: You must install the 0.9.x version of Thrift. Otherwise compiling would fail at error `error: package org.apache.thrift.annotation does not exist`
+:warning: Note 1: You must install the 0.19.x version of Thrift. Otherwise compiling would fail at error `error: package org.apache.thrift.annotation does not exist`
 
 :warning: Note 2: It's currently compatible with Java 8 compiler but no guarantee in the future. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath "gradle.plugin.org.jruyi.gradle:thrift-gradle-plugin:0.4.1"
+        classpath "gradle.plugin.org.jruyi.gradle:thrift-gradle-plugin:0.4.2"
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.11'
     }
 }
@@ -59,7 +59,7 @@ dependencies {
 
     compile group: 'com.uber.tchannel', name: 'tchannel-core', version: '0.8.30'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
-    compile group: 'org.apache.thrift', name: 'libthrift', version: '0.9.3'
+    compile group: 'org.apache.thrift', name: 'libthrift', version: '0.19.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.10'
     compile group: 'com.uber.m3', name: 'tally-core', version: '0.11.1'
     compile group: 'com.google.guava', name: 'guava', version: '31.1-jre'
@@ -81,6 +81,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testCompile group: 'commons-codec', name:'commons-codec', version: '1.16.0'
 }
 
 license {

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -4,7 +4,7 @@
 FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
 
 # Apache Thrift version
-ENV APACHE_THRIFT_VERSION=0.9.3
+ENV APACHE_THRIFT_VERSION=0.19.0
 
 # Install dependencies using apk
 RUN apk update && apk add --virtual wget ca-certificates wget && apk add --virtual build-dependencies build-base gcc

--- a/src/main/java/com/uber/cadence/converter/TBaseTypeAdapterFactory.java
+++ b/src/main/java/com/uber/cadence/converter/TBaseTypeAdapterFactory.java
@@ -30,6 +30,7 @@ import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TJSONProtocol;
+import org.apache.thrift.transport.TTransportException;
 
 /**
  * Special handling of TBase message serialization and deserialization. This is to support for
@@ -48,8 +49,7 @@ public class TBaseTypeAdapterFactory implements TypeAdapterFactory {
           @Override
           public void write(JsonWriter jsonWriter, T value) throws IOException {
             try {
-              String result =
-                  newThriftSerializer().toString((TBase) value, StandardCharsets.UTF_8.name());
+              String result = newThriftSerializer().toString((TBase) value);
               jsonWriter.value(result);
             } catch (TException e) {
               throw new DataConverterException("Failed to serialize TBase", e);
@@ -73,11 +73,11 @@ public class TBaseTypeAdapterFactory implements TypeAdapterFactory {
     return result;
   }
 
-  private static TSerializer newThriftSerializer() {
+  private static TSerializer newThriftSerializer() throws TTransportException {
     return new TSerializer(new TJSONProtocol.Factory());
   }
 
-  private static TDeserializer newThriftDeserializer() {
+  private static TDeserializer newThriftDeserializer() throws TTransportException {
     return new TDeserializer(new TJSONProtocol.Factory());
   }
 }

--- a/src/main/java/com/uber/cadence/internal/common/InternalUtils.java
+++ b/src/main/java/com/uber/cadence/internal/common/InternalUtils.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
+import org.apache.thrift.transport.TTransportException;
 
 /** Utility functions shared by the implementation code. */
 public final class InternalUtils {
@@ -167,10 +168,10 @@ public final class InternalUtils {
   // This method serializes history to blob data
   public static DataBlob SerializeFromHistoryToBlobData(History history) {
 
-    // TODO: move to global dependency after https://issues.apache.org/jira/browse/THRIFT-2218
-    TSerializer serializer = new TSerializer();
     DataBlob blob = new DataBlob();
     try {
+      // TODO: move to global dependency after https://issues.apache.org/jira/browse/THRIFT-2218
+      TSerializer serializer = new TSerializer();
       blob.setData(serializer.serialize(history));
     } catch (org.apache.thrift.TException err) {
       throw new RuntimeException("Serialize history to blob data failed", err);
@@ -215,7 +216,12 @@ public final class InternalUtils {
   public static List<DataBlob> SerializeFromHistoryEventToBlobData(List<HistoryEvent> events) {
 
     // TODO: move to global dependency after https://issues.apache.org/jira/browse/THRIFT-2218
-    TSerializer serializer = new TSerializer();
+    TSerializer serializer;
+    try {
+      serializer = new TSerializer();
+    } catch (TTransportException err) {
+      throw new RuntimeException("Serialize history event to blob data failed", err);
+    }
     List<DataBlob> blobs = Lists.newArrayListWithCapacity(events.size());
     for (HistoryEvent event : events) {
       DataBlob blob = new DataBlob();


### PR DESCRIPTION
Fixes direct vulnerabilities: CVE-2020-13949, CVE-2019-0205, CVE-2018-1320, CVE-2018-11798 and vulnerability from dependencies: CVE-2020-13956. Projects using Cadence Java client might have newer and binary incompatible versions of libthrift in the classpath due to security gates/checks. This causes exceptions information loss in Cadence server log.

<details>
<summary>Failure serializing exception: com.uber.cadence.workflow.ChildWorkflowFailureException: Failure serializing exception: com.uber.cadence.workflow.ActivityFailureException: ActivityFailureException</summary>

```json
{
  "reason": "com.uber.cadence.workflow.ChildWorkflowFailureException",
  "details": {
    "detailMessage": "Failure serializing exception: com.uber.cadence.workflow.ChildWorkflowFailureException: Failure serializing exception: com.uber.cadence.workflow.ActivityFailureException: ActivityFailureException,xxxx",
    "cause": {
      "detailMessage": "'java.lang.String org.apache.thrift.TSerializer.toString(org.apache.thrift.TBase, java.lang.String)'",
      "stackTrace": "com.uber.cadence.converter.TBaseTypeAdapterFactory$1.write(TBaseTypeAdapterFactory.java:52)\ncom.google.gson.TypeAdapter$1.write(TypeAdapter.java:191)\ncom.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69)\ncom.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:127)\ncom.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:245)\ncom.google.gson.TypeAdapter.toJsonTree(TypeAdapter.java:234)\ncom.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:93)\ncom.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:34)\ncom.google.gson.TypeAdapter$1.write(TypeAdapter.java:191)\ncom.google.gson.Gson.toJson(Gson.java:735)\ncom.google.gson.Gson.toJson(Gson.java:714)\ncom.google.gson.Gson.toJson(Gson.java:669)\ncom.google.gson.Gson.toJson(Gson.java:649)\ncom.uber.cadence.converter.JsonDataConverter.toData(JsonDataConverter.java:90)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory.mapToWorkflowExecutionException(POJOWorkflowImplementationFactory.java:374)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:275)\ncom.uber.cadence.internal.sync.WorkflowRunnable.run(WorkflowRunnable.java:47)\ncom.uber.cadence.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102)\ncom.uber.cadence.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:99)\njava.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\njava.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\njava.base/java.lang.Thread.run(Thread.java:829)\n",
      "suppressedExceptions": [],
      "class": "java.lang.NoSuchMethodError"
    },
    "stackTrace": "com.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:102)\ncom.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:34)\ncom.google.gson.TypeAdapter$1.write(TypeAdapter.java:191)\ncom.google.gson.Gson.toJson(Gson.java:735)\ncom.google.gson.Gson.toJson(Gson.java:714)\ncom.google.gson.Gson.toJson(Gson.java:669)\ncom.google.gson.Gson.toJson(Gson.java:649)\ncom.uber.cadence.converter.JsonDataConverter.toData(JsonDataConverter.java:90)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory.mapToWorkflowExecutionException(POJOWorkflowImplementationFactory.java:374)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:275)\ncom.uber.cadence.internal.sync.WorkflowRunnable.run(WorkflowRunnable.java:47)\ncom.uber.cadence.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102)\ncom.uber.cadence.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:99)\njava.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\njava.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\njava.base/java.lang.Thread.run(Thread.java:829)\n",
    "suppressedExceptions": [
      {
        "detailMessage": "Failure serializing exception: com.uber.cadence.workflow.ActivityFailureException: ActivityFailureException, ActivityType=\"xxxx",
        "cause": {
          "detailMessage": "'java.lang.String org.apache.thrift.TSerializer.toString(org.apache.thrift.TBase, java.lang.String)'",
          "stackTrace": "com.uber.cadence.converter.TBaseTypeAdapterFactory$1.write(TBaseTypeAdapterFactory.java:52)\ncom.google.gson.TypeAdapter$1.write(TypeAdapter.java:191)\ncom.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69)\ncom.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:127)\ncom.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:245)\ncom.google.gson.TypeAdapter.toJsonTree(TypeAdapter.java:234)\ncom.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:93)\ncom.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:34)\ncom.google.gson.TypeAdapter$1.write(TypeAdapter.java:191)\ncom.google.gson.Gson.toJson(Gson.java:735)\ncom.google.gson.Gson.toJson(Gson.java:714)\ncom.google.gson.Gson.toJson(Gson.java:669)\ncom.google.gson.Gson.toJson(Gson.java:649)\ncom.uber.cadence.converter.JsonDataConverter.toData(JsonDataConverter.java:90)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory.mapToWorkflowExecutionException(POJOWorkflowImplementationFactory.java:374)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:275)\ncom.uber.cadence.internal.sync.WorkflowRunnable.run(WorkflowRunnable.java:47)\ncom.uber.cadence.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102)\ncom.uber.cadence.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:99)\njava.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\njava.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\njava.base/java.lang.Thread.run(Thread.java:829)\n",
          "suppressedExceptions": [],
          "class": "java.lang.NoSuchMethodError"
        },
        "stackTrace": "com.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:102)\ncom.uber.cadence.converter.CustomThrowableTypeAdapter.write(CustomThrowableTypeAdapter.java:34)\ncom.google.gson.TypeAdapter$1.write(TypeAdapter.java:191)\ncom.google.gson.Gson.toJson(Gson.java:735)\ncom.google.gson.Gson.toJson(Gson.java:714)\ncom.google.gson.Gson.toJson(Gson.java:669)\ncom.google.gson.Gson.toJson(Gson.java:649)\ncom.uber.cadence.converter.JsonDataConverter.toData(JsonDataConverter.java:90)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory.mapToWorkflowExecutionException(POJOWorkflowImplementationFactory.java:374)\ncom.uber.cadence.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:275)\ncom.uber.cadence.internal.sync.WorkflowRunnable.run(WorkflowRunnable.java:47)\ncom.uber.cadence.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:102)\ncom.uber.cadence.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:99)\njava.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\njava.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\njava.base/java.lang.Thread.run(Thread.java:829)\n",
        "suppressedExceptions": [
          {
            "detailMessage": "com.cloudera.ApiException: Not Acceptable",
            "cause": {
              "code": 406,
              "responseHeaders": {
                "Content-Type": [
                  "application/json; charset=utf-8"
                ],
                "Date": [
                  "Wed, 27 Sep 2023 15:29:26 GMT"
                ],
                "Content-Length": [
                  "387"
                ],
                "OkHttp-Sent-Millis": [
                  "1695828565000"
                ],
                "OkHttp-Received-Millis": [
                  "1695828566468"
                ]
              },
              "responseBody": "{\"message\":\", cause: [error creating cluster]",
              "detailMessage": "Not Acceptable",
              "cause": null,
              "stackTrace": "sensitive",
              "suppressedExceptions": [],
              "class": "com.cloudera.ApiException"
            },
            "stackTrace": "sensitive",
            "suppressedExceptions": [],
            "class": "com.cloudera.ApiException"
          }
        ],
        "class": "com.uber.cadence.converter.DataConverterException"
      }
    ],
    "class": "com.uber.cadence.converter.DataConverterException"
  },
  "decisionTaskCompletedEventId": 13
}
```
</details>