### PR TITLE
Updating cassandra version to 4.1.3

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     deploy:
       resources:
         limits:

--- a/src/test/java/com/uber/cadence/internal/replay/ReplayDeciderCacheTests.java
+++ b/src/test/java/com/uber/cadence/internal/replay/ReplayDeciderCacheTests.java
@@ -103,7 +103,7 @@ public class ReplayDeciderCacheTests {
     service.close();
   }
 
-  @Test(timeout = 7000)
+  @Test(timeout = 8000)
   public void whenHistoryIsPartialCachedEntryIsReturned() throws Exception {
     // Arrange
     Map<String, String> tags =


### PR DESCRIPTION
What changed?
Docker version update from 3.1 to 4.1.3

Why?
Updating the docker version (to check the reason for docker compose with sticky on failure)

How did you test it?
Tested locally

Potential risks
It is a version upgrade (which is already followed by other services), hence will see it if buildkite build builds succesfully.

Release notes
Config update

Documentation Changes
Not required