### PR TITLE
Refactor ActivityTaskExecutor to use ActivityTask interface

### DIFF
--- a/src/main/java/com/uber/cadence/activity/ActivityTask.java
+++ b/src/main/java/com/uber/cadence/activity/ActivityTask.java
@@ -65,4 +65,5 @@ public interface ActivityTask {
   String getWorkflowDomain();
 
   int getAttempt();
+  byte[] getInput();
 }

--- a/src/main/java/com/uber/cadence/activity/ActivityTask.java
+++ b/src/main/java/com/uber/cadence/activity/ActivityTask.java
@@ -65,5 +65,6 @@ public interface ActivityTask {
   String getWorkflowDomain();
 
   int getAttempt();
+
   byte[] getInput();
 }

--- a/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
+++ b/src/main/java/com/uber/cadence/internal/sync/POJOActivityTaskHandler.java
@@ -24,6 +24,7 @@ import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.RespondActivityTaskCompletedRequest;
 import com.uber.cadence.RespondActivityTaskFailedRequest;
 import com.uber.cadence.activity.ActivityMethod;
+import com.uber.cadence.activity.ActivityTask;
 import com.uber.cadence.client.ActivityCancelledException;
 import com.uber.cadence.common.MethodRetry;
 import com.uber.cadence.converter.DataConverter;
@@ -201,7 +202,7 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
   }
 
   interface ActivityTaskExecutor {
-    ActivityTaskHandler.Result execute(ActivityTaskImpl task, Scope metricsScope);
+    ActivityTaskHandler.Result execute(ActivityTask task, Scope metricsScope);
   }
 
   private class POJOActivityImplementation implements ActivityTaskExecutor {
@@ -214,7 +215,7 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
     }
 
     @Override
-    public ActivityTaskHandler.Result execute(ActivityTaskImpl task, Scope metricsScope) {
+    public ActivityTaskHandler.Result execute(ActivityTask task, Scope metricsScope) {
       ActivityExecutionContext context =
           new ActivityExecutionContextImpl(service, domain, task, dataConverter, heartbeatExecutor);
       byte[] input = task.getInput();
@@ -250,7 +251,7 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
     }
 
     @Override
-    public ActivityTaskHandler.Result execute(ActivityTaskImpl task, Scope metricsScope) {
+    public ActivityTaskHandler.Result execute(ActivityTask task, Scope metricsScope) {
       ActivityExecutionContext context =
           new LocalActivityExecutionContextImpl(service, domain, task);
       CurrentActivityExecutionContext.set(context);


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Correctly use ActivityTask interface rather than the implementation directly in the interface.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
