### PR TITLE
Fix WorkflowQueue#offer and increase test coverage

### DIFF
--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowQueueImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowQueueImpl.java
@@ -74,10 +74,10 @@ final class WorkflowQueueImpl<E> implements WorkflowQueue<E> {
 
   @Override
   public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
-    boolean timedOut =
+    boolean success =
         WorkflowThread.await(
             unit.toMillis(timeout), "WorkflowQueue.offer", () -> queue.size() < capacity);
-    if (timedOut) {
+    if (!success) {
       return false;
     }
     queue.addLast(e);


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- WorkflowQueue#offer is misinterpreting the return value of WorkflowThread.await, resulting in it returning false whenever it can add an element to the queue or throwing an exception whenever it can't and the operation times out.
- Added additional test coverage for CompletablePromise

<!-- Tell your future self why have you made these changes -->
**Why?**
- Fix existing functionality

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
