### PR TITLE
Changed WorkerOption to fallback and use WorkflowClient tracer instead of NoopTracer

### DIFF
--- a/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
@@ -103,6 +103,7 @@ import com.uber.cadence.internal.compatibility.proto.RequestMapper;
 import com.uber.cadence.internal.compatibility.proto.serviceclient.IGrpcServiceStubs;
 import com.uber.cadence.internal.compatibility.thrift.ErrorMapper;
 import com.uber.cadence.internal.compatibility.thrift.ResponseMapper;
+import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import io.grpc.Deadline;
 import io.grpc.StatusRuntimeException;
@@ -119,6 +120,11 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
 
   public Thrift2ProtoAdapter(IGrpcServiceStubs grpcServiceStubs) {
     this.grpcServiceStubs = grpcServiceStubs;
+  }
+
+  @Override
+  public ClientOptions getOptions() {
+    return grpcServiceStubs.getOptions();
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
@@ -81,6 +81,7 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
 
   private static final String CLIENT_IMPL_HEADER_VALUE = "uber-java";
 
+  private final ClientOptions options;
   private final ManagedChannel channel;
   private final boolean shutdownChannel;
   private final AtomicBoolean shutdownRequested = new AtomicBoolean();
@@ -96,6 +97,7 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
   private final MetaAPIGrpc.MetaAPIFutureStub metaFutureStub;
 
   GrpcServiceStubs(ClientOptions options) {
+    this.options = options;
     if (options.getGRPCChannel() != null) {
       this.channel = options.getGRPCChannel();
       shutdownChannel = false;
@@ -288,6 +290,11 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
 
   public DomainAPIGrpc.DomainAPIFutureStub domainFutureStub() {
     return domainFutureStub;
+  }
+
+  @Override
+  public ClientOptions getOptions() {
+    return options;
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/IGrpcServiceStubs.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/IGrpcServiceStubs.java
@@ -39,6 +39,8 @@ public interface IGrpcServiceStubs {
     return new GrpcServiceStubs(options);
   }
 
+  ClientOptions getOptions();
+
   /** @return Blocking (synchronous) stub to domain service. */
   DomainAPIGrpc.DomainAPIBlockingStub domainBlockingStub();
 

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -26,6 +26,7 @@ import com.uber.cadence.activity.LocalActivityOptions;
 import com.uber.cadence.internal.metrics.NoopScope;
 import com.uber.cadence.internal.worker.ActivityTaskHandler;
 import com.uber.cadence.internal.worker.ActivityTaskHandler.Result;
+import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.testing.TestActivityEnvironment;
 import com.uber.cadence.testing.TestEnvironmentOptions;
@@ -322,6 +323,11 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
   private class WorkflowServiceWrapper implements IWorkflowService {
 
     private final IWorkflowService impl;
+
+    @Override
+    public ClientOptions getOptions() {
+      return impl.getOptions();
+    }
 
     @Override
     public CompletableFuture<Boolean> isHealthy() {

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -104,6 +104,7 @@ import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.client.WorkflowStub;
 import com.uber.cadence.internal.testservice.TestWorkflowService;
+import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.testing.TestEnvironmentOptions;
 import com.uber.cadence.testing.TestWorkflowEnvironment;
@@ -276,6 +277,11 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
 
     public long currentTimeMillis() {
       return impl.currentTimeMillis();
+    }
+
+    @Override
+    public ClientOptions getOptions() {
+      return impl.getOptions();
     }
 
     @Override

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -105,6 +105,7 @@ import com.uber.cadence.WorkflowExecutionInfo;
 import com.uber.cadence.WorkflowIdReusePolicy;
 import com.uber.cadence.internal.testservice.TestWorkflowMutableStateImpl.QueryId;
 import com.uber.cadence.internal.testservice.TestWorkflowStore.WorkflowState;
+import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import java.time.Duration;
 import java.util.HashMap;
@@ -145,6 +146,11 @@ public final class TestWorkflowService implements IWorkflowService {
   @Override
   public void close() {
     store.close();
+  }
+
+  @Override
+  public ClientOptions getOptions() {
+    return ClientOptions.defaultInstance();
   }
 
   private TestWorkflowMutableState getMutableState(ExecutionId executionId)

--- a/src/main/java/com/uber/cadence/migration/MigrationIWorkflowService.java
+++ b/src/main/java/com/uber/cadence/migration/MigrationIWorkflowService.java
@@ -19,6 +19,7 @@ package com.uber.cadence.migration;
 
 import com.google.common.base.Strings;
 import com.uber.cadence.*;
+import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.serviceclient.IWorkflowServiceBase;
 import java.util.Arrays;
@@ -44,6 +45,11 @@ public class MigrationIWorkflowService extends IWorkflowServiceBase {
     this.domainOld = domainOld;
     this.serviceNew = serviceNew;
     this.domainNew = domainNew;
+  }
+
+  @Override
+  public ClientOptions getOptions() {
+    return serviceOld.getOptions();
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
@@ -30,6 +30,8 @@ import org.apache.thrift.async.AsyncMethodCallback;
 public interface IWorkflowService extends Iface, AsyncIface {
   void close();
 
+  ClientOptions getOptions();
+
   /**
    * StartWorkflowExecutionWithTimeout start workflow same as StartWorkflowExecution but with
    * timeout

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
@@ -25,6 +25,11 @@ import org.apache.thrift.async.AsyncMethodCallback;
 public class IWorkflowServiceBase implements IWorkflowService {
 
   @Override
+  public ClientOptions getOptions() {
+    throw new IllegalArgumentException("unimplemented");
+  }
+
+  @Override
   public void RegisterDomain(RegisterDomainRequest registerRequest)
       throws BadRequestError, DomainAlreadyExistsError, ServiceBusyError,
           ClientVersionNotSupportedError, TException {

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -174,6 +174,11 @@ public class WorkflowServiceTChannel implements IWorkflowService {
     return buildThriftRequest(apiName, body, null);
   }
 
+  @Override
+  public ClientOptions getOptions() {
+    return options;
+  }
+
   /**
    * Checks if we have a valid connection to the Cadence cluster, and potentially resets the peer
    * list

--- a/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
@@ -226,13 +226,7 @@ public class StartWorkflowTest {
     WorkerFactory workerFactory =
         WorkerFactory.newInstance(client, WorkerFactoryOptions.newBuilder().build());
     Worker worker;
-    if (shouldPropagate) {
-      worker =
-          workerFactory.newWorker(
-              TASK_LIST, WorkerOptions.newBuilder().setTracer(mockTracer).build());
-    } else {
-      worker = workerFactory.newWorker(TASK_LIST, WorkerOptions.newBuilder().build());
-    }
+    worker = workerFactory.newWorker(TASK_LIST, WorkerOptions.newBuilder().build());
     worker.registerActivitiesImplementations(new TestActivityImpl(mockTracer, shouldPropagate));
     worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class, DoubleWorkflowImpl.class);
     workerFactory.start();
@@ -322,13 +316,7 @@ public class StartWorkflowTest {
     WorkerFactory workerFactory =
         WorkerFactory.newInstance(client, WorkerFactoryOptions.newBuilder().build());
     Worker worker;
-    if (shouldPropagate) {
-      worker =
-          workerFactory.newWorker(
-              TASK_LIST, WorkerOptions.newBuilder().setTracer(mockTracer).build());
-    } else {
-      worker = workerFactory.newWorker(TASK_LIST, WorkerOptions.newBuilder().build());
-    }
+    worker = workerFactory.newWorker(TASK_LIST, WorkerOptions.newBuilder().build());
     worker.registerActivitiesImplementations(new TestActivityImpl(mockTracer, shouldPropagate));
     worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class, DoubleWorkflowImpl.class);
     workerFactory.start();


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

WorkflowOptions will now fallback and use WorkflowClient's tracer.

<!-- Tell your future self why have you made these changes -->
**Why?**

Make it easier to set tracer. Previously, it's required to set tracer both on the client and worker. Now setting tracer only on client should just work. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
