### PR TITLE
Remove unused direct dependency of com.google.http-client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,6 @@ dependencies {
     compile group: 'com.google.api.grpc', name: 'proto-google-common-protos', version: '2.10.0'
     compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.21.9'
     compile group: 'com.google.oauth-client', name: 'google-oauth-client', version: '1.35.0'
-    compile group: 'com.google.http-client', name: 'google-http-client-gson', version: '1.19.0'
 
     implementation 'io.grpc:grpc-netty-shaded:1.54.2'
     implementation 'io.grpc:grpc-protobuf:1.54.2'


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**

com.google.http-client is already included in oauth library

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
