### PR TITLE
Refactor Test Environment and Worker initialization to CadenceTestRule

### DIFF
--- a/src/test/java/com/uber/cadence/RegisterTestDomain.java
+++ b/src/test/java/com/uber/cadence/RegisterTestDomain.java
@@ -1,7 +1,7 @@
 package com.uber.cadence;
 
-import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
-import static com.uber.cadence.workflow.WorkflowTest.DOMAIN2;
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN;
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN2;
 
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.IWorkflowService;

--- a/src/test/java/com/uber/cadence/testUtils/CadenceTestContext.java
+++ b/src/test/java/com/uber/cadence/testUtils/CadenceTestContext.java
@@ -1,0 +1,224 @@
+package com.uber.cadence.testUtils;
+
+import com.uber.cadence.FeatureFlags;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.internal.worker.PollerOptions;
+import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
+import com.uber.cadence.testing.TestEnvironmentOptions;
+import com.uber.cadence.testing.TestWorkflowEnvironment;
+import com.uber.cadence.worker.Worker;
+import com.uber.cadence.worker.WorkerFactory;
+import com.uber.cadence.worker.WorkerFactoryOptions;
+import com.uber.cadence.worker.WorkerOptions;
+import com.uber.cadence.workflow.interceptors.TracingWorkflowInterceptorFactory;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public class CadenceTestContext {
+
+  private final Map<String, Worker> workers = new HashMap<>();
+  private List<ScheduledFuture<?>> delayedCallbacks = new ArrayList<>();
+  private final IWorkflowService wfService;
+  private final WorkflowClient workflowClient;
+  private final String defaultTaskList;
+  private final TracingWorkflowInterceptorFactory tracer;
+  private WorkerFactory workerFactory;
+  // Real Service only
+  private ScheduledExecutorService scheduledExecutor;
+  // Test service only
+  private TestWorkflowEnvironment testEnvironment;
+
+  private CadenceTestContext(
+      WorkflowClient workflowClient,
+      String defaultTaskList,
+      TracingWorkflowInterceptorFactory tracer,
+      WorkerFactory workerFactory,
+      ScheduledExecutorService scheduledExecutor,
+      TestWorkflowEnvironment testEnvironment) {
+    this.wfService = workflowClient.getService();
+    this.workflowClient = workflowClient;
+    this.defaultTaskList = defaultTaskList;
+    this.tracer = tracer;
+    this.workerFactory = workerFactory;
+    this.scheduledExecutor = scheduledExecutor;
+    this.testEnvironment = testEnvironment;
+  }
+
+  public Worker getDefaultWorker() {
+    return getOrCreateWorker(getDefaultTaskList());
+  }
+
+  public Worker getOrCreateWorker(String taskList) {
+    return workers.computeIfAbsent(taskList, this::createWorker);
+  }
+
+  public void start() {
+    if (isRealService()) {
+      workerFactory.start();
+    } else {
+      testEnvironment.start();
+    }
+  }
+
+  public void stop() {
+    if (!workerFactory.isStarted() || workerFactory.isTerminated() || workerFactory.isShutdown()) {
+      return;
+    }
+    if (isRealService()) {
+      workerFactory.shutdown();
+      workerFactory.awaitTermination(1, TimeUnit.SECONDS);
+      for (ScheduledFuture<?> result : delayedCallbacks) {
+        if (result.isDone() && !result.isCancelled()) {
+          try {
+            result.get();
+          } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted, some assertions may not have run", e);
+          } catch (ExecutionException e) {
+            if (e.getCause() instanceof AssertionError) {
+              throw (AssertionError) e.getCause();
+            } else {
+              throw new RuntimeException("Failed to complete callback", e.getCause());
+            }
+          }
+        }
+      }
+      wfService.close();
+    } else {
+      testEnvironment.shutdown();
+      testEnvironment.awaitTermination(1, TimeUnit.SECONDS);
+    }
+    if (tracer != null) {
+      tracer.assertExpected();
+    }
+  }
+
+  public void suspendPolling() {
+    workerFactory.suspendPolling();
+  }
+
+  public void resumePolling() {
+    workerFactory.resumePolling();
+  }
+
+  public void registerDelayedCallback(Duration delay, Runnable r) {
+    if (isRealService()) {
+      ScheduledFuture<?> result =
+          scheduledExecutor.schedule(r, delay.toMillis(), TimeUnit.MILLISECONDS);
+      delayedCallbacks.add(result);
+    } else {
+      testEnvironment.registerDelayedCallback(delay, r);
+    }
+  }
+
+  public void sleep(Duration d) {
+    if (isRealService()) {
+      try {
+        Thread.sleep(d.toMillis());
+      } catch (InterruptedException e) {
+        throw new RuntimeException("Interrupted", e);
+      }
+    } else {
+      testEnvironment.sleep(d);
+    }
+  }
+
+  public long currentTimeMillis() {
+    if (isRealService()) {
+      return System.currentTimeMillis();
+    } else {
+      return testEnvironment.currentTimeMillis();
+    }
+  }
+
+  public String getDefaultTaskList() {
+    return defaultTaskList;
+  }
+
+  public WorkflowClient getWorkflowClient() {
+    return workflowClient;
+  }
+
+  public WorkflowClient createWorkflowClient(WorkflowClientOptions options) {
+    if (isRealService()) {
+      return WorkflowClient.newInstance(getWorkflowClient().getService(), options);
+    } else {
+      return testEnvironment.newWorkflowClient(options);
+    }
+  }
+
+  public TracingWorkflowInterceptorFactory getTracer() {
+    return tracer;
+  }
+
+  private boolean isRealService() {
+    return testEnvironment == null;
+  }
+
+  private Worker createWorker(String taskList) {
+    if (isRealService()) {
+      return workerFactory.newWorker(
+          taskList,
+          WorkerOptions.newBuilder()
+              .setActivityPollerOptions(PollerOptions.newBuilder().setPollThreadCount(5).build())
+              .setMaxConcurrentActivityExecutionSize(1000)
+              .setInterceptorFactory(tracer)
+              .build());
+    } else {
+      return testEnvironment.newWorker(taskList);
+    }
+  }
+
+  public static CadenceTestContext forTestService(
+      Function<TestEnvironmentOptions, TestWorkflowEnvironment> envFactory,
+      WorkflowClientOptions clientOptions,
+      String defaultTaskList,
+      WorkerFactoryOptions workerFactoryOptions) {
+    TracingWorkflowInterceptorFactory tracer = new TracingWorkflowInterceptorFactory();
+
+    TestEnvironmentOptions testOptions =
+        new TestEnvironmentOptions.Builder()
+            .setWorkflowClientOptions(clientOptions)
+            .setInterceptorFactory(tracer)
+            .setWorkerFactoryOptions(workerFactoryOptions)
+            .build();
+    TestWorkflowEnvironment testEnvironment = envFactory.apply(testOptions);
+    return new CadenceTestContext(
+        testEnvironment.newWorkflowClient(),
+        defaultTaskList,
+        tracer,
+        testEnvironment.getWorkerFactory(),
+        null,
+        testEnvironment);
+  }
+
+  public static CadenceTestContext forRealService(
+      WorkflowClientOptions clientOptions,
+      String defaultTaskList,
+      WorkerFactoryOptions workerFactoryOptions) {
+    TracingWorkflowInterceptorFactory tracer = new TracingWorkflowInterceptorFactory();
+
+    IWorkflowService wfService =
+        new WorkflowServiceTChannel(
+            ClientOptions.newBuilder()
+                .setFeatureFlags(
+                    new FeatureFlags().setWorkflowExecutionAlreadyCompletedErrorEnabled(true))
+                .build());
+    WorkflowClient workflowClient = WorkflowClient.newInstance(wfService, clientOptions);
+    WorkerFactory workerFactory = new WorkerFactory(workflowClient, workerFactoryOptions);
+    ScheduledExecutorService scheduledExecutor = new ScheduledThreadPoolExecutor(1);
+    return new CadenceTestContext(
+        workflowClient, defaultTaskList, tracer, workerFactory, scheduledExecutor, null);
+  }
+}

--- a/src/test/java/com/uber/cadence/testUtils/CadenceTestRule.java
+++ b/src/test/java/com/uber/cadence/testUtils/CadenceTestRule.java
@@ -1,0 +1,289 @@
+package com.uber.cadence.testUtils;
+
+import com.uber.cadence.activity.ActivityOptions;
+import com.uber.cadence.activity.LocalActivityOptions;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.client.WorkflowOptions;
+import com.uber.cadence.testing.TestEnvironmentOptions;
+import com.uber.cadence.testing.TestWorkflowEnvironment;
+import com.uber.cadence.worker.Worker;
+import com.uber.cadence.worker.WorkerFactoryOptions;
+import com.uber.cadence.workflow.interceptors.TracingWorkflowInterceptorFactory;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class CadenceTestRule implements TestRule {
+
+  private final Builder builder;
+  private CadenceTestContext context;
+
+  private CadenceTestRule(Builder builder) {
+    this.builder = builder;
+  }
+
+  @Override
+  public Statement apply(Statement testCase, Description description) {
+    // Unless the test overrides the timeout, apply our own
+    Test annotation = description.getAnnotation(Test.class);
+    if (TestEnvironment.isDebuggerTimeouts() || (annotation == null || annotation.timeout() > 0)) {
+      testCase = Timeout.millis(getDefaultTestTimeout().toMillis()).apply(testCase, description);
+    }
+    Statement finalStatement = testCase;
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        if (description.getAnnotation(RequiresDockerService.class) != null && !isDockerService()) {
+          throw new AssumptionViolatedException(
+              "Skipping test because it requires the Docker service");
+        }
+        if (description.getAnnotation(RequiresTestService.class) != null && isDockerService()) {
+          throw new AssumptionViolatedException(
+              "Skipping test because it requires the test service");
+        }
+        setup(description);
+        try {
+          finalStatement.evaluate();
+        } finally {
+          teardown();
+        }
+      }
+    };
+  }
+
+  public TracingWorkflowInterceptorFactory getTracer() {
+    return context.getTracer();
+  }
+
+  public WorkflowClient getWorkflowClient() {
+    return context.getWorkflowClient();
+  }
+
+  public WorkflowClient createWorkflowClient(WorkflowClientOptions options) {
+    return context.createWorkflowClient(options);
+  }
+
+  public Worker getWorker() {
+    return context.getDefaultWorker();
+  }
+
+  public Worker getWorker(String tasklist) {
+    return context.getOrCreateWorker(tasklist);
+  }
+
+  public String getDefaultTaskList() {
+    return context.getDefaultTaskList();
+  }
+
+  public void start() {
+    context.start();
+  }
+
+  public void stop() {
+    context.stop();
+  }
+
+  public void suspendPolling() {
+    context.suspendPolling();
+  }
+
+  public void resumePolling() {
+    context.resumePolling();
+  }
+
+  public void registerDelayedCallback(Duration delay, Runnable r) {
+    context.registerDelayedCallback(delay, r);
+  }
+
+  public void sleep(Duration d) {
+    context.sleep(d);
+  }
+
+  public long currentTimeMillis() {
+    return context.currentTimeMillis();
+  }
+
+  public WorkflowOptions.Builder workflowOptionsBuilder() {
+    return workflowOptionsBuilder(context.getDefaultTaskList());
+  }
+
+  public WorkflowOptions.Builder workflowOptionsBuilder(String taskList) {
+    if (TestEnvironment.isDebuggerTimeouts()) {
+      return new WorkflowOptions.Builder()
+          .setExecutionStartToCloseTimeout(Duration.ofSeconds(1000))
+          .setTaskStartToCloseTimeout(Duration.ofSeconds(60))
+          .setTaskList(taskList);
+    } else {
+      return new WorkflowOptions.Builder()
+          .setExecutionStartToCloseTimeout(Duration.ofSeconds(30))
+          .setTaskStartToCloseTimeout(Duration.ofSeconds(5))
+          .setTaskList(taskList);
+    }
+  }
+
+  public ActivityOptions activityOptions() {
+    return activityOptions(context.getDefaultTaskList());
+  }
+
+  public ActivityOptions activityOptions(String taskList) {
+    if (TestEnvironment.isDebuggerTimeouts()) {
+      return new ActivityOptions.Builder()
+          .setTaskList(taskList)
+          .setScheduleToCloseTimeout(Duration.ofSeconds(1000))
+          .setHeartbeatTimeout(Duration.ofSeconds(1000))
+          .setScheduleToStartTimeout(Duration.ofSeconds(1000))
+          .setStartToCloseTimeout(Duration.ofSeconds(10000))
+          .build();
+    } else {
+      return new ActivityOptions.Builder()
+          .setTaskList(taskList)
+          .setScheduleToCloseTimeout(Duration.ofSeconds(5))
+          .setHeartbeatTimeout(Duration.ofSeconds(5))
+          .setScheduleToStartTimeout(Duration.ofSeconds(5))
+          .setStartToCloseTimeout(Duration.ofSeconds(10))
+          .build();
+    }
+  }
+
+  public LocalActivityOptions localActivityOptions() {
+    if (TestEnvironment.isDebuggerTimeouts()) {
+      return new LocalActivityOptions.Builder()
+          .setScheduleToCloseTimeout(Duration.ofSeconds(1000))
+          .build();
+    } else {
+      return new LocalActivityOptions.Builder()
+          .setScheduleToCloseTimeout(Duration.ofSeconds(5))
+          .build();
+    }
+  }
+
+  private void setup(Description description) {
+    String testMethod = description.getMethodName();
+    String defaultTaskList =
+        description.getClassName() + "-" + testMethod + "-" + UUID.randomUUID();
+
+    WorkflowClientOptions clientOptions =
+        WorkflowClientOptions.newBuilder(builder.clientOptions).setDomain(builder.domain).build();
+
+    if (isDockerService()) {
+      this.context =
+          CadenceTestContext.forRealService(
+              clientOptions, defaultTaskList, builder.workerFactoryOptions);
+    } else {
+      this.context =
+          CadenceTestContext.forTestService(
+              builder.testWorkflowEnvironmentProvider,
+              clientOptions,
+              defaultTaskList,
+              builder.workerFactoryOptions);
+    }
+
+    if (!builder.activities.isEmpty() || !builder.workflowTypes.isEmpty()) {
+      Worker defaultWorker = context.getDefaultWorker();
+      if (!builder.activities.isEmpty()) {
+        defaultWorker.registerActivitiesImplementations(builder.activities.toArray());
+      }
+      if (!builder.workflowTypes.isEmpty()) {
+        defaultWorker.registerWorkflowImplementationTypes(
+            builder.workflowTypes.stream().toArray(Class[]::new));
+      }
+    }
+    if (builder.startWorkers) {
+      context.start();
+    }
+  }
+
+  private void teardown() {
+    context.stop();
+    this.context = null;
+  }
+
+  private Duration getDefaultTestTimeout() {
+    if (!builder.timeout.isZero()) {
+      return builder.timeout;
+    }
+    if (TestEnvironment.isDebuggerTimeouts()) {
+      return Duration.ofSeconds(500);
+    }
+    if (isDockerService()) {
+      return Duration.ofSeconds(30);
+    }
+    return Duration.ofSeconds(10);
+  }
+
+  public boolean isDockerService() {
+    return TestEnvironment.isUseDockerService();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<Class<?>> workflowTypes = new ArrayList<>();
+    private List<Object> activities = new ArrayList<>();
+    private WorkerFactoryOptions workerFactoryOptions = WorkerFactoryOptions.newBuilder().build();
+    private Function<TestEnvironmentOptions, TestWorkflowEnvironment>
+        testWorkflowEnvironmentProvider = TestWorkflowEnvironment::newInstance;
+    private WorkflowClientOptions clientOptions = WorkflowClientOptions.newBuilder().build();
+
+    private boolean startWorkers = false;
+    private Duration timeout = Duration.ZERO;
+    private String domain = TestEnvironment.DOMAIN;
+
+    public Builder withWorkflowTypes(Class<?>... workflowImpls) {
+      workflowTypes = Arrays.asList(workflowImpls);
+      return this;
+    }
+
+    public Builder withActivities(Object... activities) {
+      this.activities = Arrays.asList(activities);
+      return this;
+    }
+
+    public Builder withWorkerFactoryOptions(WorkerFactoryOptions options) {
+      this.workerFactoryOptions = options;
+      return this;
+    }
+
+    public Builder withTimeout(Duration timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
+    public Builder withDomain(String domain) {
+      this.domain = domain;
+      return this;
+    }
+
+    public Builder withClientOptions(WorkflowClientOptions options) {
+      this.clientOptions = options;
+      return this;
+    }
+
+    public Builder startWorkersAutomatically() {
+      startWorkers = true;
+      return this;
+    }
+
+    public Builder withTestEnvironmentProvider(
+        Function<TestEnvironmentOptions, TestWorkflowEnvironment> testEnvironmentProvider) {
+      this.testWorkflowEnvironmentProvider = testEnvironmentProvider;
+      return this;
+    }
+
+    public CadenceTestRule build() {
+      return new CadenceTestRule(this);
+    }
+  }
+}

--- a/src/test/java/com/uber/cadence/testUtils/RequiresDockerService.java
+++ b/src/test/java/com/uber/cadence/testUtils/RequiresDockerService.java
@@ -1,0 +1,10 @@
+package com.uber.cadence.testUtils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RequiresDockerService {}

--- a/src/test/java/com/uber/cadence/testUtils/RequiresTestService.java
+++ b/src/test/java/com/uber/cadence/testUtils/RequiresTestService.java
@@ -1,0 +1,10 @@
+package com.uber.cadence.testUtils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RequiresTestService {}

--- a/src/test/java/com/uber/cadence/testUtils/TestEnvironment.java
+++ b/src/test/java/com/uber/cadence/testUtils/TestEnvironment.java
@@ -1,0 +1,24 @@
+package com.uber.cadence.testUtils;
+
+public final class TestEnvironment {
+  public static final String DOMAIN = "UnitTest";
+  public static final String DOMAIN2 = "UnitTest2";
+  /**
+   * When set to true increases test, activity and workflow timeouts to large values to support
+   * stepping through code in a debugger without timing out.
+   */
+  private static final boolean DEBUGGER_TIMEOUTS = false;
+
+  private static final boolean USE_DOCKER_SERVICE =
+      Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
+
+  private TestEnvironment() {}
+
+  public static boolean isDebuggerTimeouts() {
+    return DEBUGGER_TIMEOUTS;
+  }
+
+  public static boolean isUseDockerService() {
+    return USE_DOCKER_SERVICE;
+  }
+}

--- a/src/test/java/com/uber/cadence/worker/CleanWorkerShutdownTest.java
+++ b/src/test/java/com/uber/cadence/worker/CleanWorkerShutdownTest.java
@@ -17,7 +17,7 @@
 
 package com.uber.cadence.worker;
 
-import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
+++ b/src/test/java/com/uber/cadence/worker/StickyWorkerTest.java
@@ -17,7 +17,7 @@
 
 package com.uber.cadence.worker;
 
-import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/com/uber/cadence/worker/WorkerStressTests.java
+++ b/src/test/java/com/uber/cadence/worker/WorkerStressTests.java
@@ -17,7 +17,7 @@
 
 package com.uber.cadence.worker;
 
-import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN;
 import static org.junit.Assert.assertNotNull;
 
 import com.uber.cadence.activity.ActivityMethod;

--- a/src/test/java/com/uber/cadence/workflow/CrossDomainWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/CrossDomainWorkflowTest.java
@@ -1,0 +1,85 @@
+package com.uber.cadence.workflow;
+
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN2;
+import static org.junit.Assert.assertEquals;
+
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowOptions;
+import com.uber.cadence.internal.sync.TestWorkflowEnvironmentInternal;
+import com.uber.cadence.testUtils.CadenceTestRule;
+import com.uber.cadence.testing.TestWorkflowEnvironment;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CrossDomainWorkflowTest {
+
+  // When running against the test service we need both rules to share the same one rather than each
+  // creating their own.
+  private final TestWorkflowEnvironmentInternal.WorkflowServiceWrapper testWorkflowService =
+      new TestWorkflowEnvironmentInternal.WorkflowServiceWrapper();
+
+  @Rule
+  public CadenceTestRule firstDomain =
+      CadenceTestRule.builder()
+          .withWorkflowTypes(TestWorkflowCrossDomainImpl.class)
+          .startWorkersAutomatically()
+          .withTestEnvironmentProvider(
+              options -> TestWorkflowEnvironment.newInstance(testWorkflowService, options))
+          .build();
+
+  @Rule
+  public CadenceTestRule secondDomain =
+      CadenceTestRule.builder()
+          .withDomain(DOMAIN2)
+          .withWorkflowTypes(WorkflowTest.TestWorkflowSignaledSimple.class)
+          .startWorkersAutomatically()
+          .withTestEnvironmentProvider(
+              options -> TestWorkflowEnvironment.newInstance(testWorkflowService, options))
+          .build();
+
+  public interface TestWorkflowCrossDomain {
+
+    @WorkflowMethod
+    String execute(String workflowId);
+  }
+
+  public static class TestWorkflowCrossDomainImpl implements TestWorkflowCrossDomain {
+
+    @Override
+    @WorkflowMethod
+    public String execute(String wfId) {
+      ExternalWorkflowStub externalWorkflow = Workflow.newUntypedExternalWorkflowStub(wfId);
+      SignalOptions options =
+          SignalOptions.newBuilder().setDomain(DOMAIN2).setSignalName("testSignal").build();
+      externalWorkflow.signal(options, "World");
+      return "Signaled External workflow";
+    }
+  }
+
+  @Test
+  public void testSignalCrossDomainExternalWorkflow()
+      throws ExecutionException, InterruptedException {
+
+    WorkflowOptions.Builder options = firstDomain.workflowOptionsBuilder();
+
+    String wfId = UUID.randomUUID().toString();
+    WorkflowOptions.Builder options2 = secondDomain.workflowOptionsBuilder().setWorkflowId(wfId);
+
+    TestWorkflowCrossDomain wf =
+        firstDomain
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflowCrossDomain.class, options.build());
+
+    WorkflowTest.TestWorkflowSignaled simpleWorkflow =
+        secondDomain
+            .getWorkflowClient()
+            .newWorkflowStub(WorkflowTest.TestWorkflowSignaled.class, options2.build());
+
+    CompletableFuture<String> result = WorkflowClient.execute(simpleWorkflow::execute);
+    assertEquals("Signaled External workflow", wf.execute(wfId));
+    assertEquals("Simple workflow signaled", result.get());
+  }
+}

--- a/src/test/java/com/uber/cadence/workflow/LoggerTest.java
+++ b/src/test/java/com/uber/cadence/workflow/LoggerTest.java
@@ -27,6 +27,7 @@ import com.uber.cadence.client.WorkflowClient;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.internal.logging.LoggerTag;
+import com.uber.cadence.testUtils.TestEnvironment;
 import com.uber.cadence.testing.TestEnvironmentOptions;
 import com.uber.cadence.testing.TestWorkflowEnvironment;
 import com.uber.cadence.worker.Worker;
@@ -90,7 +91,7 @@ public class LoggerTest {
   @Test
   public void testWorkflowLogger() {
     WorkflowClientOptions clientOptions =
-        WorkflowClientOptions.newBuilder().setDomain(WorkflowTest.DOMAIN).build();
+        WorkflowClientOptions.newBuilder().setDomain(TestEnvironment.DOMAIN).build();
     TestEnvironmentOptions testOptions =
         new TestEnvironmentOptions.Builder()
             .setWorkflowClientOptions(clientOptions)

--- a/src/test/java/com/uber/cadence/workflow/MetricsTest.java
+++ b/src/test/java/com/uber/cadence/workflow/MetricsTest.java
@@ -17,6 +17,7 @@
 
 package com.uber.cadence.workflow;
 
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -197,10 +198,7 @@ public class MetricsTest {
     Scope scope = new RootScopeBuilder().reporter(reporter).reportEvery(reportingFrequecy);
 
     WorkflowClientOptions clientOptions =
-        WorkflowClientOptions.newBuilder()
-            .setDomain(WorkflowTest.DOMAIN)
-            .setMetricsScope(scope)
-            .build();
+        WorkflowClientOptions.newBuilder().setDomain(DOMAIN).setMetricsScope(scope).build();
     TestEnvironmentOptions testOptions =
         new TestEnvironmentOptions.Builder().setWorkflowClientOptions(clientOptions).build();
     testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
@@ -229,7 +227,7 @@ public class MetricsTest {
 
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(2)
-            .put(MetricsTag.DOMAIN, WorkflowTest.DOMAIN)
+            .put(MetricsTag.DOMAIN, DOMAIN)
             .put(MetricsTag.TASK_LIST, taskList)
             .build();
 
@@ -252,7 +250,7 @@ public class MetricsTest {
 
     Map<String, String> activityCompletionTags =
         new ImmutableMap.Builder<String, String>(3)
-            .put(MetricsTag.DOMAIN, WorkflowTest.DOMAIN)
+            .put(MetricsTag.DOMAIN, DOMAIN)
             .put(MetricsTag.TASK_LIST, taskList)
             .put(MetricsTag.ACTIVITY_TYPE, "TestActivity::runActivity")
             .put(MetricsTag.WORKFLOW_TYPE, "TestWorkflow::execute")
@@ -293,7 +291,7 @@ public class MetricsTest {
 
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(2)
-            .put(MetricsTag.DOMAIN, WorkflowTest.DOMAIN)
+            .put(MetricsTag.DOMAIN, DOMAIN)
             .put(MetricsTag.TASK_LIST, taskList)
             .build();
     verify(reporter, times(1)).reportCounter(MetricsType.CORRUPTED_SIGNALS_COUNTER, tags, 1);

--- a/src/test/java/com/uber/cadence/workflow/WorkflowMigrationTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowMigrationTest.java
@@ -17,8 +17,8 @@
 
 package com.uber.cadence.workflow;
 
-import static com.uber.cadence.workflow.WorkflowTest.DOMAIN;
-import static com.uber.cadence.workflow.WorkflowTest.DOMAIN2;
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN;
+import static com.uber.cadence.testUtils.TestEnvironment.DOMAIN2;
 import static junit.framework.TestCase.fail;
 
 import com.uber.cadence.*;

--- a/src/test/java/com/uber/cadence/workflow/WorkflowReplayTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowReplayTest.java
@@ -1,0 +1,102 @@
+package com.uber.cadence.workflow;
+
+import com.uber.cadence.testing.WorkflowReplayer;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class WorkflowReplayTest {
+
+  // Server doesn't guarantee that the timer fire timestamp is larger or equal of the
+  // expected fire time. This test ensures that client still fires timer in this case.
+  @Test
+  public void testTimerFiringTimestampEarlierThanExpected() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "timerfiring.json", WorkflowTest.TimerFiringWorkflowImpl.class);
+  }
+
+  @Test
+  public void testWorkflowReset() throws Exception {
+    // Leave the following code to generate history.
+    //    startWorkerFor(TestWorkflowResetReplayWorkflow.class, TestMultiargsWorkflowsImpl.class);
+    //    TestWorkflow1 workflowStub =
+    //        workflowClient.newWorkflowStub(
+    //            TestWorkflow1.class, newWorkflowOptionsBuilder(taskList).build());
+    //    workflowStub.execute(taskList);
+    //
+    //    try {
+    //      Thread.sleep(60000000);
+    //    } catch (InterruptedException e) {
+    //      e.printStackTrace();
+    //    }
+
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "resetWorkflowHistory.json", WorkflowTest.TestWorkflowResetReplayWorkflow.class);
+  }
+
+  @Test
+  public void testGetVersionWithRetryReplay() throws Exception {
+
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testGetVersionWithRetryHistory.json", WorkflowTest.TestGetVersionWorkflowRetryImpl.class);
+  }
+
+  @Test
+  public void testGetVersionRemoveAndAdd() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testGetVersionHistory.json", WorkflowTest.TestGetVersionRemoveAndAddImpl.class);
+  }
+
+  /**
+   * Tests that history that was created before server side retry was supported is backwards
+   * compatible with the client that supports the server side retry.
+   */
+  @Test
+  public void testAsyncActivityRetryReplay() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testAsyncActivityRetryHistory.json", WorkflowTest.TestAsyncActivityRetry.class);
+  }
+
+  /**
+   * Tests that history created before marker header change is backwards compatible with old markers
+   * generated without headers.
+   */
+  @Test
+  // This test previously had a check for the incorrect test name and never ran. The json doesn't
+  // parse.
+  // Keeping it around in case we decide to fix it.
+  @Ignore
+  public void testMutableSideEffectReplay() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testMutableSideEffectBackwardCompatibility.json",
+        WorkflowTest.TestMutableSideEffectWorkflowImpl.class);
+  }
+
+  @Test
+  public void testGetVersionRemoved() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testGetVersionHistory.json", WorkflowTest.TestGetVersionRemovedImpl.class);
+  }
+
+  @Test
+  public void testGetVersionAdded() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testGetVersionHistory.json", WorkflowTest.TestGetVersionAddedImpl.class);
+  }
+
+  @Test
+  public void testGetVersionAddedWithCadenceChangeVersion() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testGetVersionHistoryWithCadenceChangeVersion.json",
+        WorkflowTest.TestGetVersionAddedImpl.class);
+  }
+
+  /**
+   * Tests that history that was created before server side retry was supported is backwards
+   * compatible with the client that supports the server side retry.
+   */
+  @Test
+  public void testChildWorkflowRetryReplay() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testChildWorkflowRetryHistory.json", WorkflowTest.TestChildWorkflowRetryWorkflow.class);
+  }
+}


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
- Refactor workflow initialization logic from WorkflowTest to CadenceTestRule, which can easily be used within in any test. 
  - The simplest example so far is in CrossDomainWorkflowTest, if you ignore that it's using two of them (and the withTestEnvironmentProvider nonsense).
- When run tests are run with USE_DOCKER_SERVICE=true they will run against a real Cadence instance. This is currently run as part of our CI.
- When debugging workflow executions you can change TestEnvironment.DEBUGGER_TIMEOUTS to significantly increase test, workflow, and activity timeouts.
- Tests can be annotated with @RequiresDockerService or @RequiresTestService to only execute in that environment. This also makes it much easier to find behavior disparity or gaps in our test coverage.

WorkflowTest is additionally parameterized by whether or not to use sticky execution. I think there are obviously cases where that makes sense but I don't think we need to do that in every test going forward.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Allow new tests to be easily written in separate files from the monolithic WorkflowTest.
- Simplify the initialization logic that tests need to worry about to handle running against both the test service and the real service.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Ran unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**