### PR TITLE
Run license check as part of builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ googleJavaFormat {
     exclude '**/generated-sources/*'
 }
 
+tasks.googleJavaFormat.dependsOn 'license'
+
 group = 'com.uber.cadence'
 version = '3.12.5'
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Currently we have to run the license check manually. Run it before the formatter, which is run before compiling java.

<!-- Tell your future self why have you made these changes -->
**Why?**
So that I stop forgetting to add the license.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`./gradlew build`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
