### PR TITLE
Use the same Request ID for retries

### DIFF
--- a/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/Thrift2ProtoAdapter.java
@@ -252,7 +252,9 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
   }
 
   private void initializeStartWorkflowExecutionRequest(StartWorkflowExecutionRequest request) {
-    request.setRequestId(UUID.randomUUID().toString());
+    if (!request.isSetRequestId()) {
+      request.setRequestId(UUID.randomUUID().toString());
+    }
   }
 
   @Override
@@ -466,7 +468,9 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       throws BadRequestError, EntityNotExistsError, CancellationAlreadyRequestedError,
           ServiceBusyError, DomainNotActiveError, LimitExceededError,
           ClientVersionNotSupportedError, WorkflowExecutionAlreadyCompletedError, TException {
-    cancelRequest.setRequestId(UUID.randomUUID().toString());
+    if (!cancelRequest.isSetRequestId()) {
+      cancelRequest.setRequestId(UUID.randomUUID().toString());
+    }
     try {
       grpcServiceStubs
           .workflowBlockingStub()
@@ -482,7 +486,9 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
           LimitExceededError, ClientVersionNotSupportedError,
           WorkflowExecutionAlreadyCompletedError, TException {
-    signalRequest.setRequestId(UUID.randomUUID().toString());
+    if (!signalRequest.isSetRequestId()) {
+      signalRequest.setRequestId(UUID.randomUUID().toString());
+    }
     try {
       grpcServiceStubs
           .workflowBlockingStub()
@@ -533,7 +539,9 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
 
   private void initializeSignalWithStartWorkflowExecution(
       SignalWithStartWorkflowExecutionRequest request) {
-    request.setRequestId(UUID.randomUUID().toString());
+    if (!request.isSetRequestId()) {
+      request.setRequestId(UUID.randomUUID().toString());
+    }
   }
 
   @Override
@@ -542,7 +550,9 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
           LimitExceededError, ClientVersionNotSupportedError, TException {
     try {
-      resetRequest.setRequestId(UUID.randomUUID().toString());
+      if (!resetRequest.isSetRequestId()) {
+        resetRequest.setRequestId(UUID.randomUUID().toString());
+      }
       com.uber.cadence.api.v1.ResetWorkflowExecutionResponse response =
           grpcServiceStubs
               .workflowBlockingStub()
@@ -980,7 +990,9 @@ public class Thrift2ProtoAdapter implements IWorkflowService {
       SignalWorkflowExecutionRequest signalRequest, AsyncMethodCallback resultHandler)
       throws TException {
     try {
-      signalRequest.setRequestId(UUID.randomUUID().toString());
+      if (!signalRequest.isSetRequestId()) {
+        signalRequest.setRequestId(UUID.randomUUID().toString());
+      }
       ListenableFuture<com.uber.cadence.api.v1.SignalWorkflowExecutionResponse> resultFuture =
           grpcServiceStubs
               .workflowFutureStub()

--- a/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/src/main/java/com/uber/cadence/internal/external/GenericWorkflowClientExternalImpl.java
@@ -244,7 +244,8 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
 
   private StartWorkflowExecutionRequest getStartRequest(
       StartWorkflowExecutionParameters startParameters) {
-    StartWorkflowExecutionRequest request = new StartWorkflowExecutionRequest();
+    StartWorkflowExecutionRequest request =
+        new StartWorkflowExecutionRequest().setRequestId(generateUniqueId());
     request.setDomain(domain);
     if (startParameters.getInput() != null) {
       request.setInput(startParameters.getInput());
@@ -383,7 +384,8 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
 
   private SignalWorkflowExecutionRequest getSignalRequest(
       SignalExternalWorkflowParameters signalParameters) {
-    SignalWorkflowExecutionRequest request = new SignalWorkflowExecutionRequest();
+    SignalWorkflowExecutionRequest request =
+        new SignalWorkflowExecutionRequest().setRequestId(generateUniqueId());
     request.setDomain(domain);
     request.setInput(signalParameters.getInput());
     request.setSignalName(signalParameters.getSignalName());
@@ -466,7 +468,8 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
 
   private SignalWithStartWorkflowExecutionRequest createSignalWithStartRequest(
       SignalWithStartWorkflowExecutionParameters parameters) {
-    SignalWithStartWorkflowExecutionRequest request = new SignalWithStartWorkflowExecutionRequest();
+    SignalWithStartWorkflowExecutionRequest request =
+        new SignalWithStartWorkflowExecutionRequest().setRequestId(generateUniqueId());
     request.setDomain(domain);
     StartWorkflowExecutionParameters startParameters = parameters.getStartParameters();
     request.setSignalName(parameters.getSignalName());
@@ -509,7 +512,8 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
 
   @Override
   public void requestCancelWorkflowExecution(WorkflowExecution execution) {
-    RequestCancelWorkflowExecutionRequest request = new RequestCancelWorkflowExecutionRequest();
+    RequestCancelWorkflowExecutionRequest request =
+        new RequestCancelWorkflowExecutionRequest().setRequestId(generateUniqueId());
     request.setDomain(domain);
     request.setWorkflowExecution(execution);
     try {
@@ -544,8 +548,7 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
 
   @Override
   public String generateUniqueId() {
-    String workflowId = UUID.randomUUID().toString();
-    return workflowId;
+    return UUID.randomUUID().toString();
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -712,7 +712,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
   }
 
   private void initializeStartWorkflowRequest(StartWorkflowExecutionRequest startRequest) {
-    startRequest.setRequestId(UUID.randomUUID().toString());
+    if (!startRequest.isSetRequestId()) {
+      startRequest.setRequestId(UUID.randomUUID().toString());
+    }
     // Write span context to header
     if (!startRequest.isSetHeader()) {
       startRequest.setHeader(new Header());
@@ -1412,7 +1414,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
 
   private void requestCancelWorkflowExecution(RequestCancelWorkflowExecutionRequest cancelRequest)
       throws TException {
-    cancelRequest.setRequestId(UUID.randomUUID().toString());
+    if (!cancelRequest.isSetRequestId()) {
+      cancelRequest.setRequestId(UUID.randomUUID().toString());
+    }
     ThriftResponse<WorkflowService.RequestCancelWorkflowExecution_result> response = null;
     try {
       ThriftRequest<WorkflowService.RequestCancelWorkflowExecution_args> request =
@@ -1667,7 +1671,9 @@ public class WorkflowServiceTChannel implements IWorkflowService {
 
   private void initializeSignalWithStartWorkflowRequest(
       SignalWithStartWorkflowExecutionRequest request) {
-    request.setRequestId(UUID.randomUUID().toString());
+    if (!request.isSetRequestId()) {
+      request.setRequestId(UUID.randomUUID().toString());
+    }
     // Write span context to header
     if (!request.isSetHeader()) {
       request.setHeader(new Header());


### PR DESCRIPTION
Currently the RequestId is initialized in the implementation of IWorkflowService (either Thrift2ProtoAdapter or WorkflowServiceTChannel). Since retries are handled within GenericWorkflowClientExternalImpl which calls to IWorkflowService, each attempt uses a different request ID. This causes Cadence's idempotency feature not to work correctly for retries from the Java client.

Move Request ID initialization to GenericWorkflowClientExternalImpl, and for backwards compatibility (since users may be interacting with the IWorkflowService directly) continue setting the request ID within IWorkflowService implementations if not specified.

We have Request IDs within the following operations:
- Start
- Signal
- SignalWithStart
- StartAsync
- SignalWithStartAsync
- Cancel
- Reset

All of these other than Reset will be supported following this change. Reset isn't used within the Java client so there isn't a layer on top of IWorkflowService to add initialization. Users may be using the IWorkflowService directly to call reset, in which case they should provide a request ID. The current behavior for Reset within the IWorkflowService is that no request ID is included.

<!-- Describe what has changed in this PR -->
**What changed?**
- Retries will use the same Request ID for retries of a request

<!-- Tell your future self why have you made these changes -->
**Why?**
- Allows server-side idempotency handling to correctly identify duplicate requests.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
