### PR TITLE
Add support for SignalWithStartWorkflowExecutionAsync

### DIFF
--- a/src/main/java/com/uber/cadence/client/WorkflowClient.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClient.java
@@ -227,7 +227,8 @@ public interface WorkflowClient {
    * running. The batch before invocation must contain exactly two operations. One annotated
    * with @WorkflowMethod and another with @SignalMethod.
    *
-   * @return batch request used to call {@link #signalWithStart(BatchRequest)}
+   * @return batch request used to call {@link #signalWithStart(BatchRequest)} or {@link
+   *     #enqueueSignalWithStart(BatchRequest)}
    */
   BatchRequest newSignalWithStartRequest();
 
@@ -238,6 +239,20 @@ public interface WorkflowClient {
    * @return workflowID and runId of the signaled or started workflow.
    */
   WorkflowExecution signalWithStart(BatchRequest signalWithStartBatch);
+
+  /**
+   * Schedules a SignalWithStart operation to be performed at a future date via
+   * SignalWithStartWorkflowExecutionAsync. This requires that async execution has been enabled for
+   * this domain.
+   *
+   * <p>Note that the returned WorkflowExecution will <b>NOT</b> contain a {@code runId}, only a
+   * {@code workflowId}. This is because the {@code runId} is only determined at the time the
+   * workflow actually starts.
+   *
+   * @param signalWithStartBatch Must be created with {@link #newSignalWithStartRequest()}
+   * @return WorkflowExecution containing only the workflowId
+   */
+  WorkflowExecution enqueueSignalWithStart(BatchRequest signalWithStartBatch);
 
   /**
    * Refreshes all the tasks of a given workflow.

--- a/src/main/java/com/uber/cadence/client/WorkflowStub.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowStub.java
@@ -85,6 +85,9 @@ public interface WorkflowStub {
 
   WorkflowExecution signalWithStart(String signalName, Object[] signalArgs, Object[] startArgs);
 
+  WorkflowExecution enqueueSignalWithStart(
+      String signalName, Object[] signalArgs, Object[] startArgs);
+
   Optional<String> getWorkflowType();
 
   WorkflowExecution getExecution();

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
@@ -231,6 +231,30 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
                           .setStartRequest(
                               request.getStartRequest().toBuilder().setHeader(newHeader))
                           .build();
+            } else if (Objects.equals(
+                    method.getBareMethodName(), "SignalWithStartWorkflowExecutionAsync")
+                && message instanceof SignalWithStartWorkflowExecutionAsyncRequest) {
+              SignalWithStartWorkflowExecutionAsyncRequest request =
+                  (SignalWithStartWorkflowExecutionAsyncRequest) message;
+              Header newHeader =
+                  addTracingHeaders(request.getRequest().getStartRequest().getHeader());
+
+              // cast should not throw error as we are using the builder
+              message =
+                  (ReqT)
+                      request
+                          .toBuilder()
+                          .setRequest(
+                              request
+                                  .getRequest()
+                                  .toBuilder()
+                                  .setStartRequest(
+                                      request
+                                          .getRequest()
+                                          .getStartRequest()
+                                          .toBuilder()
+                                          .setHeader(newHeader)))
+                          .build();
             }
             super.sendMessage(message);
           }

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternal.java
@@ -56,6 +56,9 @@ public interface GenericWorkflowClientExternal {
   WorkflowExecution signalWithStartWorkflowExecution(
       SignalWithStartWorkflowExecutionParameters parameters);
 
+  WorkflowExecution enqueueSignalWithStartWorkflowExecution(
+      SignalWithStartWorkflowExecutionParameters parameters);
+
   void requestCancelWorkflowExecution(WorkflowExecution execution);
 
   QueryWorkflowResponse queryWorkflow(QueryWorkflowParameters queryParameters);

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsType.java
@@ -43,6 +43,8 @@ public class MetricsType {
       CADENCE_METRICS_PREFIX + "workflow-get-history-latency";
   public static final String WORKFLOW_SIGNAL_WITH_START_COUNTER =
       CADENCE_METRICS_PREFIX + "workflow-signal-with-start";
+  public static final String WORKFLOW_SIGNAL_WITH_START_ASYNC_COUNTER =
+      CADENCE_METRICS_PREFIX + "workflow-signal-with-start-async";
 
   public static final String DECISION_POLL_COUNTER = CADENCE_METRICS_PREFIX + "decision-poll-total";
   public static final String DECISION_POLL_FAILED_COUNTER =

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -1013,6 +1013,12 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
       }
 
       @Override
+      public WorkflowExecution enqueueSignalWithStart(
+          String signalName, Object[] signalArgs, Object[] startArgs) {
+        return next.enqueueSignalWithStart(signalName, signalArgs, startArgs);
+      }
+
+      @Override
       public Optional<String> getWorkflowType() {
         return next.getWorkflowType();
       }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -210,7 +210,12 @@ public final class WorkflowClientInternal implements WorkflowClient {
 
   @Override
   public WorkflowExecution signalWithStart(BatchRequest signalWithStartBatch) {
-    return ((SignalWithStartBatchRequest) signalWithStartBatch).invoke();
+    return ((SignalWithStartBatchRequest) signalWithStartBatch).execute();
+  }
+
+  @Override
+  public WorkflowExecution enqueueSignalWithStart(BatchRequest signalWithStartBatch) {
+    return ((SignalWithStartBatchRequest) signalWithStartBatch).enqueue();
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowStubImpl.java
@@ -324,6 +324,31 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   @Override
+  public WorkflowExecution enqueueSignalWithStart(
+      String signalName, Object[] signalArgs, Object[] startArgs) {
+    if (!options.isPresent()) {
+      throw new IllegalStateException("Required parameter WorkflowOptions is missing");
+    }
+    return enqueueSignalWithStart(
+        WorkflowOptions.merge(null, null, null, options.get()), signalName, signalArgs, startArgs);
+  }
+
+  private WorkflowExecution enqueueSignalWithStart(
+      WorkflowOptions options, String signalName, Object[] signalArgs, Object[] startArgs) {
+    StartWorkflowExecutionParameters sp = getStartWorkflowExecutionParameters(options, startArgs);
+
+    byte[] signalInput = dataConverter.toData(signalArgs);
+    SignalWithStartWorkflowExecutionParameters p =
+        new SignalWithStartWorkflowExecutionParameters(sp, signalName, signalInput);
+    try {
+      execution.set(genericClient.enqueueSignalWithStartWorkflowExecution(p));
+    } catch (Exception e) {
+      throw new WorkflowServiceException(execution.get(), workflowType, e);
+    }
+    return execution.get();
+  }
+
+  @Override
   public Optional<String> getWorkflowType() {
     return workflowType;
   }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -602,7 +602,8 @@ public final class TestWorkflowService implements IWorkflowService {
       throws BadRequestError, WorkflowExecutionAlreadyStartedError, ServiceBusyError,
           DomainNotActiveError, LimitExceededError, EntityNotExistsError,
           ClientVersionNotSupportedError, TException {
-    throw new UnsupportedOperationException("not implemented");
+    SignalWithStartWorkflowExecution(signalWithStartRequest.getRequest());
+    return new SignalWithStartWorkflowExecutionAsyncResponse();
   }
 
   // TODO: https://github.com/uber/cadence-java-client/issues/359

--- a/src/test/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapterTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapterTest.java
@@ -1,0 +1,159 @@
+package com.uber.cadence.internal.compatibility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import com.uber.cadence.SignalWithStartWorkflowExecutionAsyncRequest;
+import com.uber.cadence.StartWorkflowExecutionAsyncRequest;
+import com.uber.cadence.api.v1.Header;
+import com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.api.v1.WorkflowAPIGrpc;
+import com.uber.cadence.internal.compatibility.proto.RequestMapper;
+import com.uber.cadence.internal.compatibility.proto.serviceclient.IGrpcServiceStubs;
+import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import java.util.function.BiConsumer;
+import org.apache.commons.io.Charsets;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class Thrift2ProtoAdapterTest {
+
+  @Rule public GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private final WorkflowAPIGrpc.WorkflowAPIImplBase mockApi =
+      Mockito.mock(WorkflowAPIGrpc.WorkflowAPIImplBase.class);
+  private final MockTracer tracer = new MockTracer();
+  private IWorkflowService client;
+
+  @Before
+  public void setup() throws Exception {
+    grpcCleanup.register(
+        InProcessServerBuilder.forName("test")
+            .directExecutor()
+            .addService(mockApi)
+            .build()
+            .start());
+    ManagedChannel channel =
+        grpcCleanup.register(InProcessChannelBuilder.forName("test").directExecutor().build());
+    client =
+        new Thrift2ProtoAdapter(
+            IGrpcServiceStubs.newInstance(
+                ClientOptions.newBuilder().setTracer(tracer).setGRPCChannel(channel).build()));
+  }
+
+  @Test
+  public void testStartWorkflowExecutionAsync() throws Exception {
+    ArgumentCaptor<com.uber.cadence.api.v1.StartWorkflowExecutionAsyncRequest> captor =
+        mockRpc(
+            mockApi::startWorkflowExecutionAsync,
+            StartWorkflowExecutionAsyncResponse.newBuilder().build());
+    com.uber.cadence.StartWorkflowExecutionAsyncRequest thriftRequest =
+        new StartWorkflowExecutionAsyncRequest()
+            .setRequest(
+                new com.uber.cadence.StartWorkflowExecutionRequest()
+                    .setDomain("domain")
+                    .setWorkflowId("workflowId")
+                    .setRequestId("requestId"));
+    com.uber.cadence.StartWorkflowExecutionAsyncResponse response =
+        client.StartWorkflowExecutionAsync(thriftRequest);
+
+    com.uber.cadence.api.v1.StartWorkflowExecutionAsyncRequest actual = captor.getValue();
+
+    assertTracingHeaders(actual.getRequest().getHeader());
+    // Clear header as it will have values injected into it, therefore not matching our input
+    actual =
+        actual
+            .toBuilder()
+            .setRequest(actual.getRequest().toBuilder().setHeader(Header.newBuilder()))
+            .build();
+
+    assertEquals(RequestMapper.startWorkflowExecutionAsyncRequest(thriftRequest), actual);
+    assertNotNull(response);
+  }
+
+  @Test
+  public void testSignalWithStartWorkflowExecutionAsync() throws Exception {
+    ArgumentCaptor<com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncRequest> captor =
+        mockRpc(
+            mockApi::signalWithStartWorkflowExecutionAsync,
+            SignalWithStartWorkflowExecutionAsyncResponse.newBuilder().build());
+    com.uber.cadence.SignalWithStartWorkflowExecutionAsyncRequest thriftRequest =
+        new SignalWithStartWorkflowExecutionAsyncRequest()
+            .setRequest(
+                new com.uber.cadence.SignalWithStartWorkflowExecutionRequest()
+                    .setDomain("domain")
+                    .setWorkflowId("workflowId")
+                    .setRequestId("requestId")
+                    .setSignalName("signal"));
+    com.uber.cadence.SignalWithStartWorkflowExecutionAsyncResponse response =
+        client.SignalWithStartWorkflowExecutionAsync(thriftRequest);
+
+    com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncRequest actual = captor.getValue();
+
+    assertTracingHeaders(actual.getRequest().getStartRequest().getHeader());
+    // Clear header as it will have values injected into it, therefore not matching our input
+    actual =
+        actual
+            .toBuilder()
+            .setRequest(
+                actual
+                    .getRequest()
+                    .toBuilder()
+                    .setStartRequest(
+                        actual
+                            .getRequest()
+                            .getStartRequest()
+                            .toBuilder()
+                            .setHeader(Header.newBuilder())))
+            .build();
+
+    assertEquals(RequestMapper.signalWithStartWorkflowExecutionAsyncRequest(thriftRequest), actual);
+    assertNotNull(response);
+  }
+
+  private void assertTracingHeaders(Header header) {
+    assertEquals(1, tracer.finishedSpans().size());
+    MockSpan mockSpan = tracer.finishedSpans().get(0);
+    assertEquals(
+        mockSpan.context().toTraceId(),
+        Charsets.UTF_8
+            .decode(header.getFieldsMap().get("traceid").getData().asReadOnlyByteBuffer())
+            .toString());
+    assertEquals(
+        mockSpan.context().toSpanId(),
+        Charsets.UTF_8
+            .decode(header.getFieldsMap().get("spanid").getData().asReadOnlyByteBuffer())
+            .toString());
+  }
+
+  private <REQ, RES> ArgumentCaptor<REQ> mockRpc(
+      BiConsumer<REQ, StreamObserver<RES>> method, RES value) {
+    ArgumentCaptor<REQ> captor = new ArgumentCaptor<>();
+    doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              StreamObserver<RES> resultObserver =
+                  (StreamObserver<RES>) invocation.getArguments()[1];
+              resultObserver.onNext(value);
+              resultObserver.onCompleted();
+              return null;
+            })
+        .when(mockApi);
+    method.accept(captor.capture(), any());
+    return captor;
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/thrift/ResponseMapperTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertNotNull;
 
 import com.uber.cadence.api.v1.DescribeDomainResponse;
 import com.uber.cadence.api.v1.Domain;
+import com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionResponse;
 import com.uber.cadence.api.v1.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.api.v1.StartWorkflowExecutionResponse;
 import com.uber.cadence.api.v1.UpdateDomainResponse;
@@ -76,6 +78,37 @@ public class ResponseMapperTest {
 
     assertNoMissingFields(
         response, com.uber.cadence.StartWorkflowExecutionAsyncResponse._Fields.class);
+
+    // No fields to test
+    assertNotNull(response);
+  }
+
+  @Test
+  public void testSignalWithStartWorkflowExecutionResponse() {
+    com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionResponse
+        startWorkflowExecutionResponse =
+            SignalWithStartWorkflowExecutionResponse.newBuilder().setRunId("runId").build();
+
+    com.uber.cadence.StartWorkflowExecutionResponse response =
+        ResponseMapper.signalWithStartWorkflowExecutionResponse(startWorkflowExecutionResponse);
+
+    assertNoMissingFields(response, com.uber.cadence.StartWorkflowExecutionResponse._Fields.class);
+
+    assertEquals("runId", response.getRunId());
+  }
+
+  @Test
+  public void testSignalWithStartWorkflowExecutionAsyncResponse() {
+    com.uber.cadence.api.v1.SignalWithStartWorkflowExecutionAsyncResponse
+        startWorkflowExecutionResponse =
+            SignalWithStartWorkflowExecutionAsyncResponse.newBuilder().build();
+
+    com.uber.cadence.SignalWithStartWorkflowExecutionAsyncResponse response =
+        ResponseMapper.signalWithStartWorkflowExecutionAsyncResponse(
+            startWorkflowExecutionResponse);
+
+    assertNoMissingFields(
+        response, com.uber.cadence.SignalWithStartWorkflowExecutionAsyncResponse._Fields.class);
 
     // No fields to test
     assertNotNull(response);

--- a/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
@@ -3,19 +3,26 @@ package com.uber.cadence.internal.sync;
 import static org.junit.Assert.assertEquals;
 
 import com.uber.cadence.FakeWorkflowServiceRule;
+import com.uber.cadence.SignalWithStartWorkflowExecutionAsyncResponse;
+import com.uber.cadence.SignalWithStartWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionAsyncRequest;
 import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowService;
 import com.uber.cadence.WorkflowType;
+import com.uber.cadence.client.BatchRequest;
 import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.client.WorkflowStub;
+import com.uber.cadence.workflow.SignalMethod;
 import com.uber.cadence.workflow.WorkflowMethod;
+import io.opentracing.mock.MockSpan;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.io.Charsets;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -63,6 +70,41 @@ public class WorkflowClientInternalTest {
     assertEquals("domain", request.getRequest().getDomain());
     assertEquals("taskList", request.getRequest().getTaskList().getName());
     assertEquals("\"input\"", StandardCharsets.UTF_8.decode(request.request.input).toString());
+  }
+
+  @Test
+  public void testEnqueueStart_includesTracing() {
+    CompletableFuture<WorkflowService.StartWorkflowExecutionAsync_args> requestFuture =
+        fakeService.stubEndpoint(
+            "WorkflowService::StartWorkflowExecutionAsync",
+            WorkflowService.StartWorkflowExecutionAsync_args.class,
+            new WorkflowService.StartWorkflowExecutionAsync_result()
+                .setSuccess(new StartWorkflowExecutionAsyncResponse()));
+
+    WorkflowStub stub =
+        client.newUntypedWorkflowStub(
+            "type",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+    stub.enqueueStart("input");
+
+    StartWorkflowExecutionAsyncRequest request = requestFuture.getNow(null).getStartRequest();
+    assertEquals(1, fakeService.getTracer().finishedSpans().size());
+    MockSpan mockSpan = fakeService.getTracer().finishedSpans().get(0);
+    assertEquals(
+        mockSpan.context().toTraceId(),
+        Charsets.UTF_8
+            .decode(request.getRequest().getHeader().getFields().get("traceid"))
+            .toString());
+    assertEquals(
+        mockSpan.context().toSpanId(),
+        Charsets.UTF_8
+            .decode(request.getRequest().getHeader().getFields().get("spanid"))
+            .toString());
   }
 
   interface TestWorkflow {
@@ -135,5 +177,134 @@ public class WorkflowClientInternalTest {
     assertEquals("domain", request.getRequest().getDomain());
     assertEquals("taskList", request.getRequest().getTaskList().getName());
     assertEquals("\"input\"", StandardCharsets.UTF_8.decode(request.request.input).toString());
+  }
+
+  @Test
+  public void testEnqueueSignalWithStart() {
+    CompletableFuture<WorkflowService.SignalWithStartWorkflowExecutionAsync_args> requestFuture =
+        fakeService.stubEndpoint(
+            "WorkflowService::SignalWithStartWorkflowExecutionAsync",
+            WorkflowService.SignalWithStartWorkflowExecutionAsync_args.class,
+            new WorkflowService.SignalWithStartWorkflowExecutionAsync_result()
+                .setSuccess(new SignalWithStartWorkflowExecutionAsyncResponse()));
+
+    WorkflowStub stub =
+        client.newUntypedWorkflowStub(
+            "type",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+    WorkflowExecution execution =
+        stub.enqueueSignalWithStart(
+            "signalName", new Object[] {"signalValue"}, new Object[] {"startValue"});
+
+    assertEquals(new WorkflowExecution().setWorkflowId("workflowId"), execution);
+
+    SignalWithStartWorkflowExecutionRequest request =
+        requestFuture.getNow(null).getSignalWithStartRequest().getRequest();
+    assertEquals(new WorkflowType().setName("type"), request.getWorkflowType());
+    assertEquals("workflowId", request.getWorkflowId());
+    assertEquals(1, request.getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, request.getTaskStartToCloseTimeoutSeconds());
+    assertEquals("domain", request.getDomain());
+    assertEquals("taskList", request.getTaskList().getName());
+    assertEquals(
+        "\"startValue\"",
+        StandardCharsets.UTF_8.decode(ByteBuffer.wrap(request.getInput())).toString());
+    assertEquals("signalName", request.getSignalName());
+    assertEquals(
+        "\"signalValue\"",
+        StandardCharsets.UTF_8.decode(ByteBuffer.wrap(request.getSignalInput())).toString());
+  }
+
+  @Test
+  public void testEnqueueSignalWithStart_includesTracing() {
+    CompletableFuture<WorkflowService.SignalWithStartWorkflowExecutionAsync_args> requestFuture =
+        fakeService.stubEndpoint(
+            "WorkflowService::SignalWithStartWorkflowExecutionAsync",
+            WorkflowService.SignalWithStartWorkflowExecutionAsync_args.class,
+            new WorkflowService.SignalWithStartWorkflowExecutionAsync_result()
+                .setSuccess(new SignalWithStartWorkflowExecutionAsyncResponse()));
+
+    WorkflowStub stub =
+        client.newUntypedWorkflowStub(
+            "type",
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+    stub.enqueueSignalWithStart(
+        "signalName", new Object[] {"signalValue"}, new Object[] {"startValue"});
+
+    SignalWithStartWorkflowExecutionRequest request =
+        requestFuture.getNow(null).getSignalWithStartRequest().getRequest();
+    assertEquals(1, fakeService.getTracer().finishedSpans().size());
+    MockSpan mockSpan = fakeService.getTracer().finishedSpans().get(0);
+    assertEquals(
+        mockSpan.context().toTraceId(),
+        Charsets.UTF_8.decode(request.getHeader().getFields().get("traceid")).toString());
+    assertEquals(
+        mockSpan.context().toSpanId(),
+        Charsets.UTF_8.decode(request.getHeader().getFields().get("spanid")).toString());
+  }
+
+  interface TestSignalWorkflow {
+    @WorkflowMethod(
+      taskList = "taskList",
+      executionStartToCloseTimeoutSeconds = 1,
+      taskStartToCloseTimeoutSeconds = 2
+    )
+    void test(String input);
+
+    @SignalMethod
+    void signal(String input);
+  }
+
+  @Test
+  public void testEnqueueSignalWithStart_stronglyTyped() {
+    CompletableFuture<WorkflowService.SignalWithStartWorkflowExecutionAsync_args> requestFuture =
+        fakeService.stubEndpoint(
+            "WorkflowService::SignalWithStartWorkflowExecutionAsync",
+            WorkflowService.SignalWithStartWorkflowExecutionAsync_args.class,
+            new WorkflowService.SignalWithStartWorkflowExecutionAsync_result()
+                .setSuccess(new SignalWithStartWorkflowExecutionAsyncResponse()));
+
+    TestSignalWorkflow stub =
+        client.newWorkflowStub(
+            TestSignalWorkflow.class,
+            new WorkflowOptions.Builder()
+                .setExecutionStartToCloseTimeout(Duration.ofSeconds(1))
+                .setTaskStartToCloseTimeout(Duration.ofSeconds(2))
+                .setWorkflowId("workflowId")
+                .setTaskList("taskList")
+                .build());
+
+    BatchRequest batch = client.newSignalWithStartRequest();
+    batch.add(stub::test, "startValue");
+    batch.add(stub::signal, "signalValue");
+    WorkflowExecution execution = client.enqueueSignalWithStart(batch);
+
+    assertEquals(new WorkflowExecution().setWorkflowId("workflowId"), execution);
+
+    SignalWithStartWorkflowExecutionRequest request =
+        requestFuture.getNow(null).getSignalWithStartRequest().getRequest();
+    assertEquals(new WorkflowType().setName("TestSignalWorkflow::test"), request.getWorkflowType());
+    assertEquals("workflowId", request.getWorkflowId());
+    assertEquals(1, request.getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(2, request.getTaskStartToCloseTimeoutSeconds());
+    assertEquals("domain", request.getDomain());
+    assertEquals("taskList", request.getTaskList().getName());
+    assertEquals(
+        "\"startValue\"",
+        StandardCharsets.UTF_8.decode(ByteBuffer.wrap(request.getInput())).toString());
+    assertEquals("TestSignalWorkflow::signal", request.getSignalName());
+    assertEquals(
+        "\"signalValue\"",
+        StandardCharsets.UTF_8.decode(ByteBuffer.wrap(request.getSignalInput())).toString());
   }
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add support to schedule a SignalWithStartWorkflowExecution operation to be performed at a future date via SignalWithStartWorkflowExecutionAsync. This is exposed in the java client in two ways:
- WorkflowStub#enqueueSignalWithStart, which presents an untyped interface.
- WorkflowClient#enqueueSignalWithStart, with presents a statically typed interface.

The existing mechanisms for SignalWithStart don't currently have an async equivalent so we don't introduce one here.

Additionally add full test coverage for tracing information being injected into headers both in GRPC and TChannel.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Adding support for new functionality to the Java client.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
