### PR TITLE
Adding Nate as co-owner of Java client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-* @Groxx @abhishekj720 @dkrotx @taylanisikdemir @demirkayaender
+* @Groxx @abhishekj720 @natemort @dkrotx @taylanisikdemir @demirkayaender


### PR DESCRIPTION
What changed?
Adding note as coowner for the java client.

Why?
Having one more java expert in the team is helpful.