### PR TITLE
Added signalWorkflow implementation and tests for both SignalWorkflowExecution and SignalWithStart

### DIFF
--- a/src/main/java/com/uber/cadence/migration/MigrationIWorkflowService.java
+++ b/src/main/java/com/uber/cadence/migration/MigrationIWorkflowService.java
@@ -56,12 +56,32 @@ public class MigrationIWorkflowService extends IWorkflowServiceBase {
     return serviceOld.StartWorkflowExecution(startRequest);
   }
 
+  /**
+   * SignalWithStartWorkflowExecution is used to ensure sending signal to a workflow. If the
+   * workflow is running, this results in WorkflowExecutionSignaled event being recorded in the
+   * history and a decision task being created for the execution. If the workflow is not running or
+   * not found, this results in WorkflowExecutionStarted and WorkflowExecutionSignaled events being
+   * recorded in history, and a decision task being created for the execution
+   */
   @Override
   public StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(
       SignalWithStartWorkflowExecutionRequest signalWithStartRequest) throws TException {
     if (shouldStartInNew(signalWithStartRequest.getWorkflowId()))
       return serviceNew.SignalWithStartWorkflowExecution(signalWithStartRequest);
     return serviceOld.SignalWithStartWorkflowExecution(signalWithStartRequest);
+  }
+
+  /**
+   * SignalWorkflowExecution is used to send a signal event to running workflow execution. This
+   * results in WorkflowExecutionSignaled event recorded in the history and a decision task being
+   * created for the execution.
+   */
+  @Override
+  public void SignalWorkflowExecution(SignalWorkflowExecutionRequest signalRequest)
+      throws TException {
+    if (shouldStartInNew(signalRequest.getWorkflowExecution().getWorkflowId()))
+      serviceNew.SignalWorkflowExecution(signalRequest);
+    else serviceOld.SignalWorkflowExecution(signalRequest);
   }
 
   @Override


### PR DESCRIPTION
Why?:
-- Added implementation of signalWorkflowExecution
      basically, it will first signal in new new, if it does not found the domain there, then it will go to the old service
-- Test: SignalWorkflowExecution
-- Test: SignalWithStartWorkflowExecution

How did you test it?:
Unit test locally