### PR TITLE
fix<data converter>: fail open on exception not found

### DIFF
--- a/src/main/java/com/uber/cadence/client/ApplicationFailureException.java
+++ b/src/main/java/com/uber/cadence/client/ApplicationFailureException.java
@@ -15,29 +15,10 @@
 package com.uber.cadence.client;
 
 import com.uber.cadence.CadenceError;
-import java.util.Objects;
 
 public final class ApplicationFailureException extends CadenceError {
 
   public ApplicationFailureException(String message) {
     super(message);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
-    }
-    ApplicationFailureException that = (ApplicationFailureException) obj;
-    return Objects.equals(getMessage(), that.getMessage())
-        && Objects.equals(getCause(), that.getCause());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(getMessage(), getCause());
   }
 }

--- a/src/main/java/com/uber/cadence/converter/CustomThrowableTypeAdapter.java
+++ b/src/main/java/com/uber/cadence/converter/CustomThrowableTypeAdapter.java
@@ -138,7 +138,7 @@ class CustomThrowableTypeAdapter<T extends Throwable> extends TypeAdapter<T> {
       try {
         classType = Class.forName(className);
       } catch (ClassNotFoundException e) {
-        return (T) new ApplicationFailureException("Class not found: " + className);
+        classType = ApplicationFailureException.class;
       }
       if (!Throwable.class.isAssignableFrom(classType)) {
         throw new IOException("Expected type that extends Throwable: " + className);

--- a/src/test/java/com/uber/cadence/converter/JsonDataConverterTest.java
+++ b/src/test/java/com/uber/cadence/converter/JsonDataConverterTest.java
@@ -287,8 +287,7 @@ public class JsonDataConverterTest {
             RuntimeException.class,
             RuntimeException.class);
     assertEquals(ApplicationFailureException.class, fromConverted.getClass());
-    assertEquals(
-        "Class not found: com.uber.cadence.converter.ExceptionNotFound",
-        fromConverted.getMessage());
+    assertEquals("application exception", fromConverted.getMessage());
+    assertNotSame(fromConverted.getStackTrace().length, 0);
   }
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Default data converter would throw I/O exception and thus fail workflow processing if the exception no longer exists. This PR changes the behavior by return null instead. 

<!-- Tell your future self why have you made these changes -->
**Why?**

In V4, thrift exceptions will be removed and thus this is needed to avoid breaking existing workflows.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
