### PR TITLE
Migrate Buildkite CI queues from AWS to GKE

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,76 +1,146 @@
+container:
+  kubernetes: &kubernetes
+    gitEnvFrom:
+      - secretRef:
+          name: oss-github-ssh-credentials
+    sidecars:
+    - image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-dind:v1
+      volumeMounts:
+        - mountPath: /var/run/
+          name: docker-sock
+      securityContext:
+        privileged: true
+        allowPrivilegeEscalation: true
+    mirrorVolumeMounts: true # CRITICAL: this must be at the same indentation level as sidecars
+    podSpec: &podSpec
+      containers:
+        - &commandContainer
+          image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-command-container:v2
+          command:
+          - |-
+            echo "Command step was not overridden."
+            exit 1
+          volumeMounts:
+            - mountPath: /var/run/
+              name: docker-sock
+          resources:
+            requests:
+              cpu: 7500m
+              memory: 30G
+      volumes:
+      - name: docker-sock
+        emptyDir: {}
+
+agents:
+  queue: buildkite-gcp
+
 steps:
   - label: "fossa analyze"
-    agents:
-      queue: "init"
-      docker: "*"
-    command: ".buildkite/scripts/fossa.sh"
-  - label: "Lint Check"
-    agents:
-      queue: "init"
-      docker: "*"
-    command: ".buildkite/scripts/lint.sh"
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  .buildkite/scripts/fossa.sh
+
+  - label: "Lint Check"
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  .buildkite/scripts/lint.sh
       - docker-compose#v3.0.0:
           run: unit-test-test-service
           config: docker/buildkite/docker-compose.yaml
+
   - label: ":java: Unit test with test services"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "./gradlew --no-daemon test jacocoTestReport"
     artifact_paths:
       - "build/reports/jacoco/test/*.xml"
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     retry:
       automatic:
         - exit_status: "*"
           limit: 3
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  ./gradlew --no-daemon test jacocoTestReport
       - docker-compose#v3.0.0:
           run: unit-test-test-service
           config: docker/buildkite/docker-compose.yaml
 
   - label: ":java: Unit test with docker services sticky on"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "./gradlew --no-daemon test"
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     retry:
       automatic:
         - exit_status: "*"
           limit: 3
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  ./gradlew --no-daemon test
       - docker-compose#v3.0.0:
           run: unit-test-docker-sticky-on
           config: docker/buildkite/docker-compose.yaml
 
   - label: ":java: Unit test with docker services sticky off"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "./gradlew --no-daemon test"
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     retry:
       automatic:
         - exit_status: "*"
           limit: 3
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  ./gradlew --no-daemon test
       - docker-compose#v3.0.0:
           run: unit-test-docker-sticky-off
           config: docker/buildkite/docker-compose.yaml
+
   - wait
 
   - label: ":java: Report test coverage"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: ".buildkite/scripts/coverage.sh"
     retry:
       automatic:
         - exit_status: "*"
           limit: 3
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  .buildkite/scripts/coverage.sh
       - docker-compose#v3.0.0:
           run: test-coverage-report
           config: docker/buildkite/docker-compose.yaml

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -9,7 +9,11 @@ ENV APACHE_THRIFT_VERSION=0.9.3
 # Install dependencies using apk
 RUN apk update && apk add --virtual wget ca-certificates wget && apk add --virtual build-dependencies build-base gcc
 # Git is needed in order to update the dls submodule
-RUN apk add git libstdc++
+RUN apk add git libstdc++ bash curl
+
+# Install buildkite agent
+RUN bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/main/install.sh`"
+RUN ln -s /root/.buildkite-agent/bin/buildkite-agent /usr/bin/buildkite-agent
 
 # Compile source
 RUN set -ex ;\

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -12,6 +12,7 @@ RUN apk update && apk add --virtual wget ca-certificates wget && apk add --virtu
 RUN apk add git libstdc++ bash curl
 
 # Install buildkite agent
+# https://buildkite.com/docs/agent/v3/linux
 RUN bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/main/install.sh`"
 RUN ln -s /root/.buildkite-agent/bin/buildkite-agent /usr/bin/buildkite-agent
 

--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -122,4 +122,3 @@ services:
       - COVERALLS_REPO_TOKEN
     volumes:
       - "../../:/cadence-java-client"
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update Buildkite pipeline yaml to work with the newly provisioned queues in Google Kubernetes Engine
- Use [agent-stack-k8s v0.8.0 helm chart](https://github.com/buildkite/agent-stack-k8s/tree/v0.8.0?tab=readme-ov-file#cloning-repos-via-ssh) which has its own expected pipeline yaml syntax in order to successfully onboard. 
- Install buildkite-agent in Dockerfile for use in the code coverage step
  - The mount that previously worked in AWS's VM based infra doesn't work in Kubernete's container based set up. Install the cli directly for simplicity. 

<!-- Tell your future self why have you made these changes -->
**Why?**
- There is a company mandate to evacuate Uber's AWS CI footprint. The go forward decision is to use Google Cloud. Buildkite Enterprise recommends GKE (as opposed to GCP) as the way to have a queue with autoscaling compute. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- https://buildkite.com/uberopensource/cadence-java-client-gcp/builds/19

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- CI builds will be broken or flaky
- Can be mitigated by a git revert

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
n/a

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
n/a