### PR TITLE
downgrade java-jwt dependency to 3.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     compile group: 'com.cronutils', name: 'cron-utils', version: '9.2.0'
     compile group: 'io.micrometer', name: 'micrometer-core', version: '1.10.2'
     compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
-    compile group: 'com.auth0', name: 'java-jwt', version:'4.4.0'
+    compile group: 'com.auth0', name: 'java-jwt', version:'3.10.2'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.21.9'
     compile group: 'com.google.api.grpc', name: 'proto-google-common-protos', version: '2.10.0'
     compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.21.9'

--- a/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
+++ b/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
@@ -23,6 +23,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.sql.Date;
 import java.time.Instant;
 
 public class AdminJwtAuthorizationProvider implements IAuthorizationProvider {
@@ -42,8 +43,8 @@ public class AdminJwtAuthorizationProvider implements IAuthorizationProvider {
     int JWT_TTL_SECONDS = 60 * 10;
     jwtBuilder.withClaim("admin", true);
     jwtBuilder.withClaim("ttl", JWT_TTL_SECONDS);
-    jwtBuilder.withIssuedAt(now);
-    jwtBuilder.withExpiresAt(now.plusSeconds(JWT_TTL_SECONDS));
+    jwtBuilder.withIssuedAt(Date.from(now));
+    jwtBuilder.withExpiresAt(Date.from(now.plusSeconds(JWT_TTL_SECONDS)));
     return jwtBuilder
         .sign(Algorithm.RSA256(this.rsaPublicKey, this.rsaPrivateKey))
         .getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Keeping java-jwt dependency version at 3.10.2

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
