### PR TITLE
Add statically-typed support for enqueueStart

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowClient.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClient.java
@@ -470,6 +470,299 @@ public interface WorkflowClient {
   }
 
   /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static WorkflowExecution enqueueStart(Functions.Proc workflow) {
+    return WorkflowClientInternal.enqueueStart(workflow);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow argument
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1> WorkflowExecution enqueueStart(Functions.Proc1<A1> workflow, A1 arg1) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2> WorkflowExecution enqueueStart(
+      Functions.Proc2<A1, A2> workflow, A1 arg1, A2 arg2) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3> WorkflowExecution enqueueStart(
+      Functions.Proc3<A1, A2, A3> workflow, A1 arg1, A2 arg2, A3 arg3) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @param arg3 third workflow function parameter
+   * @param arg4 fourth workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3, A4> WorkflowExecution enqueueStart(
+      Functions.Proc4<A1, A2, A3, A4> workflow, A1 arg1, A2 arg2, A3 arg3, A4 arg4) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3, arg4);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @param arg3 third workflow function parameter
+   * @param arg4 fourth workflow function parameter
+   * @param arg5 fifth workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3, A4, A5> WorkflowExecution enqueueStart(
+      Functions.Proc5<A1, A2, A3, A4, A5> workflow, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3, arg4, arg5);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @param arg3 third workflow function parameter
+   * @param arg4 fourth workflow function parameter
+   * @param arg5 sixth workflow function parameter
+   * @param arg6 sixth workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3, A4, A5, A6> WorkflowExecution enqueueStart(
+      Functions.Proc6<A1, A2, A3, A4, A5, A6> workflow,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3, arg4, arg5, arg6);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <R> WorkflowExecution enqueueStart(Functions.Func<R> workflow) {
+    return WorkflowClientInternal.enqueueStart(workflow);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, R> WorkflowExecution enqueueStart(Functions.Func1<A1, R> workflow, A1 arg1) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, R> WorkflowExecution enqueueStart(
+      Functions.Func2<A1, A2, R> workflow, A1 arg1, A2 arg2) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @param arg3 third workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3, R> WorkflowExecution enqueueStart(
+      Functions.Func3<A1, A2, A3, R> workflow, A1 arg1, A2 arg2, A3 arg3) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @param arg3 third workflow function parameter
+   * @param arg4 fourth workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3, A4, R> WorkflowExecution enqueueStart(
+      Functions.Func4<A1, A2, A3, A4, R> workflow, A1 arg1, A2 arg2, A3 arg3, A4 arg4) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3, arg4);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @param arg3 third workflow function parameter
+   * @param arg4 fourth workflow function parameter
+   * @param arg5 fifth workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3, A4, A5, R> WorkflowExecution enqueueStart(
+      Functions.Func5<A1, A2, A3, A4, A5, R> workflow,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3, arg4, arg5);
+  }
+
+  /**
+   * Schedules a workflow to be started at a future date via StartWorkflowExecutionAsync. This
+   * requires that async execution has been enabled for this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param workflow The only supported value is method reference to a proxy created through {@link
+   *     #newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first workflow function parameter
+   * @param arg2 second workflow function parameter
+   * @param arg3 third workflow function parameter
+   * @param arg4 fourth workflow function parameter
+   * @param arg5 sixth workflow function parameter
+   * @param arg6 sixth workflow function parameter
+   * @return WorkflowExecution containing only the workflowId
+   */
+  static <A1, A2, A3, A4, A5, A6, R> WorkflowExecution enqueueStart(
+      Functions.Func6<A1, A2, A3, A4, A5, A6, R> workflow,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6) {
+    return WorkflowClientInternal.enqueueStart(workflow, arg1, arg2, arg3, arg4, arg5, arg6);
+  }
+
+  /**
    * Executes zero argument workflow with void return type
    *
    * @param workflow The only supported value is method reference to a proxy created through {@link

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -311,6 +311,98 @@ public final class WorkflowClientInternal implements WorkflowClient {
     return start(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
   }
 
+  public static WorkflowExecution enqueueStart(Functions.Proc workflow) {
+    WorkflowInvocationHandler.initAsyncInvocation(InvocationType.ENQUEUE_START);
+    try {
+      workflow.apply();
+      return WorkflowInvocationHandler.getAsyncInvocationResult(WorkflowExecution.class);
+    } finally {
+      WorkflowInvocationHandler.closeAsyncInvocation();
+    }
+  }
+
+  public static <A1> WorkflowExecution enqueueStart(Functions.Proc1<A1> workflow, A1 arg1) {
+    return enqueueStart(() -> workflow.apply(arg1));
+  }
+
+  public static <A1, A2> WorkflowExecution enqueueStart(
+      Functions.Proc2<A1, A2> workflow, A1 arg1, A2 arg2) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2));
+  }
+
+  public static <A1, A2, A3> WorkflowExecution enqueueStart(
+      Functions.Proc3<A1, A2, A3> workflow, A1 arg1, A2 arg2, A3 arg3) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3));
+  }
+
+  public static <A1, A2, A3, A4> WorkflowExecution enqueueStart(
+      Functions.Proc4<A1, A2, A3, A4> workflow, A1 arg1, A2 arg2, A3 arg3, A4 arg4) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3, arg4));
+  }
+
+  public static <A1, A2, A3, A4, A5> WorkflowExecution enqueueStart(
+      Functions.Proc5<A1, A2, A3, A4, A5> workflow, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5));
+  }
+
+  public static <A1, A2, A3, A4, A5, A6> WorkflowExecution enqueueStart(
+      Functions.Proc6<A1, A2, A3, A4, A5, A6> workflow,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
+  }
+
+  public static <R> WorkflowExecution enqueueStart(Functions.Func<R> workflow) {
+    return enqueueStart(
+        () -> {
+          workflow.apply();
+        });
+  }
+
+  public static <A1, R> WorkflowExecution enqueueStart(Functions.Func1<A1, R> workflow, A1 arg1) {
+    return enqueueStart(() -> workflow.apply(arg1));
+  }
+
+  public static <A1, A2, R> WorkflowExecution enqueueStart(
+      Functions.Func2<A1, A2, R> workflow, A1 arg1, A2 arg2) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2));
+  }
+
+  public static <A1, A2, A3, R> WorkflowExecution enqueueStart(
+      Functions.Func3<A1, A2, A3, R> workflow, A1 arg1, A2 arg2, A3 arg3) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3));
+  }
+
+  public static <A1, A2, A3, A4, R> WorkflowExecution enqueueStart(
+      Functions.Func4<A1, A2, A3, A4, R> workflow, A1 arg1, A2 arg2, A3 arg3, A4 arg4) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3, arg4));
+  }
+
+  public static <A1, A2, A3, A4, A5, R> WorkflowExecution enqueueStart(
+      Functions.Func5<A1, A2, A3, A4, A5, R> workflow,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5));
+  }
+
+  public static <A1, A2, A3, A4, A5, A6, R> WorkflowExecution enqueueStart(
+      Functions.Func6<A1, A2, A3, A4, A5, A6, R> workflow,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6) {
+    return enqueueStart(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
+  }
+
   @SuppressWarnings("unchecked")
   public static CompletableFuture<Void> execute(Functions.Proc workflow) {
     WorkflowInvocationHandler.initAsyncInvocation(InvocationType.EXECUTE);

--- a/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
@@ -5,12 +5,14 @@ import static org.junit.Assert.assertEquals;
 import com.uber.cadence.FakeWorkflowServiceRule;
 import com.uber.cadence.StartWorkflowExecutionAsyncRequest;
 import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowService;
 import com.uber.cadence.WorkflowType;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.client.WorkflowStub;
+import com.uber.cadence.workflow.WorkflowMethod;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +57,48 @@ public class WorkflowClientInternalTest {
 
     StartWorkflowExecutionAsyncRequest request = requestFuture.getNow(null).getStartRequest();
     assertEquals(new WorkflowType().setName("type"), request.getRequest().getWorkflowType());
+    assertEquals("workflowId", request.getRequest().getWorkflowId());
+    assertEquals(1, request.getRequest().getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, request.getRequest().getTaskStartToCloseTimeoutSeconds());
+    assertEquals("domain", request.getRequest().getDomain());
+    assertEquals("taskList", request.getRequest().getTaskList().getName());
+    assertEquals("\"input\"", StandardCharsets.UTF_8.decode(request.request.input).toString());
+  }
+
+  interface TestWorkflow {
+    @WorkflowMethod(
+      taskList = "taskList",
+      executionStartToCloseTimeoutSeconds = 1,
+      taskStartToCloseTimeoutSeconds = 2
+    )
+    void test(String input);
+  }
+
+  @Test
+  public void testEnqueueStart_stronglyTyped() throws Exception {
+    CompletableFuture<WorkflowService.StartWorkflowExecutionAsync_args> requestFuture =
+        fakeService.stubEndpoint(
+            "WorkflowService::StartWorkflowExecutionAsync",
+            WorkflowService.StartWorkflowExecutionAsync_args.class,
+            new WorkflowService.StartWorkflowExecutionAsync_result()
+                .setSuccess(new StartWorkflowExecutionAsyncResponse()));
+
+    TestWorkflow stub =
+        client.newWorkflowStub(
+            TestWorkflow.class,
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+
+    WorkflowExecution execution = WorkflowClient.enqueueStart(stub::test, "input");
+
+    assertEquals(new WorkflowExecution().setWorkflowId("workflowId"), execution);
+    StartWorkflowExecutionAsyncRequest request = requestFuture.getNow(null).getStartRequest();
+    assertEquals(
+        new WorkflowType().setName("TestWorkflow::test"), request.getRequest().getWorkflowType());
     assertEquals("workflowId", request.getRequest().getWorkflowId());
     assertEquals(1, request.getRequest().getExecutionStartToCloseTimeoutSeconds());
     assertEquals(2, request.getRequest().getTaskStartToCloseTimeoutSeconds());


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
The preferred mechanism for interacting with workflows is via the statically typed interface so that parameter types can be checked at compile time. Add the 14 required overloads of WorkflowClient#enqueueStart to mirror WorkflowClient#start, and implement support for it in WorkflowInvocationHandler.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Finishes adding support for StartWorkflowExecutionAsync

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
