### PR TITLE
Add unsetCurrentContext to ContextPropagator interface

### DIFF
--- a/src/main/java/com/uber/cadence/context/ContextPropagator.java
+++ b/src/main/java/com/uber/cadence/context/ContextPropagator.java
@@ -136,4 +136,7 @@ public interface ContextPropagator {
 
   /** Sets the current context */
   void setCurrentContext(Object context);
+
+  /** Unsets the current context. This is called when the context is no longer needed */
+  void unsetCurrentContext();
 }

--- a/src/main/java/com/uber/cadence/internal/context/ContextThreadLocal.java
+++ b/src/main/java/com/uber/cadence/internal/context/ContextThreadLocal.java
@@ -67,4 +67,10 @@ public class ContextThreadLocal {
       }
     }
   }
+
+  public static void unsetCurrentContext() {
+    for (ContextPropagator propagator : contextPropagators.get()) {
+      propagator.unsetCurrentContext();
+    }
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
@@ -132,12 +132,12 @@ class WorkflowThreadImpl implements WorkflowThread {
         }
         threadContext.setUnhandledException(e);
       } finally {
+        ContextThreadLocal.unsetCurrentContext();
         DeterministicRunnerImpl.setCurrentThreadInternal(null);
         threadContext.setStatus(Status.DONE);
         thread.setName(originalName);
         thread = null;
         MDC.clear();
-        ContextThreadLocal.unsetCurrentContext();
       }
     }
 

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowThreadImpl.java
@@ -137,6 +137,7 @@ class WorkflowThreadImpl implements WorkflowThread {
         thread.setName(originalName);
         thread = null;
         MDC.clear();
+        ContextThreadLocal.unsetCurrentContext();
       }
     }
 

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
@@ -174,6 +174,7 @@ public class ActivityWorker extends SuspendableWorkerBase {
         MDC.remove(LoggerTag.ACTIVITY_TYPE);
         MDC.remove(LoggerTag.WORKFLOW_ID);
         MDC.remove(LoggerTag.RUN_ID);
+        unsetCurrentContext();
       }
     }
 
@@ -197,6 +198,12 @@ public class ActivityWorker extends SuspendableWorkerBase {
 
       for (ContextPropagator propagator : options.getContextPropagators()) {
         propagator.setCurrentContext(propagator.deserializeContext(headerData));
+      }
+    }
+
+    void unsetCurrentContext() {
+      for (ContextPropagator propagator : options.getContextPropagators()) {
+        propagator.unsetCurrentContext();
       }
     }
 

--- a/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
@@ -22,6 +22,7 @@ import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.MarkerRecordedEventAttributes;
 import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.common.RetryOptions;
+import com.uber.cadence.context.ContextPropagator;
 import com.uber.cadence.internal.common.LocalActivityMarkerData;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
@@ -168,6 +169,7 @@ public final class LocalActivityWorker extends SuspendableWorkerBase {
         task.eventConsumer.accept(event);
       } finally {
         span.finish();
+        unsetCurrentContext();
       }
     }
 
@@ -239,6 +241,10 @@ public final class LocalActivityWorker extends SuspendableWorkerBase {
     Optional.ofNullable(params.getContext())
         .filter(context -> !context.isEmpty())
         .ifPresent(this::restoreContext);
+  }
+
+  private void unsetCurrentContext() {
+    options.getContextPropagators().forEach(ContextPropagator::unsetCurrentContext);
   }
 
   private void restoreContext(Map<String, byte[]> context) {

--- a/src/test/java/com/uber/cadence/activity/LocalActivityContextPropagationTest.java
+++ b/src/test/java/com/uber/cadence/activity/LocalActivityContextPropagationTest.java
@@ -218,6 +218,9 @@ public class LocalActivityContextPropagationTest {
       String propagatedContextName = ((Context) context).getContextName();
       wrapperContext.newContext(propagatedContextName);
     }
+
+    @Override
+    public void unsetCurrentContext() {}
   }
 
   private class WrapperContext {

--- a/src/test/java/com/uber/cadence/internal/testing/WorkflowTestingTest.java
+++ b/src/test/java/com/uber/cadence/internal/testing/WorkflowTestingTest.java
@@ -17,9 +17,7 @@
 
 package com.uber.cadence.internal.testing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,21 +43,10 @@ import com.uber.cadence.testing.SimulatedTimeoutException;
 import com.uber.cadence.testing.TestEnvironmentOptions;
 import com.uber.cadence.testing.TestWorkflowEnvironment;
 import com.uber.cadence.worker.Worker;
-import com.uber.cadence.workflow.ActivityTimeoutException;
-import com.uber.cadence.workflow.Async;
-import com.uber.cadence.workflow.ChildWorkflowOptions;
-import com.uber.cadence.workflow.ChildWorkflowTimedOutException;
-import com.uber.cadence.workflow.Promise;
-import com.uber.cadence.workflow.SignalMethod;
-import com.uber.cadence.workflow.Workflow;
-import com.uber.cadence.workflow.WorkflowMethod;
+import com.uber.cadence.workflow.*;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -742,6 +729,37 @@ public class WorkflowTestingTest {
 
   public static class TestContextPropagator implements ContextPropagator {
 
+    //    public static class TestContext {
+    //        private final String testKey;
+    //        private final Integer level;
+    //
+    //        public TestContext(String testKey, Integer level) {
+    //            this.testKey = testKey;
+    //            this.level = level;
+    //        }
+    //
+    //        public String getTestKey() {
+    //            return testKey;
+    //        }
+    //        public Integer getLevel() {
+    //            return level;
+    //        }
+    //
+    //        public Map<String, byte[]> ToMap() {
+    //            return "TestContext{testKey=" + testKey + ", level=" + level + "}";
+    //        }
+    //    }
+
+    private int level;
+
+    TestContextPropagator() {
+      level = 0;
+    }
+
+    public int getLevel() {
+      return level;
+    }
+
     @Override
     public String getName() {
       return this.getClass().getName();
@@ -774,11 +792,13 @@ public class WorkflowTestingTest {
     @Override
     public void setCurrentContext(Object context) {
       MDC.put("test", String.valueOf(context));
+      level++;
     }
 
     @Override
     public void unsetCurrentContext() {
       MDC.remove("test");
+      level--;
     }
   }
 
@@ -798,13 +818,15 @@ public class WorkflowTestingTest {
     testEnvironment.start();
     MDC.put("test", "testing123");
     WorkflowClient client = testEnvironment.newWorkflowClient();
+    TestContextPropagator propagator = new TestContextPropagator();
     WorkflowOptions options =
         new WorkflowOptions.Builder()
-            .setContextPropagators(Collections.singletonList(new TestContextPropagator()))
+            .setContextPropagators(Collections.singletonList(propagator))
             .build();
     TestWorkflow workflow = client.newWorkflowStub(TestWorkflow.class, options);
     String result = workflow.workflow1("input1");
     assertEquals("testing123", result);
+    assertEquals(0, propagator.getLevel());
   }
 
   public static class ContextPropagationParentWorkflowImpl implements ParentWorkflow {

--- a/src/test/java/com/uber/cadence/internal/testing/WorkflowTestingTest.java
+++ b/src/test/java/com/uber/cadence/internal/testing/WorkflowTestingTest.java
@@ -775,6 +775,11 @@ public class WorkflowTestingTest {
     public void setCurrentContext(Object context) {
       MDC.put("test", String.valueOf(context));
     }
+
+    @Override
+    public void unsetCurrentContext() {
+      MDC.remove("test");
+    }
   }
 
   public static class ContextPropagationWorkflowImpl implements TestWorkflow {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* added unsetCurrentContext method to ContextPropagator

<!-- Tell your future self why have you made these changes -->
**Why?**

Existing ContextPropagator interface do not support context deactivation

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
