### PR TITLE
remove raw history support

### DIFF
--- a/src/main/java/com/uber/cadence/internal/shadowing/ReplayWorkflowActivityImpl.java
+++ b/src/main/java/com/uber/cadence/internal/shadowing/ReplayWorkflowActivityImpl.java
@@ -19,12 +19,9 @@ import static com.uber.cadence.internal.errors.ErrorType.UNKNOWN_WORKFLOW_TYPE;
 
 import com.google.common.collect.Lists;
 import com.uber.cadence.GetWorkflowExecutionHistoryResponse;
-import com.uber.cadence.History;
 import com.uber.cadence.HistoryEvent;
-import com.uber.cadence.HistoryEventFilterType;
 import com.uber.cadence.activity.Activity;
 import com.uber.cadence.common.WorkflowExecutionHistory;
-import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.common.RpcRetryer;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.metrics.MetricsType;
@@ -185,14 +182,10 @@ public final class ReplayWorkflowActivityImpl implements ReplayWorkflowActivity 
                       nextPageToken, this.serviceClient, domain, execution.toThrift()));
       pageToken = resp.getNextPageToken();
 
-      // handle raw history
+      // TODO support raw history feature once server removes default Thrift encoding
       if (resp.getRawHistory() != null && resp.getRawHistory().size() > 0) {
-        History history =
-            InternalUtils.DeserializeFromBlobDataToHistory(
-                resp.getRawHistory(), HistoryEventFilterType.ALL_EVENT);
-        if (history != null && history.getEvents() != null) {
-          histories.addAll(history.getEvents());
-        }
+        throw new UnsupportedOperationException(
+            "Raw history is not supported. Please turn off frontend.sendRawWorkflowHistory feature flag in frontend service to recover");
       } else {
         histories.addAll(resp.getHistory().getEvents());
       }

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowStoreImpl.java
@@ -18,7 +18,6 @@
 package com.uber.cadence.internal.testservice;
 
 import com.uber.cadence.BadRequestError;
-import com.uber.cadence.DataBlob;
 import com.uber.cadence.EntityNotExistsError;
 import com.uber.cadence.EventType;
 import com.uber.cadence.GetWorkflowExecutionHistoryRequest;
@@ -34,7 +33,6 @@ import com.uber.cadence.PollForDecisionTaskResponse;
 import com.uber.cadence.StickyExecutionAttributes;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionInfo;
-import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.testservice.RequestContext.Timer;
 import java.time.Duration;
@@ -348,12 +346,10 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       if (!getRequest.isWaitForNewEvent()
           && getRequest.getHistoryEventFilterType() != HistoryEventFilterType.CLOSE_EVENT) {
         List<HistoryEvent> events = history.getEventsLocked();
-        List<DataBlob> blobs = InternalUtils.SerializeFromHistoryEventToBlobData(events);
         // Copy the list as it is mutable. Individual events assumed immutable.
         ArrayList<HistoryEvent> eventsCopy = new ArrayList<>(events);
         return new GetWorkflowExecutionHistoryResponse()
-            .setHistory(new History().setEvents(eventsCopy))
-            .setRawHistory(blobs);
+            .setHistory(new History().setEvents(eventsCopy));
       }
       expectedNextEventId = history.getNextEventIdLocked();
     } finally {
@@ -361,11 +357,9 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     }
     List<HistoryEvent> events =
         history.waitForNewEvents(expectedNextEventId, getRequest.getHistoryEventFilterType());
-    List<DataBlob> blobs = InternalUtils.SerializeFromHistoryEventToBlobData(events);
     GetWorkflowExecutionHistoryResponse result = new GetWorkflowExecutionHistoryResponse();
     if (events != null) {
       result.setHistory(new History().setEvents(events));
-      result.setRawHistory(blobs);
     }
     return result;
   }

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -28,7 +28,6 @@ import com.uber.cadence.*;
 import com.uber.cadence.WorkflowService.GetWorkflowExecutionHistory_result;
 import com.uber.cadence.internal.Version;
 import com.uber.cadence.internal.common.CheckedExceptionWrapper;
-import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.internal.metrics.ServiceMethod;
@@ -774,10 +773,8 @@ public class WorkflowServiceTChannel implements IWorkflowService {
       if (response.getResponseCode() == ResponseCode.OK) {
         GetWorkflowExecutionHistoryResponse res = result.getSuccess();
         if (res.getRawHistory() != null) {
-          History history =
-              InternalUtils.DeserializeFromBlobDataToHistory(
-                  res.getRawHistory(), getRequest.getHistoryEventFilterType());
-          res.setHistory(history);
+          throw new TException(
+              "Raw history is not supported. Please turn off frontend.sendRawWorkflowHistory feature flag in frontend service to recover");
         }
         return res;
       }
@@ -2601,10 +2598,8 @@ public class WorkflowServiceTChannel implements IWorkflowService {
                 if (r.getResponseCode() == ResponseCode.OK) {
                   GetWorkflowExecutionHistoryResponse res = result.getSuccess();
                   if (res.getRawHistory() != null) {
-                    History history =
-                        InternalUtils.DeserializeFromBlobDataToHistory(
-                            res.getRawHistory(), getRequest.getHistoryEventFilterType());
-                    res.setHistory(history);
+                    throw new TException(
+                        "Raw history is not supported. Please turn off frontend.sendRawWorkflowHistory feature flag in frontend service to recover");
                   }
                   resultHandler.onComplete(res);
                   return;

--- a/src/test/java/com/uber/cadence/internal/common/InternalUtilsTest.java
+++ b/src/test/java/com/uber/cadence/internal/common/InternalUtilsTest.java
@@ -17,23 +17,14 @@
 
 package com.uber.cadence.internal.common;
 
-import static com.uber.cadence.EventType.WorkflowExecutionStarted;
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
-import com.google.common.collect.Lists;
-import com.googlecode.junittoolbox.MultithreadingTester;
-import com.googlecode.junittoolbox.RunnableAssert;
 import com.uber.cadence.*;
 import com.uber.cadence.converter.DataConverterException;
 import com.uber.cadence.workflow.WorkflowUtils;
 import java.io.FileOutputStream;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import junit.framework.TestCase;
 import org.junit.Test;
 
 public class InternalUtilsTest {
@@ -55,102 +46,5 @@ public class InternalUtilsTest {
     Map<String, Object> attr = new HashMap<>();
     attr.put("InvalidValue", new FileOutputStream("dummy"));
     InternalUtils.convertMapToSearchAttributes(attr);
-  }
-
-  @Test
-  public void testSerialization_History() {
-
-    RunnableAssert r =
-        new RunnableAssert("history_serialization") {
-          @Override
-          public void run() {
-            HistoryEvent event =
-                new HistoryEvent()
-                    .setEventId(1)
-                    .setVersion(1)
-                    .setEventType(WorkflowExecutionStarted)
-                    .setTimestamp(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
-                    .setWorkflowExecutionStartedEventAttributes(
-                        new WorkflowExecutionStartedEventAttributes()
-                            .setAttempt(1)
-                            .setFirstExecutionRunId("test"));
-
-            List<HistoryEvent> historyEvents = Lists.newArrayList(event);
-            History history = new History().setEvents(historyEvents);
-            DataBlob blob = InternalUtils.SerializeFromHistoryToBlobData(history);
-            assertNotNull(blob);
-
-            try {
-              History result =
-                  InternalUtils.DeserializeFromBlobDataToHistory(
-                      Lists.newArrayList(blob), HistoryEventFilterType.ALL_EVENT);
-              assertNotNull(result);
-              assertEquals(1, result.events.size());
-              assertEquals(event.getEventId(), result.events.get(0).getEventId());
-              assertEquals(event.getVersion(), result.events.get(0).getVersion());
-              assertEquals(event.getEventType(), result.events.get(0).getEventType());
-              assertEquals(event.getTimestamp(), result.events.get(0).getTimestamp());
-              assertEquals(
-                  event.getWorkflowExecutionStartedEventAttributes(),
-                  result.events.get(0).getWorkflowExecutionStartedEventAttributes());
-            } catch (Exception e) {
-              TestCase.fail("Received unexpected error during deserialization");
-            }
-          }
-        };
-
-    try {
-      new MultithreadingTester().add(r).numThreads(50).numRoundsPerThread(10).run();
-    } catch (Exception e) {
-      TestCase.fail("Received unexpected error during concurrent deserialization");
-    }
-  }
-
-  @Test
-  public void testSerialization_HistoryEvent() {
-
-    RunnableAssert r =
-        new RunnableAssert("history_event_serialization") {
-          @Override
-          public void run() {
-            HistoryEvent event =
-                new HistoryEvent()
-                    .setEventId(1)
-                    .setVersion(1)
-                    .setEventType(WorkflowExecutionStarted)
-                    .setTimestamp(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
-                    .setWorkflowExecutionStartedEventAttributes(
-                        new WorkflowExecutionStartedEventAttributes()
-                            .setAttempt(1)
-                            .setFirstExecutionRunId("test"));
-
-            List<HistoryEvent> historyEvents = Lists.newArrayList(event);
-            List<DataBlob> blobList =
-                InternalUtils.SerializeFromHistoryEventToBlobData(historyEvents);
-            assertEquals(1, blobList.size());
-
-            try {
-              List<HistoryEvent> result =
-                  InternalUtils.DeserializeFromBlobDataToHistoryEvents(blobList);
-              assertNotNull(result);
-              assertEquals(1, result.size());
-              assertEquals(event.getEventId(), result.get(0).getEventId());
-              assertEquals(event.getVersion(), result.get(0).getVersion());
-              assertEquals(event.getEventType(), result.get(0).getEventType());
-              assertEquals(event.getTimestamp(), result.get(0).getTimestamp());
-              assertEquals(
-                  event.getWorkflowExecutionStartedEventAttributes(),
-                  result.get(0).getWorkflowExecutionStartedEventAttributes());
-            } catch (Exception e) {
-              TestCase.fail("Received unexpected error during deserialization");
-            }
-          }
-        };
-
-    try {
-      new MultithreadingTester().add(r).numThreads(50).numRoundsPerThread(10).run();
-    } catch (Exception e) {
-      TestCase.fail("Received unexpected error during concurrent deserialization");
-    }
   }
 }


### PR DESCRIPTION
What changed?

Remove raw history support in client. (It's already reviewed and merged in a side branch #1004 ) Now we are checking into main branch

Why?

History is stored as Thrift encoded binary. Sending raw history in Thrift will no longer be supported in V4

How did you test it?

Unit Test

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
