### PR TITLE
Add initial support for StartWorkflowExecutionAsync

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowStub.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowStub.java
@@ -76,11 +76,12 @@ public interface WorkflowStub {
   CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
       long timeout, TimeUnit unit, Object... args);
 
-  void enqueueStart(Object... args);
+  WorkflowExecution enqueueStart(Object... args);
 
-  CompletableFuture<Void> enqueueStartAsync(Object... args);
+  CompletableFuture<WorkflowExecution> enqueueStartAsync(Object... args);
 
-  CompletableFuture<Void> enqueueStartAsyncWithTimeout(long timeout, TimeUnit unit, Object... args);
+  CompletableFuture<WorkflowExecution> enqueueStartAsyncWithTimeout(
+      long timeout, TimeUnit unit, Object... args);
 
   WorkflowExecution signalWithStart(String signalName, Object[] signalArgs, Object[] startArgs);
 

--- a/src/main/java/com/uber/cadence/client/WorkflowStub.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowStub.java
@@ -76,6 +76,12 @@ public interface WorkflowStub {
   CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
       long timeout, TimeUnit unit, Object... args);
 
+  void enqueueStart(Object... args);
+
+  CompletableFuture<Void> enqueueStartAsync(Object... args);
+
+  CompletableFuture<Void> enqueueStartAsyncWithTimeout(long timeout, TimeUnit unit, Object... args);
+
   WorkflowExecution signalWithStart(String signalName, Object[] signalArgs, Object[] startArgs);
 
   Optional<String> getWorkflowType();

--- a/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
@@ -221,7 +221,17 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
           DomainNotActiveError, LimitExceededError, EntityNotExistsError,
           ClientVersionNotSupportedError, TException {
-    throw new IllegalArgumentException("unimplemented");
+    initializeStartWorkflowExecutionRequest(startRequest.getRequest());
+    try {
+      com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse response =
+          grpcServiceStubs
+              .workflowBlockingStub()
+              .startWorkflowExecutionAsync(
+                  RequestMapper.startWorkflowExecutionAsyncRequest(startRequest));
+      return ResponseMapper.startWorkflowExecutionAsyncResponse(response);
+    } catch (StatusRuntimeException e) {
+      throw ErrorMapper.Error(e);
+    }
   }
 
   private StartWorkflowExecutionResponse startWorkflowExecution(
@@ -229,7 +239,7 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
           DomainNotActiveError, LimitExceededError, EntityNotExistsError,
           ClientVersionNotSupportedError, TException {
-    startRequest.setRequestId(UUID.randomUUID().toString());
+    initializeStartWorkflowExecutionRequest(startRequest);
     try {
       com.uber.cadence.api.v1.StartWorkflowExecutionResponse response =
           grpcServiceStubs
@@ -239,6 +249,10 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
     } catch (StatusRuntimeException e) {
       throw ErrorMapper.Error(e);
     }
+  }
+
+  private void initializeStartWorkflowExecutionRequest(StartWorkflowExecutionRequest request) {
+    request.setRequestId(UUID.randomUUID().toString());
   }
 
   @Override
@@ -485,7 +499,7 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
           LimitExceededError, WorkflowExecutionAlreadyStartedError, ClientVersionNotSupportedError,
           TException {
     try {
-      signalWithStartRequest.setRequestId(UUID.randomUUID().toString());
+      initializeSignalWithStartWorkflowExecution(signalWithStartRequest);
       com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionResponse response =
           grpcServiceStubs
               .workflowBlockingStub()
@@ -503,7 +517,23 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
           DomainNotActiveError, LimitExceededError, EntityNotExistsError,
           ClientVersionNotSupportedError, TException {
-    throw new IllegalArgumentException("unimplemented");
+    try {
+      initializeSignalWithStartWorkflowExecution(signalWithStartRequest.getRequest());
+      com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncResponse response =
+          grpcServiceStubs
+              .workflowBlockingStub()
+              .signalWithStartWorkflowExecutionAsync(
+                  RequestMapper.signalWithStartWorkflowExecutionAsyncRequest(
+                      signalWithStartRequest));
+      return ResponseMapper.signalWithStartWorkflowExecutionAsyncResponse(response);
+    } catch (StatusRuntimeException e) {
+      throw ErrorMapper.Error(e);
+    }
+  }
+
+  private void initializeSignalWithStartWorkflowExecution(
+      SignalWithStartWorkflowExecutionRequest request) {
+    request.setRequestId(UUID.randomUUID().toString());
   }
 
   @Override
@@ -825,7 +855,28 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
   public void StartWorkflowExecutionAsync(
       StartWorkflowExecutionAsyncRequest startRequest, AsyncMethodCallback resultHandler)
       throws TException {
-    throw new IllegalArgumentException("unimplemented");
+    try {
+      initializeStartWorkflowExecutionRequest(startRequest.getRequest());
+      ListenableFuture<com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse> resultFuture =
+          grpcServiceStubs
+              .workflowFutureStub()
+              .startWorkflowExecutionAsync(
+                  RequestMapper.startWorkflowExecutionAsyncRequest(startRequest));
+      resultFuture.addListener(
+          () -> {
+            try {
+              com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse response =
+                  resultFuture.get();
+              resultHandler.onComplete(
+                  ResponseMapper.startWorkflowExecutionAsyncResponse(response));
+            } catch (Exception e) {
+              resultHandler.onError(e);
+            }
+          },
+          ForkJoinPool.commonPool());
+    } catch (StatusRuntimeException e) {
+      throw ErrorMapper.Error(e);
+    }
   }
 
   @Override
@@ -1124,7 +1175,7 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       Long timeoutInMillis)
       throws TException {
     try {
-      startRequest.setRequestId(UUID.randomUUID().toString());
+      initializeStartWorkflowExecutionRequest(startRequest);
       ListenableFuture<com.uber.cadence.api.v1.StartWorkflowExecutionResponse> resultFuture =
           grpcServiceStubs
               .workflowFutureStub()
@@ -1135,6 +1186,37 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
             try {
               com.uber.cadence.api.v1.StartWorkflowExecutionResponse response = resultFuture.get();
               resultHandler.onComplete(ResponseMapper.startWorkflowExecutionResponse(response));
+            } catch (Exception e) {
+              resultHandler.onError(e);
+            }
+          },
+          ForkJoinPool.commonPool());
+    } catch (StatusRuntimeException e) {
+      throw ErrorMapper.Error(e);
+    }
+  }
+
+  @Override
+  public void StartWorkflowExecutionAsyncWithTimeout(
+      StartWorkflowExecutionAsyncRequest startAsyncRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis)
+      throws TException {
+    try {
+      initializeStartWorkflowExecutionRequest(startAsyncRequest.getRequest());
+      ListenableFuture<com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse> resultFuture =
+          grpcServiceStubs
+              .workflowFutureStub()
+              .withDeadline(Deadline.after(timeoutInMillis, TimeUnit.MILLISECONDS))
+              .startWorkflowExecutionAsync(
+                  RequestMapper.startWorkflowExecutionAsyncRequest(startAsyncRequest));
+      resultFuture.addListener(
+          () -> {
+            try {
+              com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse response =
+                  resultFuture.get();
+              resultHandler.onComplete(
+                  ResponseMapper.startWorkflowExecutionAsyncResponse(response));
             } catch (Exception e) {
               resultHandler.onError(e);
             }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/RequestMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/RequestMapper.java
@@ -84,8 +84,10 @@ import com.uber.cadence.api.v1.RespondDecisionTaskCompletedRequest;
 import com.uber.cadence.api.v1.RespondDecisionTaskFailedRequest;
 import com.uber.cadence.api.v1.RespondQueryTaskCompletedRequest;
 import com.uber.cadence.api.v1.ScanWorkflowExecutionsRequest;
+import com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncRequest;
 import com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionRequest;
 import com.uber.cadence.api.v1.SignalWorkflowExecutionRequest;
+import com.uber.cadence.api.v1.StartWorkflowExecutionAsyncRequest;
 import com.uber.cadence.api.v1.StartWorkflowExecutionRequest;
 import com.uber.cadence.api.v1.TerminateWorkflowExecutionRequest;
 import com.uber.cadence.api.v1.UpdateDomainRequest;
@@ -449,7 +451,7 @@ public class RequestMapper {
     if (t.getDelayStartSeconds() > 0) {
       builder.setDelayStart(secondsToDuration(t.getDelayStartSeconds()));
     }
-    ;
+
     if (t.getIdentity() != null) {
       builder.setIdentity(t.getIdentity());
     }
@@ -462,6 +464,20 @@ public class RequestMapper {
       sb.setControl(arrayToByteString(t.getControl()));
     }
     return sb.build();
+  }
+
+  public static SignalWithStartWorkflowExecutionAsyncRequest
+      signalWithStartWorkflowExecutionAsyncRequest(
+          com.uber.cadence.SignalWithStartWorkflowExecutionAsyncRequest t) {
+    if (t == null) {
+      return null;
+    }
+    SignalWithStartWorkflowExecutionAsyncRequest.Builder builder =
+        SignalWithStartWorkflowExecutionAsyncRequest.newBuilder();
+    if (t.getRequest() != null) {
+      builder.setRequest(signalWithStartWorkflowExecutionRequest(t.getRequest()));
+    }
+    return builder.build();
   }
 
   public static SignalWorkflowExecutionRequest signalWorkflowExecutionRequest(
@@ -516,6 +532,19 @@ public class RequestMapper {
       request.setIdentity(t.getIdentity());
     }
     return request.build();
+  }
+
+  public static StartWorkflowExecutionAsyncRequest startWorkflowExecutionAsyncRequest(
+      com.uber.cadence.StartWorkflowExecutionAsyncRequest t) {
+    if (t == null) {
+      return null;
+    }
+    StartWorkflowExecutionAsyncRequest.Builder builder =
+        StartWorkflowExecutionAsyncRequest.newBuilder();
+    if (t.getRequest() != null) {
+      builder.setRequest(startWorkflowExecutionRequest(t.getRequest()));
+    }
+    return builder.build();
   }
 
   public static TerminateWorkflowExecutionRequest terminateWorkflowExecutionRequest(

--- a/src/main/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapper.java
@@ -71,6 +71,8 @@ import com.uber.cadence.QueryWorkflowResponse;
 import com.uber.cadence.RecordActivityTaskHeartbeatResponse;
 import com.uber.cadence.ResetWorkflowExecutionResponse;
 import com.uber.cadence.RespondDecisionTaskCompletedResponse;
+import com.uber.cadence.SignalWithStartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.UpdateDomainResponse;
 import com.uber.cadence.api.v1.WorkflowQuery;
@@ -86,6 +88,11 @@ public class ResponseMapper {
         new StartWorkflowExecutionResponse();
     startWorkflowExecutionResponse.setRunId(t.getRunId());
     return startWorkflowExecutionResponse;
+  }
+
+  public static StartWorkflowExecutionAsyncResponse startWorkflowExecutionAsyncResponse(
+      com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse t) {
+    return t == null ? null : new StartWorkflowExecutionAsyncResponse();
   }
 
   public static DescribeTaskListResponse describeTaskListResponse(
@@ -397,6 +404,12 @@ public class ResponseMapper {
         new StartWorkflowExecutionResponse();
     startWorkflowExecutionResponse.setRunId(t.getRunId());
     return startWorkflowExecutionResponse;
+  }
+
+  public static SignalWithStartWorkflowExecutionAsyncResponse
+      signalWithStartWorkflowExecutionAsyncResponse(
+          com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncResponse t) {
+    return t == null ? null : new SignalWithStartWorkflowExecutionAsyncResponse();
   }
 
   public static UpdateDomainResponse updateDomainResponse(

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
@@ -39,6 +39,12 @@ public interface GenericWorkflowClientExternal {
   CompletableFuture<WorkflowExecution> startWorkflowAsync(
       StartWorkflowExecutionParameters startParameters, Long timeoutInMillis);
 
+  void enqueueStartWorkflow(StartWorkflowExecutionParameters startParameters)
+      throws WorkflowExecutionAlreadyStartedError;
+
+  CompletableFuture<Void> enqueueStartWorkflowAsync(
+      StartWorkflowExecutionParameters startParameters, Long timeoutInMillis);
+
   void signalWorkflowExecution(SignalExternalWorkflowParameters signalParameters);
 
   CompletableFuture<Void> signalWorkflowExecutionAsync(

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
@@ -21,6 +21,8 @@ public class MetricsType {
 
   public static final String CADENCE_METRICS_PREFIX = "cadence-";
   public static final String WORKFLOW_START_COUNTER = CADENCE_METRICS_PREFIX + "workflow-start";
+  public static final String WORKFLOW_START_ASYNC_COUNTER =
+      CADENCE_METRICS_PREFIX + "workflow-start-async";
   public static final String WORKFLOW_COMPLETED_COUNTER =
       CADENCE_METRICS_PREFIX + "workflow-completed";
   public static final String WORKFLOW_CANCELLED_COUNTER =

--- a/src/main/java/com/uber/cadence/internal/metrics/ServiceMethod.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/ServiceMethod.java
@@ -77,8 +77,12 @@ public class ServiceMethod {
       MetricsType.CADENCE_METRICS_PREFIX + "ResetWorkflowExecution";
   public static final String SIGNAL_WITH_START_WORKFLOW_EXECUTION =
       MetricsType.CADENCE_METRICS_PREFIX + "SignalWithStartWorkflowExecution";
+  public static final String SIGNAL_WITH_START_WORKFLOW_EXECUTION_ASYNC =
+      MetricsType.CADENCE_METRICS_PREFIX + "SignalWithStartWorkflowExecutionAsync";
   public static final String START_WORKFLOW_EXECUTION =
       MetricsType.CADENCE_METRICS_PREFIX + "StartWorkflowExecution";
+  public static final String START_WORKFLOW_EXECUTION_ASYNC =
+      MetricsType.CADENCE_METRICS_PREFIX + "StartWorkflowExecutionAsync";
   public static final String TERMINATE_WORKFLOW_EXECUTION =
       MetricsType.CADENCE_METRICS_PREFIX + "TerminateWorkflowExecution";
   public static final String UPDATE_DOMAIN = MetricsType.CADENCE_METRICS_PREFIX + "UpdateDomain";

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -650,6 +650,16 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     }
 
     @Override
+    public void StartWorkflowExecutionAsyncWithTimeout(
+        StartWorkflowExecutionAsyncRequest startAsyncRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.StartWorkflowExecutionAsyncWithTimeout(
+          startAsyncRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
     public void GetWorkflowExecutionHistory(
         GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
         throws TException {

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -991,17 +991,17 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
       }
 
       @Override
-      public void enqueueStart(Object... args) {
-        next.enqueueStart(args);
+      public WorkflowExecution enqueueStart(Object... args) {
+        return next.enqueueStart(args);
       }
 
       @Override
-      public CompletableFuture<Void> enqueueStartAsync(Object... args) {
+      public CompletableFuture<WorkflowExecution> enqueueStartAsync(Object... args) {
         return next.enqueueStartAsync(args);
       }
 
       @Override
-      public CompletableFuture<Void> enqueueStartAsyncWithTimeout(
+      public CompletableFuture<WorkflowExecution> enqueueStartAsyncWithTimeout(
           long timeout, TimeUnit unit, Object... args) {
         return next.enqueueStartAsyncWithTimeout(timeout, unit, args);
       }

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -532,6 +532,16 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     }
 
     @Override
+    public void StartWorkflowExecutionAsyncWithTimeout(
+        StartWorkflowExecutionAsyncRequest startAsyncRequest,
+        AsyncMethodCallback resultHandler,
+        Long timeoutInMillis)
+        throws TException {
+      impl.StartWorkflowExecutionAsyncWithTimeout(
+          startAsyncRequest, resultHandler, timeoutInMillis);
+    }
+
+    @Override
     public void GetWorkflowExecutionHistory(
         GetWorkflowExecutionHistoryRequest getRequest, AsyncMethodCallback resultHandler)
         throws TException {
@@ -978,6 +988,22 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
       public CompletableFuture<WorkflowExecution> startAsyncWithTimeout(
           long timeout, TimeUnit unit, Object... args) {
         return next.startAsyncWithTimeout(timeout, unit, args);
+      }
+
+      @Override
+      public void enqueueStart(Object... args) {
+        next.enqueueStart(args);
+      }
+
+      @Override
+      public CompletableFuture<Void> enqueueStartAsync(Object... args) {
+        return next.enqueueStartAsync(args);
+      }
+
+      @Override
+      public CompletableFuture<Void> enqueueStartAsyncWithTimeout(
+          long timeout, TimeUnit unit, Object... args) {
+        return next.enqueueStartAsyncWithTimeout(timeout, unit, args);
       }
 
       @Override

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -253,7 +253,9 @@ public final class TestWorkflowService implements IWorkflowService {
       throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
           DomainNotActiveError, LimitExceededError, EntityNotExistsError,
           ClientVersionNotSupportedError, TException {
-    throw new UnsupportedOperationException("not implemented");
+    // Just run it
+    StartWorkflowExecution(startRequest.getRequest());
+    return new StartWorkflowExecutionAsyncResponse();
   }
 
   StartWorkflowExecutionResponse startWorkflowExecutionImpl(
@@ -872,13 +874,6 @@ public final class TestWorkflowService implements IWorkflowService {
   }
 
   @Override
-  public void StartWorkflowExecutionAsync(
-      StartWorkflowExecutionAsyncRequest startRequest, AsyncMethodCallback resultHandler)
-      throws TException {
-    throw new UnsupportedOperationException("not implemented");
-  }
-
-  @Override
   public void StartWorkflowExecutionWithTimeout(
       StartWorkflowExecutionRequest startRequest,
       AsyncMethodCallback resultHandler,
@@ -893,6 +888,37 @@ public final class TestWorkflowService implements IWorkflowService {
             resultHandler.onError(e);
           }
         });
+  }
+
+  @Override
+  public void StartWorkflowExecutionAsync(
+      StartWorkflowExecutionAsyncRequest startRequest, AsyncMethodCallback resultHandler)
+      throws TException {
+    StartWorkflowExecutionAsyncWithTimeout(startRequest, resultHandler, null);
+  }
+
+  @Override
+  public void StartWorkflowExecutionAsyncWithTimeout(
+      StartWorkflowExecutionAsyncRequest startAsyncRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis)
+      throws TException {
+    // Treat it like a synchronous call but ignore the result
+    StartWorkflowExecutionWithTimeout(
+        startAsyncRequest.getRequest(),
+        new AsyncMethodCallback() {
+          @Override
+          public void onComplete(Object response) {
+            // Noop
+          }
+
+          @Override
+          public void onError(Exception exception) {
+            // Noop
+          }
+        },
+        timeoutInMillis);
+    resultHandler.onComplete(new StartWorkflowExecutionAsyncResponse());
   }
 
   @SuppressWarnings("unchecked") // Generator ignores that AsyncMethodCallback is generic

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
@@ -20,6 +20,7 @@ package com.uber.cadence.serviceclient;
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
 import com.uber.cadence.SignalWorkflowExecutionRequest;
+import com.uber.cadence.StartWorkflowExecutionAsyncRequest;
 import com.uber.cadence.StartWorkflowExecutionRequest;
 import com.uber.cadence.WorkflowService.AsyncIface;
 import com.uber.cadence.WorkflowService.Iface;
@@ -43,6 +44,21 @@ public interface IWorkflowService extends Iface, AsyncIface {
    */
   void StartWorkflowExecutionWithTimeout(
       StartWorkflowExecutionRequest startRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis)
+      throws TException;
+
+  /**
+   * StartWorkflowExecutionAsyncWithTimeout start workflow same as StartWorkflowExecutionAsync but
+   * with timeout
+   *
+   * @param startAsyncRequest
+   * @param resultHandler
+   * @param timeoutInMillis
+   * @throws TException
+   */
+  void StartWorkflowExecutionAsyncWithTimeout(
+      StartWorkflowExecutionAsyncRequest startAsyncRequest,
       AsyncMethodCallback resultHandler,
       Long timeoutInMillis)
       throws TException;

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
@@ -668,6 +668,15 @@ public class IWorkflowServiceBase implements IWorkflowService {
   }
 
   @Override
+  public void StartWorkflowExecutionAsyncWithTimeout(
+      StartWorkflowExecutionAsyncRequest startAsyncRequest,
+      AsyncMethodCallback resultHandler,
+      Long timeoutInMillis)
+      throws TException {
+    throw new IllegalArgumentException("unimplemented");
+  }
+
+  @Override
   public GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistoryWithTimeout(
       GetWorkflowExecutionHistoryRequest getRequest, Long timeoutInMillis) throws TException {
     throw new IllegalArgumentException("unimplemented");

--- a/src/test/java/com/uber/cadence/FakeWorkflowServiceRule.java
+++ b/src/test/java/com/uber/cadence/FakeWorkflowServiceRule.java
@@ -1,0 +1,104 @@
+package com.uber.cadence;
+
+import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
+import com.uber.tchannel.api.ResponseCode;
+import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.api.handlers.ThriftRequestHandler;
+import com.uber.tchannel.messages.ThriftRequest;
+import com.uber.tchannel.messages.ThriftResponse;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.rules.ExternalResource;
+
+/**
+ * FakeWorkflowServiceRule a local TChannel service which can be stubbed with fixed responses and
+ * captures the requests made to it. This allows testing throw the entire TChannel stack,
+ * particularly with TChannel being difficult to mock.
+ */
+public class FakeWorkflowServiceRule extends ExternalResource {
+
+  private final Map<String, StubbedResponse<?>> stubbedResponses = new ConcurrentHashMap<>();
+  private TChannel tChannel;
+  private IWorkflowService clientConn;
+
+  @Override
+  protected void before() throws Throwable {
+    tChannel = new TChannel.Builder("cadence-frontend").build();
+    tChannel.setDefaultUserHandler(
+        new ThriftRequestHandler<Object, Object>() {
+          @Override
+          public ThriftResponse<Object> handleImpl(ThriftRequest<Object> request) {
+            @SuppressWarnings("rawtypes")
+            StubbedResponse stub = stubbedResponses.get(request.getEndpoint());
+            if (stub == null) {
+              throw new IllegalStateException(
+                  "Endpoint " + request.getEndpoint() + " was not stubbed");
+            }
+            //noinspection unchecked
+            stub.future.complete(request.getBody(stub.requestType));
+            return new ThriftResponse.Builder<>(request)
+                .setBody(stub.body)
+                .setResponseCode(stub.code)
+                .build();
+          }
+        });
+    tChannel.listen();
+    clientConn =
+        new WorkflowServiceTChannel(
+            ClientOptions.newBuilder()
+                .setHost(tChannel.getListeningHost())
+                .setPort(tChannel.getListeningPort())
+                .build());
+  }
+
+  @Override
+  protected void after() {
+    stubbedResponses.clear();
+    if (clientConn != null) {
+      clientConn.close();
+    }
+    if (tChannel != null) {
+      tChannel.shutdown();
+      tChannel = null;
+    }
+  }
+
+  public void resetStubs() {
+    stubbedResponses.clear();
+  }
+
+  public IWorkflowService getClient() {
+    return clientConn;
+  }
+
+  public <V> CompletableFuture<V> stubEndpoint(
+      String endpoint, Class<V> requestType, Object response) {
+    CompletableFuture<V> future = new CompletableFuture<>();
+    StubbedResponse<?> existingStub =
+        stubbedResponses.putIfAbsent(
+            endpoint, new StubbedResponse<>(response, ResponseCode.OK, future, requestType));
+    if (existingStub != null) {
+      throw new IllegalStateException(
+          "Endpoint " + endpoint + " was already stubbed to return " + existingStub.body);
+    }
+    return future;
+  }
+
+  private static class StubbedResponse<V> {
+    private final Object body;
+    private final ResponseCode code;
+    private final CompletableFuture<V> future;
+    private final Class<V> requestType;
+
+    private StubbedResponse(
+        Object body, ResponseCode code, CompletableFuture<V> future, Class<V> requestType) {
+      this.body = body;
+      this.code = code;
+      this.future = future;
+      this.requestType = requestType;
+    }
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/compatibility/MapperTestUtil.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/MapperTestUtil.java
@@ -1,0 +1,43 @@
+package com.uber.cadence.internal.compatibility;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TFieldIdEnum;
+import org.junit.Assert;
+
+/**
+ * Utility that asserts all fields on a Thrift object are present other than a specified list of
+ * fields. This ensures that any changes to the IDL will result in the test failing unless either
+ * the test or mapper is updated.
+ */
+public class MapperTestUtil {
+
+  public static <E extends Enum<E> & TFieldIdEnum, M extends TBase<M, E>>
+      void assertNoMissingFields(M message, Class<E> fields) {
+    Assert.assertEquals(
+        "All fields expected to be set", Collections.emptySet(), getUnsetFields(message, fields));
+  }
+
+  public static <E extends Enum<E> & TFieldIdEnum, M extends TBase<M, E>> void assertMissingFields(
+      M message, Class<E> fields, String... values) {
+    assertMissingFields(message, fields, ImmutableSet.copyOf(values));
+  }
+
+  public static <E extends Enum<E> & TFieldIdEnum, M extends TBase<M, E>> void assertMissingFields(
+      M message, Class<E> fields, Set<String> expected) {
+    Assert.assertEquals(
+        "Additional fields are unexpectedly not set", expected, getUnsetFields(message, fields));
+  }
+
+  private static <E extends Enum<E> & TFieldIdEnum, M extends TBase<M, E>>
+      Set<String> getUnsetFields(M message, Class<E> fields) {
+    return Arrays.stream(fields.getEnumConstants())
+        .filter(field -> !message.isSet(field))
+        .map(TFieldIdEnum::getFieldName)
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/RequestMapperTest.java
@@ -1,0 +1,145 @@
+package com.uber.cadence.internal.compatibility.proto;
+
+import static com.uber.cadence.internal.compatibility.MapperTestUtil.assertMissingFields;
+import static com.uber.cadence.internal.compatibility.MapperTestUtil.assertNoMissingFields;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
+import com.uber.cadence.api.v1.Header;
+import com.uber.cadence.api.v1.Memo;
+import com.uber.cadence.api.v1.Payload;
+import com.uber.cadence.api.v1.RetryPolicy;
+import com.uber.cadence.api.v1.SearchAttributes;
+import com.uber.cadence.api.v1.StartWorkflowExecutionAsyncRequest;
+import com.uber.cadence.api.v1.StartWorkflowExecutionRequest;
+import com.uber.cadence.api.v1.TaskList;
+import com.uber.cadence.api.v1.TaskListKind;
+import com.uber.cadence.api.v1.WorkflowIdReusePolicy;
+import com.uber.cadence.api.v1.WorkflowType;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class RequestMapperTest {
+
+  // These are shared between testStartWorkflowExecutionRequest and
+  // testStartWorkflowExecutionAsyncRequest
+  // because the mapper throws an exception if necessary fields are missing
+  private static final com.uber.cadence.StartWorkflowExecutionRequest
+      THRIFT_START_WORKFLOW_EXECUTION =
+          new com.uber.cadence.StartWorkflowExecutionRequest()
+              .setDomain("domain")
+              .setWorkflowId("workflowId")
+              .setWorkflowType(new com.uber.cadence.WorkflowType().setName("workflowType"))
+              .setTaskList(
+                  new com.uber.cadence.TaskList()
+                      .setName("taskList")
+                      .setKind(com.uber.cadence.TaskListKind.NORMAL))
+              .setInput("input".getBytes(StandardCharsets.UTF_8))
+              .setExecutionStartToCloseTimeoutSeconds(1)
+              .setTaskStartToCloseTimeoutSeconds(2)
+              .setIdentity("identity")
+              .setRequestId("requestId")
+              .setWorkflowIdReusePolicy(com.uber.cadence.WorkflowIdReusePolicy.AllowDuplicate)
+              .setRetryPolicy(
+                  new com.uber.cadence.RetryPolicy()
+                      .setInitialIntervalInSeconds(11)
+                      .setBackoffCoefficient(0.5)
+                      .setMaximumIntervalInSeconds(12)
+                      .setMaximumAttempts(13)
+                      .setNonRetriableErrorReasons(ImmutableList.of("error"))
+                      .setExpirationIntervalInSeconds(14))
+              .setCronSchedule("cronSchedule")
+              .setMemo(
+                  new com.uber.cadence.Memo().setFields(ImmutableMap.of("memo", utf8("memoValue"))))
+              .setSearchAttributes(
+                  new com.uber.cadence.SearchAttributes()
+                      .setIndexedFields(ImmutableMap.of("search", utf8("searchValue"))))
+              .setHeader(
+                  new com.uber.cadence.Header().setFields(ImmutableMap.of("key", utf8("value"))))
+              .setDelayStartSeconds(3);
+  private static final com.uber.cadence.api.v1.StartWorkflowExecutionRequest
+      PROTO_START_WORKFLOW_EXECUTION =
+          StartWorkflowExecutionRequest.newBuilder()
+              .setDomain("domain")
+              .setWorkflowId("workflowId")
+              .setWorkflowType(WorkflowType.newBuilder().setName("workflowType"))
+              .setTaskList(
+                  TaskList.newBuilder()
+                      .setName("taskList")
+                      .setKind(TaskListKind.TASK_LIST_KIND_NORMAL))
+              .setInput(protoPayload("input"))
+              .setExecutionStartToCloseTimeout(seconds(1))
+              .setTaskStartToCloseTimeout(seconds(2))
+              .setIdentity("identity")
+              .setRequestId("requestId")
+              .setWorkflowIdReusePolicy(
+                  WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE)
+              .setRetryPolicy(
+                  RetryPolicy.newBuilder()
+                      .setInitialInterval(seconds(11))
+                      .setBackoffCoefficient(0.5)
+                      .setMaximumInterval(seconds(12))
+                      .setMaximumAttempts(13)
+                      .addNonRetryableErrorReasons("error")
+                      .setExpirationInterval(seconds(14)))
+              .setCronSchedule("cronSchedule")
+              .setMemo(Memo.newBuilder().putFields("memo", protoPayload("memoValue")).build())
+              .setSearchAttributes(
+                  SearchAttributes.newBuilder()
+                      .putIndexedFields("search", protoPayload("searchValue"))
+                      .build())
+              .setHeader(Header.newBuilder().putFields("key", protoPayload("value")).build())
+              .setDelayStart(seconds(3))
+              .build();
+
+  @Test
+  public void testStartWorkflowExecutionRequest() {
+    // Pulling in new IDL will intentionally cause this to fail. Either update the mapper or account
+    // for it here
+    assertMissingFields(
+        THRIFT_START_WORKFLOW_EXECUTION,
+        com.uber.cadence.StartWorkflowExecutionRequest._Fields.class,
+        "jitterStartSeconds");
+
+    assertEquals(
+        PROTO_START_WORKFLOW_EXECUTION,
+        RequestMapper.startWorkflowExecutionRequest(THRIFT_START_WORKFLOW_EXECUTION));
+  }
+
+  @Test
+  public void testStartWorkflowExecutionAsyncRequest() {
+    com.uber.cadence.StartWorkflowExecutionAsyncRequest thrift =
+        new com.uber.cadence.StartWorkflowExecutionAsyncRequest()
+            .setRequest(THRIFT_START_WORKFLOW_EXECUTION);
+
+    com.uber.cadence.api.v1.StartWorkflowExecutionAsyncRequest expected =
+        StartWorkflowExecutionAsyncRequest.newBuilder()
+            .setRequest(PROTO_START_WORKFLOW_EXECUTION)
+            .build();
+
+    assertNoMissingFields(
+        thrift, com.uber.cadence.StartWorkflowExecutionAsyncRequest._Fields.class);
+
+    assertEquals(expected, RequestMapper.startWorkflowExecutionAsyncRequest(thrift));
+  }
+
+  private static Duration seconds(int value) {
+    return Duration.newBuilder().setSeconds(value).build();
+  }
+
+  private static Payload protoPayload(String value) {
+    return Payload.newBuilder().setData(ByteString.copyFromUtf8(value)).build();
+  }
+
+  private static ByteBuffer utf8(String value) {
+    return ByteBuffer.wrap(utf8Bytes(value));
+  }
+
+  private static byte[] utf8Bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapperTest.java
@@ -17,8 +17,14 @@
 
 package com.uber.cadence.internal.compatibility.thrift;
 
+import static com.uber.cadence.internal.compatibility.MapperTestUtil.assertNoMissingFields;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.uber.cadence.api.v1.DescribeDomainResponse;
 import com.uber.cadence.api.v1.Domain;
+import com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.api.v1.StartWorkflowExecutionResponse;
 import com.uber.cadence.api.v1.UpdateDomainResponse;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,5 +51,33 @@ public class ResponseMapperTest {
 
     Assert.assertNotNull(response.configuration);
     Assert.assertNotNull(response.replicationConfiguration);
+  }
+
+  @Test
+  public void testStartWorkflowExecutionResponse() {
+    com.uber.cadence.api.v1.StartWorkflowExecutionResponse startWorkflowExecutionResponse =
+        StartWorkflowExecutionResponse.newBuilder().setRunId("runId").build();
+
+    com.uber.cadence.StartWorkflowExecutionResponse response =
+        ResponseMapper.startWorkflowExecutionResponse(startWorkflowExecutionResponse);
+
+    assertNoMissingFields(response, com.uber.cadence.StartWorkflowExecutionResponse._Fields.class);
+
+    assertEquals("runId", response.getRunId());
+  }
+
+  @Test
+  public void testStartWorkflowExecutionAsyncResponse() {
+    com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse startWorkflowExecutionResponse =
+        StartWorkflowExecutionAsyncResponse.newBuilder().build();
+
+    com.uber.cadence.StartWorkflowExecutionAsyncResponse response =
+        ResponseMapper.startWorkflowExecutionAsyncResponse(startWorkflowExecutionResponse);
+
+    assertNoMissingFields(
+        response, com.uber.cadence.StartWorkflowExecutionAsyncResponse._Fields.class);
+
+    // No fields to test
+    assertNotNull(response);
   }
 }

--- a/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
@@ -1,0 +1,95 @@
+package com.uber.cadence.internal.sync;
+
+import static org.junit.Assert.assertEquals;
+
+import com.uber.cadence.FakeWorkflowServiceRule;
+import com.uber.cadence.StartWorkflowExecutionAsyncRequest;
+import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.WorkflowService;
+import com.uber.cadence.WorkflowType;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.client.WorkflowOptions;
+import com.uber.cadence.client.WorkflowStub;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class WorkflowClientInternalTest {
+
+  @ClassRule public static FakeWorkflowServiceRule fakeService = new FakeWorkflowServiceRule();
+
+  private WorkflowClient client;
+
+  @Before
+  public void setup() throws Exception {
+    fakeService.resetStubs();
+    client =
+        WorkflowClient.newInstance(
+            fakeService.getClient(),
+            WorkflowClientOptions.newBuilder().setDomain("domain").build());
+  }
+
+  @Test
+  public void testEnqueueStart() throws Exception {
+    CompletableFuture<WorkflowService.StartWorkflowExecutionAsync_args> requestFuture =
+        fakeService.stubEndpoint(
+            "WorkflowService::StartWorkflowExecutionAsync",
+            WorkflowService.StartWorkflowExecutionAsync_args.class,
+            new WorkflowService.StartWorkflowExecutionAsync_result()
+                .setSuccess(new StartWorkflowExecutionAsyncResponse()));
+
+    WorkflowStub stub =
+        client.newUntypedWorkflowStub(
+            "type",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+    stub.enqueueStart("input");
+
+    StartWorkflowExecutionAsyncRequest request = requestFuture.getNow(null).getStartRequest();
+    assertEquals(new WorkflowType().setName("type"), request.getRequest().getWorkflowType());
+    assertEquals("workflowId", request.getRequest().getWorkflowId());
+    assertEquals(1, request.getRequest().getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, request.getRequest().getTaskStartToCloseTimeoutSeconds());
+    assertEquals("domain", request.getRequest().getDomain());
+    assertEquals("taskList", request.getRequest().getTaskList().getName());
+    assertEquals("\"input\"", StandardCharsets.UTF_8.decode(request.request.input).toString());
+  }
+
+  @Test
+  public void testEnqueueStartAsync() {
+    CompletableFuture<WorkflowService.StartWorkflowExecutionAsync_args> requestFuture =
+        fakeService.stubEndpoint(
+            "WorkflowService::StartWorkflowExecutionAsync",
+            WorkflowService.StartWorkflowExecutionAsync_args.class,
+            new WorkflowService.StartWorkflowExecutionAsync_result()
+                .setSuccess(new StartWorkflowExecutionAsyncResponse()));
+
+    WorkflowStub stub =
+        client.newUntypedWorkflowStub(
+            "type",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+    stub.enqueueStartAsync("input").join();
+
+    StartWorkflowExecutionAsyncRequest request = requestFuture.getNow(null).getStartRequest();
+    assertEquals(new WorkflowType().setName("type"), request.getRequest().getWorkflowType());
+    assertEquals("workflowId", request.getRequest().getWorkflowId());
+    assertEquals(1, request.getRequest().getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, request.getRequest().getTaskStartToCloseTimeoutSeconds());
+    assertEquals("domain", request.getRequest().getDomain());
+    assertEquals("taskList", request.getRequest().getTaskList().getName());
+    assertEquals("\"input\"", StandardCharsets.UTF_8.decode(request.request.input).toString());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/sync/WorkflowStubImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/WorkflowStubImplTest.java
@@ -50,8 +50,9 @@ public class WorkflowStubImplTest {
                 .setTaskList("taskList")
                 .build());
 
-    stub.enqueueStart("input");
+    WorkflowExecution execution = stub.enqueueStart("input");
 
+    assertEquals(new WorkflowExecution().setWorkflowId("workflowId"), execution);
     assertEquals(new WorkflowExecution().setWorkflowId("workflowId"), stub.getExecution());
 
     ArgumentCaptor<StartWorkflowExecutionParameters> captor =
@@ -81,7 +82,7 @@ public class WorkflowStubImplTest {
                 .setTaskList("taskList")
                 .build());
 
-    stub.enqueueStart("input");
+    WorkflowExecution execution = stub.enqueueStart("input");
 
     ArgumentCaptor<StartWorkflowExecutionParameters> captor =
         ArgumentCaptor.forClass(StartWorkflowExecutionParameters.class);
@@ -89,6 +90,7 @@ public class WorkflowStubImplTest {
 
     StartWorkflowExecutionParameters params = captor.getValue();
     assertNotNull("workflowId", params.getWorkflowId());
+    assertEquals(execution.getWorkflowId(), params.getWorkflowId());
   }
 
   @Test

--- a/src/test/java/com/uber/cadence/internal/sync/WorkflowStubImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/WorkflowStubImplTest.java
@@ -1,0 +1,210 @@
+package com.uber.cadence.internal.sync;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.uber.cadence.QueryWorkflowResponse;
+import com.uber.cadence.WorkflowExecution;
+import com.uber.cadence.WorkflowType;
+import com.uber.cadence.client.DuplicateWorkflowException;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.client.WorkflowOptions;
+import com.uber.cadence.internal.common.StartWorkflowExecutionParameters;
+import com.uber.cadence.internal.external.GenericWorkflowClientExternal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class WorkflowStubImplTest {
+  private static final WorkflowClientOptions CLIENT_OPTIONS =
+      WorkflowClientOptions.newBuilder().setDomain("domain").build();
+  private GenericWorkflowClientExternal mockClient;
+
+  @Before
+  public void setup() {
+    mockClient = Mockito.mock(GenericWorkflowClientExternal.class);
+  }
+
+  @Test
+  public void testEnqueueStart() throws Exception {
+    WorkflowStubImpl stub =
+        new WorkflowStubImpl(
+            CLIENT_OPTIONS,
+            mockClient,
+            "workflowType",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+
+    stub.enqueueStart("input");
+
+    assertEquals(new WorkflowExecution().setWorkflowId("workflowId"), stub.getExecution());
+
+    ArgumentCaptor<StartWorkflowExecutionParameters> captor =
+        ArgumentCaptor.forClass(StartWorkflowExecutionParameters.class);
+    verify(mockClient).enqueueStartWorkflow(captor.capture());
+
+    StartWorkflowExecutionParameters params = captor.getValue();
+    assertEquals(new WorkflowType().setName("workflowType"), params.getWorkflowType());
+    assertEquals("workflowId", params.getWorkflowId());
+    assertEquals(1, params.getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, params.getTaskStartToCloseTimeoutSeconds());
+    assertEquals("taskList", params.getTaskList());
+    assertEquals(
+        "\"input\"", StandardCharsets.UTF_8.decode(ByteBuffer.wrap(params.getInput())).toString());
+  }
+
+  @Test
+  public void testEnqueueStart_generatesWorkflowId() throws Exception {
+    WorkflowStubImpl stub =
+        new WorkflowStubImpl(
+            CLIENT_OPTIONS,
+            mockClient,
+            "workflowType",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setTaskList("taskList")
+                .build());
+
+    stub.enqueueStart("input");
+
+    ArgumentCaptor<StartWorkflowExecutionParameters> captor =
+        ArgumentCaptor.forClass(StartWorkflowExecutionParameters.class);
+    verify(mockClient).enqueueStartWorkflow(captor.capture());
+
+    StartWorkflowExecutionParameters params = captor.getValue();
+    assertNotNull("workflowId", params.getWorkflowId());
+  }
+
+  @Test
+  public void testEnqueueStart_thenQuery() {
+    WorkflowStubImpl stub =
+        new WorkflowStubImpl(
+            CLIENT_OPTIONS,
+            mockClient,
+            "workflowType",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setTaskList("taskList")
+                .setWorkflowId("workflowId")
+                .build());
+
+    when(mockClient.queryWorkflow(any()))
+        .thenReturn(
+            new QueryWorkflowResponse().setQueryResult("\"res\"".getBytes(StandardCharsets.UTF_8)));
+
+    stub.enqueueStart("input");
+    String result = stub.query("fakeQuery", String.class);
+
+    assertEquals("res", result);
+  }
+
+  @Test(expected = DuplicateWorkflowException.class)
+  public void testEnqueueStart_twice() {
+    WorkflowStubImpl stub =
+        new WorkflowStubImpl(
+            CLIENT_OPTIONS,
+            mockClient,
+            "workflowType",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setTaskList("taskList")
+                .build());
+
+    stub.enqueueStart("input");
+    stub.enqueueStart("again");
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testEnqueueStart_stubForExistingWorkflow() {
+    WorkflowStubImpl stub =
+        new WorkflowStubImpl(
+            CLIENT_OPTIONS,
+            mockClient,
+            Optional.of("workflowType"),
+            new WorkflowExecution().setWorkflowId("foo"));
+
+    stub.enqueueStart("input");
+  }
+
+  @Test
+  public void testEnqueueStartAsync() {
+    when(mockClient.enqueueStartWorkflowAsync(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    WorkflowStubImpl stub =
+        new WorkflowStubImpl(
+            CLIENT_OPTIONS,
+            mockClient,
+            "workflowType",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setTaskList("taskList")
+                .setWorkflowId("workflowId")
+                .build());
+
+    stub.enqueueStartAsync("input");
+
+    ArgumentCaptor<StartWorkflowExecutionParameters> captor =
+        ArgumentCaptor.forClass(StartWorkflowExecutionParameters.class);
+    verify(mockClient).enqueueStartWorkflowAsync(captor.capture(), eq(Long.MAX_VALUE));
+
+    StartWorkflowExecutionParameters params = captor.getValue();
+    assertEquals(new WorkflowType().setName("workflowType"), params.getWorkflowType());
+    assertEquals("workflowId", params.getWorkflowId());
+    assertEquals(1, params.getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, params.getTaskStartToCloseTimeoutSeconds());
+    assertEquals("taskList", params.getTaskList());
+    assertEquals(
+        "\"input\"", StandardCharsets.UTF_8.decode(ByteBuffer.wrap(params.getInput())).toString());
+  }
+
+  @Test
+  public void testEnqueueStartAsyncWithTimeout() {
+    when(mockClient.enqueueStartWorkflowAsync(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    WorkflowStubImpl stub =
+        new WorkflowStubImpl(
+            CLIENT_OPTIONS,
+            mockClient,
+            "workflowType",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setTaskList("taskList")
+                .setWorkflowId("workflowId")
+                .build());
+
+    stub.enqueueStartAsyncWithTimeout(123, TimeUnit.MILLISECONDS, "input");
+
+    ArgumentCaptor<StartWorkflowExecutionParameters> captor =
+        ArgumentCaptor.forClass(StartWorkflowExecutionParameters.class);
+    verify(mockClient).enqueueStartWorkflowAsync(captor.capture(), eq(123L));
+
+    StartWorkflowExecutionParameters params = captor.getValue();
+    assertEquals(new WorkflowType().setName("workflowType"), params.getWorkflowType());
+    assertEquals("workflowId", params.getWorkflowId());
+    assertEquals(1, params.getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, params.getTaskStartToCloseTimeoutSeconds());
+    assertEquals("taskList", params.getTaskList());
+    assertEquals(
+        "\"input\"", StandardCharsets.UTF_8.decode(ByteBuffer.wrap(params.getInput())).toString());
+  }
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add WorkflowStub#enqueueStart which uses the new StartWorkflowExecutionAsync to submit a workflow to be started at some point in the future.

Currently nearly all testing of the Cadence Java client is implemented as integration tests in WorkflowTests, running against either a locally running Cadence service or using the test environment. While this approach would be technically possible to configure (adding zookeeper and kafka to the docker-compose files), this would require reimplementing the integration tests already present on the Cadence server for all new features added. This approach doesn't scale well for adding new functionality to each client.

Instead, we add tests for this functionality via targeted unit tests at the different layers of the client. Add WorkflowClientInternalTest to use an in-memory fake server with stubbed responses to assert that we make exactly the correct request. This tests the entire Tchannel networking stack of the client end to end. Add WorkflowStubImplTest to test the specific semantics and state of the WorkflowStubImpl. State is particularly important with WorkflowStubs as they're intended to represent a single execution of a Workflow, so they normally capture the Workflow runId when starting a workflow. For StartWorkflowExecutionAsync we capture only the workflowId so that a stub can be used to enqueueStart(), then later qury or signal that workflow.

Additionally add tests for the thrift2proto mappers, including the MapperTestUtil assertions to ensure that all fields are present. This ensures that any update to the IDL files requires a corresponding change to either the test or mapper to account for the new field.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Adding support for new Cadence features to the Java client

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests
- Running WorkflowTest against locally running cadence instead with async workflows enabled

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
