### PR TITLE
Fix incorrect span activation for local activities

### DIFF
--- a/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
+++ b/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
@@ -101,8 +101,7 @@ public class TracingPropagator {
     // retrieve spancontext from params
     SpanContext parent = extract(params.getContext());
 
-    Span span =
-        tracer
+    return tracer
             .buildSpan(EXECUTE_LOCAL_ACTIVITY)
             .ignoreActiveSpan()
             .addReference(References.FOLLOWS_FROM, parent)
@@ -110,8 +109,6 @@ public class TracingPropagator {
             .withTag(TAG_WORKFLOW_RUN_ID, params.getWorkflowExecution().getRunId())
             .withTag(TAG_ACTIVITY_TYPE, params.getActivityType().getName())
             .start();
-    tracer.activateSpan(span);
-    return span;
   }
 
   public void inject(Map<String, byte[]> headers) {

--- a/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
+++ b/src/main/java/com/uber/cadence/internal/tracing/TracingPropagator.java
@@ -102,13 +102,13 @@ public class TracingPropagator {
     SpanContext parent = extract(params.getContext());
 
     return tracer
-            .buildSpan(EXECUTE_LOCAL_ACTIVITY)
-            .ignoreActiveSpan()
-            .addReference(References.FOLLOWS_FROM, parent)
-            .withTag(TAG_WORKFLOW_ID, params.getWorkflowExecution().getWorkflowId())
-            .withTag(TAG_WORKFLOW_RUN_ID, params.getWorkflowExecution().getRunId())
-            .withTag(TAG_ACTIVITY_TYPE, params.getActivityType().getName())
-            .start();
+        .buildSpan(EXECUTE_LOCAL_ACTIVITY)
+        .ignoreActiveSpan()
+        .addReference(References.FOLLOWS_FROM, parent)
+        .withTag(TAG_WORKFLOW_ID, params.getWorkflowExecution().getWorkflowId())
+        .withTag(TAG_WORKFLOW_RUN_ID, params.getWorkflowExecution().getRunId())
+        .withTag(TAG_ACTIVITY_TYPE, params.getActivityType().getName())
+        .start();
   }
 
   public void inject(Map<String, byte[]> headers) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

span is incorrectly activated for local activities, this is already activated in activity worker https://github.com/uber/cadence-java-client/blob/95cb139ff9947db730186369a4f4ed34578f85c8/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java#L137 

<!-- Tell your future self why have you made these changes -->
**Why?**

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
