### PR TITLE
Changed default tracer from NoopTracer to GlobalTracer

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -38,6 +38,7 @@ import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Functions.Func1;
 import com.uber.cadence.workflow.Promise;
 import com.uber.m3.tally.Scope;
+import io.opentracing.noop.NoopTracerFactory;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -193,7 +194,8 @@ class DeterministicRunnerImpl implements DeterministicRunner {
         null,
         (next) -> next,
         null,
-        null);
+        null,
+        NoopTracerFactory.create());
   }
 
   SyncDecisionContext getDecisionContext() {

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -61,7 +61,6 @@ import com.uber.cadence.workflow.WorkflowInterceptor;
 import com.uber.m3.tally.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-import io.opentracing.noop.NoopTracerFactory;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.HashMap;
@@ -95,23 +94,6 @@ final class SyncDecisionContext implements WorkflowInterceptor {
   private final byte[] lastCompletionResult;
   private final WorkflowImplementationOptions workflowImplementationOptions;
   private final TracingPropagator tracingPropagator;
-
-  public SyncDecisionContext(
-      DecisionContext context,
-      DataConverter converter,
-      List<ContextPropagator> contextPropagators,
-      Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory,
-      byte[] lastCompletionResult,
-      WorkflowImplementationOptions workflowImplementationOptions) {
-    this(
-        context,
-        converter,
-        contextPropagators,
-        interceptorFactory,
-        lastCompletionResult,
-        workflowImplementationOptions,
-        NoopTracerFactory.create());
-  }
 
   public SyncDecisionContext(
       DecisionContext context,

--- a/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
+++ b/src/main/java/com/uber/cadence/serviceclient/ClientOptions.java
@@ -25,7 +25,7 @@ import com.uber.cadence.serviceclient.auth.IAuthorizationProvider;
 import com.uber.m3.tally.Scope;
 import io.grpc.ManagedChannel;
 import io.opentracing.Tracer;
-import io.opentracing.noop.NoopTracerFactory;
+import io.opentracing.util.GlobalTracer;
 import java.util.Map;
 
 public class ClientOptions {
@@ -233,8 +233,8 @@ public class ClientOptions {
     private IAuthorizationProvider authProvider;
     private FeatureFlags featureFlags;
     private String isolationGroup;
-    // by default NoopTracer
-    private Tracer tracer = NoopTracerFactory.create();
+    // by default GlobalTracer
+    private Tracer tracer = GlobalTracer.get();
 
     private Builder() {}
 

--- a/src/main/java/com/uber/cadence/worker/WorkerOptions.java
+++ b/src/main/java/com/uber/cadence/worker/WorkerOptions.java
@@ -20,7 +20,7 @@ package com.uber.cadence.worker;
 import com.uber.cadence.internal.worker.PollerOptions;
 import com.uber.cadence.workflow.WorkflowInterceptor;
 import io.opentracing.Tracer;
-import io.opentracing.noop.NoopTracerFactory;
+import io.opentracing.util.GlobalTracer;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -53,8 +53,8 @@ public final class WorkerOptions {
     private PollerOptions activityPollerOptions;
     private PollerOptions workflowPollerOptions;
     private Function<WorkflowInterceptor, WorkflowInterceptor> interceptorFactory = (n) -> n;
-    // by default NoopTracer
-    private Tracer tracer = NoopTracerFactory.create();
+    // by default GlobalTracer
+    private Tracer tracer = GlobalTracer.get();
 
     private Builder() {}
 
@@ -141,7 +141,7 @@ public final class WorkerOptions {
     }
 
     /**
-     * Optional: Sets the tracer to use for tracing. Default is NoopTracer
+     * Optional: Sets the tracer to use for tracing. Default is GlobalTracer
      *
      * @param tracer
      * @return

--- a/src/test/java/com/uber/cadence/internal/sync/DeterministicRunnerTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/DeterministicRunnerTest.java
@@ -47,6 +47,7 @@ import com.uber.m3.tally.RootScopeBuilder;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.StatsReporter;
 import com.uber.m3.util.ImmutableMap;
+import io.opentracing.noop.NoopTracerFactory;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -727,7 +728,13 @@ public class DeterministicRunnerTest {
         new DeterministicRunnerImpl(
             threadPool,
             new SyncDecisionContext(
-                decisionContext, JsonDataConverter.getInstance(), null, next -> next, null, null),
+                decisionContext,
+                JsonDataConverter.getInstance(),
+                null,
+                next -> next,
+                null,
+                null,
+                NoopTracerFactory.create()),
             () -> 0L, // clock override
             () -> {
               Promise<Void> thread =
@@ -752,7 +759,13 @@ public class DeterministicRunnerTest {
         new DeterministicRunnerImpl(
             threadPool,
             new SyncDecisionContext(
-                decisionContext, JsonDataConverter.getInstance(), null, next -> next, null, null),
+                decisionContext,
+                JsonDataConverter.getInstance(),
+                null,
+                next -> next,
+                null,
+                null,
+                NoopTracerFactory.create()),
             () -> 0L, // clock override
             () -> {
               Promise<Void> thread =

--- a/src/test/java/com/uber/cadence/internal/sync/SyncDecisionContextTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/SyncDecisionContextTest.java
@@ -25,6 +25,7 @@ import com.uber.cadence.SearchAttributes;
 import com.uber.cadence.converter.JsonDataConverter;
 import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.replay.DecisionContext;
+import io.opentracing.noop.NoopTracerFactory;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -38,7 +39,13 @@ public class SyncDecisionContextTest {
   public void setUp() {
     this.context =
         new SyncDecisionContext(
-            mockDecisionContext, JsonDataConverter.getInstance(), null, (next) -> next, null, null);
+            mockDecisionContext,
+            JsonDataConverter.getInstance(),
+            null,
+            (next) -> next,
+            null,
+            null,
+            NoopTracerFactory.create());
   }
 
   @Test

--- a/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
@@ -40,6 +40,7 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracer;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -132,6 +133,17 @@ public class StartWorkflowTest {
   private static final Logger logger = LoggerFactory.getLogger(StartWorkflowTest.class);
   private static final String DOMAIN = "test-domain";
   private static final String TASK_LIST = "test-tasklist";
+
+  @Test
+  public void testStartWorkflowTchannelDefaultBehavior() {
+    Assume.assumeTrue(useDockerService);
+    MockTracer mockTracer = new MockTracer();
+    GlobalTracer.registerIfAbsent(mockTracer);
+    IWorkflowService service =
+        new WorkflowServiceTChannel(
+            ClientOptions.newBuilder().build()); // default should propagate trace context
+    testStartWorkflowHelper(service, mockTracer, true);
+  }
 
   @Test
   public void testStartWorkflowTchannel() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* Default tracer will use GlobalTracer instead.
* Removed one constructor of `SyncDecisionContext` to set tracer more explicitly so it's less error-prone. 

<!-- Tell your future self why have you made these changes -->
**Why?**

Simplify onboarding time and match go client behavior. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Integration test for default behavior

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
