### PR TITLE
Bug Fix for null pointer exception in case header getFields is null in workflow context replay

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
+}

--- a/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
@@ -156,7 +156,7 @@ final class WorkflowContext {
       return new HashMap<>();
     }
 
-    Map<String, Field> fields = headers.getFields();
+    Map<String, ByteBuffer> fields = headers.getFields();
     if (fields == null) {
       return new HashMap<>();
     }

--- a/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
@@ -162,9 +162,10 @@ final class WorkflowContext {
     }
 
     Map<String, byte[]> headerData = new HashMap<>();
-    fields.forEach((k, v) -> {
-      headerData.put(k, org.apache.thrift.TBaseHelper.byteBufferToByteArray(v));
-    });
+    fields.forEach(
+        (k, v) -> {
+          headerData.put(k, org.apache.thrift.TBaseHelper.byteBufferToByteArray(v));
+        });
 
     Map<String, Object> contextData = new HashMap<>();
     for (ContextPropagator propagator : contextPropagators) {

--- a/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/WorkflowContext.java
@@ -156,13 +156,15 @@ final class WorkflowContext {
       return new HashMap<>();
     }
 
+    Map<String, Field> fields = headers.getFields();
+    if (fields == null) {
+      return new HashMap<>();
+    }
+
     Map<String, byte[]> headerData = new HashMap<>();
-    headers
-        .getFields()
-        .forEach(
-            (k, v) -> {
-              headerData.put(k, org.apache.thrift.TBaseHelper.byteBufferToByteArray(v));
-            });
+    fields.forEach((k, v) -> {
+      headerData.put(k, org.apache.thrift.TBaseHelper.byteBufferToByteArray(v));
+    });
 
     Map<String, Object> contextData = new HashMap<>();
     for (ContextPropagator propagator : contextPropagators) {


### PR DESCRIPTION
What changed?
Added a fix for the case when headers's getFields is null while checking for workflowcontext in replay.
Causing null pointer in the code.

Why?
Bug fix

How did you test it?
Need to add test for it. will discuss with the team, now adding this to fix bug and unblock customer.

Potential risks
It should be a safe change, as it is returning empty map in case of empty getFields.

Release notes

Documentation Changes