### PR TITLE
Fix context propagation bug that would link two parents in some cases

### DIFF
--- a/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
+++ b/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
@@ -102,6 +102,7 @@ public class TracingPropagator {
     Span span =
         tracer
             .buildSpan(EXECUTE_LOCAL_ACTIVITY)
+            .ignoreActiveSpan()
             .addReference(References.FOLLOWS_FROM, parent)
             .withTag(TAG_WORKFLOW_ID, params.getWorkflowExecution().getWorkflowId())
             .withTag(TAG_WORKFLOW_RUN_ID, params.getWorkflowExecution().getRunId())

--- a/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
+++ b/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
@@ -54,7 +54,7 @@ public class TracingPropagator {
   }
 
   public Span spanByServiceMethod(String serviceMethod) {
-    return tracer.buildSpan(serviceMethod).asChildOf(tracer.activeSpan()).start();
+    return tracer.buildSpan(serviceMethod).start();
   }
 
   public Span spanForExecuteWorkflow(DecisionContext context) {

--- a/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
+++ b/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
@@ -64,7 +64,8 @@ public class TracingPropagator {
 
     return tracer
         .buildSpan(EXECUTE_WORKFLOW)
-        .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the start workflow context
+        .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the start
+                            // workflow context
         .addReference(
             References.FOLLOWS_FROM, parent != NoopSpan.INSTANCE.context() ? parent : null)
         .withTag(TAG_WORKFLOW_TYPE, context.getWorkflowType().getName())
@@ -77,7 +78,8 @@ public class TracingPropagator {
     SpanContext parent = extract(task.getHeader());
     return tracer
         .buildSpan(EXECUTE_ACTIVITY)
-        .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the execute workflow context
+        .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the execute
+                            // workflow context
         .addReference(
             References.FOLLOWS_FROM, parent != NoopSpan.INSTANCE.context() ? parent : null)
         .withTag(

--- a/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
+++ b/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
@@ -65,7 +65,7 @@ public class TracingPropagator {
     return tracer
         .buildSpan(EXECUTE_WORKFLOW)
         .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the start
-                            // workflow context
+        // workflow context
         .addReference(
             References.FOLLOWS_FROM, parent != NoopSpan.INSTANCE.context() ? parent : null)
         .withTag(TAG_WORKFLOW_TYPE, context.getWorkflowType().getName())
@@ -79,7 +79,7 @@ public class TracingPropagator {
     return tracer
         .buildSpan(EXECUTE_ACTIVITY)
         .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the execute
-                            // workflow context
+        // workflow context
         .addReference(
             References.FOLLOWS_FROM, parent != NoopSpan.INSTANCE.context() ? parent : null)
         .withTag(

--- a/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
+++ b/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
@@ -64,6 +64,7 @@ public class TracingPropagator {
 
     return tracer
         .buildSpan(EXECUTE_WORKFLOW)
+        .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the start workflow context
         .addReference(
             References.FOLLOWS_FROM, parent != NoopSpan.INSTANCE.context() ? parent : null)
         .withTag(TAG_WORKFLOW_TYPE, context.getWorkflowType().getName())
@@ -76,6 +77,7 @@ public class TracingPropagator {
     SpanContext parent = extract(task.getHeader());
     return tracer
         .buildSpan(EXECUTE_ACTIVITY)
+        .ignoreActiveSpan() // ignore active span to start a new trace that ONLY links the execute workflow context
         .addReference(
             References.FOLLOWS_FROM, parent != NoopSpan.INSTANCE.context() ? parent : null)
         .withTag(

--- a/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.*;
 import com.uber.cadence.DomainAlreadyExistsError;
 import com.uber.cadence.RegisterDomainRequest;
 import com.uber.cadence.activity.ActivityMethod;
+import com.uber.cadence.activity.ActivityOptions;
 import com.uber.cadence.client.*;
+import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.internal.compatibility.Thrift2ProtoAdapter;
 import com.uber.cadence.internal.compatibility.proto.serviceclient.IGrpcServiceStubs;
 import com.uber.cadence.serviceclient.ClientOptions;
@@ -108,7 +110,16 @@ public class StartWorkflowTest {
   }
 
   public static class TestWorkflowImpl implements TestWorkflow {
-    private final TestActivity activities = Workflow.newActivityStub(TestActivity.class);
+    private final TestActivity activities =
+        Workflow.newActivityStub(
+            TestActivity.class,
+            new ActivityOptions.Builder()
+                .setRetryOptions(
+                    new RetryOptions.Builder()
+                        .setInitialInterval(Duration.ofSeconds(10))
+                        .setMaximumAttempts(2)
+                        .build())
+                .build());
 
     @Override
     public Integer AddOneThenDouble(Integer n) {

--- a/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
@@ -166,7 +166,7 @@ public class StartWorkflowTest {
 
   @Test
   public void testStartMultipleWorkflowGRPC() {
-    //    Assume.assumeTrue(useDockerService);
+    Assume.assumeTrue(useDockerService);
     MockTracer mockTracer = new MockTracer();
     IWorkflowService service =
         new Thrift2ProtoAdapter(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* ignore active span in ExecuteWorkflow and ExecuteActivity.

<!-- Tell your future self why have you made these changes -->
**Why?**

Because workflowThreads are coroutines, it's possible that two workflows are referencing each other as parents.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
