### PR TITLE
Report child workflow started synchronously in Test Implementation

### DIFF
--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1179,17 +1179,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
               .setWorkflowExecution(getExecutionId().getExecution())
               .setDomain(getExecutionId().getDomain())
               .setWorkflowType(startRequest.getWorkflowType());
-      ForkJoinPool.commonPool()
-          .execute(
-              () -> {
-                try {
-                  parent.get().childWorkflowStarted(a);
-                } catch (EntityNotExistsError | WorkflowExecutionAlreadyCompletedError e) {
-                  // Not a problem. Parent might just close by now.
-                } catch (BadRequestError | InternalServiceError e) {
-                  log.error("Failure reporting child completion", e);
-                }
-              });
+      try {
+        parent.get().childWorkflowStarted(a);
+      } catch (EntityNotExistsError | WorkflowExecutionAlreadyCompletedError e) {
+        // Not a problem. Parent might just close by now.
+      } catch (BadRequestError | InternalServiceError e) {
+        log.error("Failure reporting child completion", e);
+      }
     }
   }
 


### PR DESCRIPTION
By reporting child workflow started asynchronously we can observe a child workflow attempting to complete prior to its state machine registering that it started. This is an invalid state transition and causes test failures.

See https://github.com/uber/cadence-java-client/actions/runs/11508671742/job/32037318976 as the most recent occurrence of this issue.

Temporal addressed this issue in https://github.com/temporalio/sdk-java/pull/1289 due to the same test case failing..

<!-- Describe what has changed in this PR -->
**What changed?**
- Fixed cause of test failures

<!-- Tell your future self why have you made these changes -->
**Why?**

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
