### PR TITLE
Add claims exp and iat to admin JWT token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     compile group: 'com.cronutils', name: 'cron-utils', version: '9.2.0'
     compile group: 'io.micrometer', name: 'micrometer-core', version: '1.10.2'
     compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
-    compile group: 'com.auth0', name: 'java-jwt', version:'3.10.2'
+    compile group: 'com.auth0', name: 'java-jwt', version:'4.4.0'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.21.9'
     compile group: 'com.google.api.grpc', name: 'proto-google-common-protos', version: '2.10.0'
     compile group: 'io.grpc', name: 'grpc-testing', version: '1.54.2'

--- a/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
+++ b/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
@@ -23,8 +23,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.sql.Date;
-import java.time.Clock;
+import java.time.Instant;
 
 public class AdminJwtAuthorizationProvider implements IAuthorizationProvider {
 
@@ -38,10 +37,13 @@ public class AdminJwtAuthorizationProvider implements IAuthorizationProvider {
 
   @Override
   public byte[] getAuthToken() {
+    final Instant now = Instant.now();
     final JWTCreator.Builder jwtBuilder = JWT.create();
+    int JWT_TTL_SECONDS = 60 * 10;
     jwtBuilder.withClaim("admin", true);
-    jwtBuilder.withClaim("ttl", 60 * 10);
-    jwtBuilder.withIssuedAt(Date.from(Clock.systemUTC().instant()));
+    jwtBuilder.withClaim("ttl", JWT_TTL_SECONDS);
+    jwtBuilder.withIssuedAt(now);
+    jwtBuilder.withExpiresAt(now.plusSeconds(JWT_TTL_SECONDS));
     return jwtBuilder
         .sign(Algorithm.RSA256(this.rsaPublicKey, this.rsaPrivateKey))
         .getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProviderTest.java
+++ b/src/test/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProviderTest.java
@@ -28,6 +28,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Date;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
@@ -56,6 +57,10 @@ public class AdminJwtAuthorizationProviderTest {
     assertTrue(adminClaim.asBoolean());
     final Claim ttlClaim = decodedJwt.getClaim("ttl");
     assertEquals((int) (60 * 10), (int) ttlClaim.asInt());
+    final Date expClaim = decodedJwt.getExpiresAt();
+    // Check if expClaim and issued at + ttl is the same time
+    assertEquals(
+        expClaim.toInstant(), decodedJwt.getIssuedAt().toInstant().plusSeconds(ttlClaim.asInt()));
   }
 
   private static String testPublicKey =


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding two standard JWT claims `exp` and `iat` while still leaving custom `ttl` claim

<!-- Tell your future self why have you made these changes -->
**Why?**
For better interoperability. Having standard claims in JWT makes it easier to use 3rd party OAuth libraries for validation

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
