### PR TITLE
feat: Dual emitting timer and histogram metrics

### DIFF
--- a/src/main/java/com/uber/cadence/internal/metrics/HistogramBuckets.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/HistogramBuckets.java
@@ -1,0 +1,207 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.metrics;
+
+import com.uber.m3.tally.DurationBuckets;
+import com.uber.m3.util.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Histogram bucket configurations for timer metrics migration.
+ *
+ * <p>This class defines standard histogram bucket configurations used during the migration from
+ * timers to histograms. These buckets provide consistent granularity for measuring latencies across
+ * different time ranges.
+ *
+ * <p>Note: Unlike the Go client which uses subsettable exponential histograms with algorithmic
+ * bucket generation, the Java client uses explicit bucket definitions. We provide multiple
+ * configurations to balance between granularity and cardinality:
+ *
+ * <ul>
+ *   <li><b>DEFAULT_1MS_100S</b>: Most common metrics (46 buckets, 1ms-100s)
+ *   <li><b>LOW_1MS_100S</b>: High-cardinality metrics (16 buckets, 1ms-100s)
+ *   <li><b>HIGH_1MS_24H</b>: Long-running operations (27 buckets, 1ms-24h)
+ *   <li><b>MID_1MS_24H</b>: High-cardinality long operations (14 buckets, 1ms-24h)
+ * </ul>
+ */
+public final class HistogramBuckets {
+
+  /**
+   * Default bucket configuration for most client-side latency metrics.
+   *
+   * <p>Range: 1ms to 100s
+   *
+   * <p>Provides: - Fine-grained buckets (1ms steps) from 1ms to 10ms - Medium-grained buckets (10ms
+   * steps) from 10ms to 100ms - Coarser buckets (100ms steps) from 100ms to 1s - Second-level
+   * buckets from 1s to 100s
+   *
+   * <p>Use for: - Decision poll latency - Activity poll latency - Decision execution latency -
+   * Activity execution latency - Workflow replay latency - Most RPC call latencies
+   */
+  public static final DurationBuckets DEFAULT_1MS_100S =
+      DurationBuckets.custom(
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(1)), // 1ms
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(2)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(3)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(4)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(5)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(6)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(7)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(8)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(9)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(20)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(30)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(40)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(50)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(60)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(70)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(80)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(90)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(100)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(200)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(300)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(400)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(500)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(600)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(700)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(800)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(900)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(2)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(3)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(4)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(5)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(6)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(7)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(8)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(9)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(20)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(30)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(40)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(50)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(60)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(70)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(80)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(90)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(100)));
+
+  /**
+   * Low-resolution bucket configuration for high-cardinality metrics.
+   *
+   * <p>Range: 1ms to 100s (same as DEFAULT_1MS_100S but with fewer buckets)
+   *
+   * <p>Provides: - Coarser buckets with ~2x steps instead of fine-grained steps - Approximately
+   * half the cardinality of DEFAULT_1MS_100S
+   *
+   * <p>Use for: - Per-activity-type metrics where cardinality is high - Per-workflow-type metrics
+   * where cardinality is high - Metrics with many tag combinations
+   */
+  public static final DurationBuckets LOW_1MS_100S =
+      DurationBuckets.custom(
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(2)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(5)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(20)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(50)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(100)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(200)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(500)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(2)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(5)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(20)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(50)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(100)));
+
+  /**
+   * High-resolution bucket configuration for long-running operations.
+   *
+   * <p>Range: 1ms to 24 hours
+   *
+   * <p>Provides: - Fine-grained buckets from 1ms to 10ms - Medium-grained from 10ms to 1s -
+   * Second-level buckets from 1s to 10 minutes - Minute-level buckets from 10 minutes to 24 hours
+   *
+   * <p>Use for: - Workflow end-to-end latency - Long-running activity execution latency - Multi-day
+   * operation metrics
+   */
+  public static final DurationBuckets HIGH_1MS_24H =
+      DurationBuckets.custom(
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(2)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(5)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(20)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(50)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(100)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(200)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(500)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(2)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(5)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(20)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(30)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(60)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(120)), // 2 min
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(300)), // 5 min
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(600)), // 10 min
+          Duration.ofNanos(TimeUnit.MINUTES.toNanos(20)),
+          Duration.ofNanos(TimeUnit.MINUTES.toNanos(30)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(2)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(4)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(8)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(12)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(24)));
+
+  /**
+   * Medium-resolution bucket configuration for long-running operations.
+   *
+   * <p>Range: 1ms to 24 hours (same as HIGH_1MS_24H but with fewer buckets)
+   *
+   * <p>Provides: - Coarser buckets than HIGH_1MS_24H - Better for high-cardinality long-duration
+   * metrics
+   *
+   * <p>Use for: - When HIGH_1MS_24H's cardinality is too high - Per-workflow-type E2E latency with
+   * many workflow types
+   */
+  public static final DurationBuckets MID_1MS_24H =
+      DurationBuckets.custom(
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(100)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(10)),
+          Duration.ofNanos(TimeUnit.SECONDS.toNanos(30)),
+          Duration.ofNanos(TimeUnit.MINUTES.toNanos(1)),
+          Duration.ofNanos(TimeUnit.MINUTES.toNanos(5)),
+          Duration.ofNanos(TimeUnit.MINUTES.toNanos(10)),
+          Duration.ofNanos(TimeUnit.MINUTES.toNanos(30)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(1)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(4)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(12)),
+          Duration.ofNanos(TimeUnit.HOURS.toNanos(24)));
+
+  private HistogramBuckets() {
+    // Utility class - prevent instantiation
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/metrics/MIGRATION.md
+++ b/src/main/java/com/uber/cadence/internal/metrics/MIGRATION.md
@@ -1,0 +1,173 @@
+# Timer to Histogram Migration
+
+## Overview
+
+This document describes the migration from timer metrics to histogram metrics in the Cadence Java client. The migration uses a dual-emit pattern where **both timer and histogram metrics are always emitted**, allowing for gradual migration of dashboards and alerts without requiring a coordinated flag day.
+
+## Why Migrate?
+
+Timers and histograms serve similar purposes (measuring latencies and durations) but have different characteristics:
+
+- **Timers**: Legacy approach, currently used throughout the codebase
+- **Histograms**: More flexible, better support for custom buckets and percentile calculations
+
+## Migration Strategy
+
+### Phase 1: Dual Emission (Current)
+
+Both timer and histogram metrics are emitted simultaneously:
+
+```java
+// Old code:
+Stopwatch sw = scope.timer(MetricsType.DECISION_POLL_LATENCY).start();
+// ... do work ...
+sw.stop();
+
+// New code (dual emit):
+DualStopwatch sw = MetricsEmit.startLatency(
+    scope,
+    MetricsType.DECISION_POLL_LATENCY,
+    HistogramBuckets.DEFAULT_1MS_100S
+);
+// ... do work ...
+sw.stop(); // Records to BOTH timer and histogram
+```
+
+### Phase 2: Dashboard/Alert Migration (Next)
+
+Update all dashboards and alerts to use histogram metrics instead of timer metrics. This can be done gradually since both are being emitted.
+
+### Phase 3: Remove Timer Emission (Future)
+
+Once all dashboards/alerts are migrated, remove timer emission:
+
+```java
+// Future code (histogram only):
+Stopwatch sw = scope.histogram(
+    MetricsType.DECISION_POLL_LATENCY,
+    HistogramBuckets.DEFAULT_1MS_100S
+).start();
+// ... do work ...
+sw.stop();
+```
+
+## Helper Classes
+
+### HistogramBuckets
+
+Defines standard bucket configurations:
+
+- `DEFAULT_1MS_100S`: For most latency measurements (1ms to 100s range)
+  - Fine-grained: 1ms steps from 1-10ms
+  - Medium-grained: 10ms steps from 10-100ms
+  - Coarse: 100ms steps from 100ms-1s
+  - Second-level: 1s steps from 1-100s
+  - Use for: Most RPC calls, decision/activity poll, execution latencies
+
+- `LOW_1MS_100S`: Low-resolution version for high-cardinality metrics (1ms to 100s)
+  - Approximately half the buckets of DEFAULT_1MS_100S
+  - Use for: Per-activity-type, per-workflow-type metrics with high cardinality
+
+- `HIGH_1MS_24H`: For long-running operations (1ms to 24 hours)
+  - Extended range for multi-hour workflows
+  - Use for: Workflow end-to-end latency, long-running activities
+
+- `MID_1MS_24H`: Lower-resolution version of HIGH_1MS_24H
+  - Fewer buckets than HIGH_1MS_24H
+  - Use for: When HIGH_1MS_24H's cardinality is too high
+
+### MetricsEmit
+
+Provides dual-emit helper methods:
+
+- `emitLatency(scope, name, duration, buckets)`: Directly record a duration
+- `startLatency(scope, name, buckets)`: Create a dual stopwatch
+
+### DualStopwatch
+
+A stopwatch wrapper that records to both timer and histogram when `.stop()` is called.
+
+## Migration Checklist
+
+For each timer metric:
+
+1. ✅ Identify the timer usage (e.g., `scope.timer(name).start()`)
+2. ✅ Replace with `MetricsEmit.startLatency(scope, name, buckets)`
+3. ✅ Choose appropriate bucket configuration (typically `HistogramBuckets.DEFAULT_1MS_100S`)
+4. ✅ Verify both metrics are being emitted
+5. ⏳ Update dashboards to use histogram metric
+6. ⏳ Update alerts to use histogram metric
+7. ⏳ (Future) Remove timer emission
+
+## Example Conversions
+
+### Example 1: Poll Latency
+
+```java
+// Before:
+Stopwatch sw = scope.timer(MetricsType.DECISION_POLL_LATENCY).start();
+PollForDecisionTaskResponse result = service.PollForDecisionTask(request);
+sw.stop();
+
+// After:
+DualStopwatch sw = MetricsEmit.startLatency(
+    scope,
+    MetricsType.DECISION_POLL_LATENCY,
+    HistogramBuckets.DEFAULT_1MS_100S
+);
+PollForDecisionTaskResponse result = service.PollForDecisionTask(request);
+sw.stop();
+```
+
+### Example 2: Execution Latency
+
+```java
+// Before:
+Stopwatch sw = metricsScope.timer(MetricsType.ACTIVITY_EXEC_LATENCY).start();
+Result response = handler.handle(task, metricsScope, false);
+sw.stop();
+
+// After:
+DualStopwatch sw = MetricsEmit.startLatency(
+    metricsScope,
+    MetricsType.ACTIVITY_EXEC_LATENCY,
+    HistogramBuckets.DEFAULT_1MS_100S
+);
+Result response = handler.handle(task, metricsScope, false);
+sw.stop();
+```
+
+### Example 3: Direct Duration Recording
+
+```java
+// Before:
+Duration scheduledToStartLatency = Duration.between(scheduledTime, startedTime);
+scope.timer(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY).record(scheduledToStartLatency);
+
+// After:
+Duration scheduledToStartLatency = Duration.between(scheduledTime, startedTime);
+MetricsEmit.emitLatency(
+    scope,
+    MetricsType.DECISION_SCHEDULED_TO_START_LATENCY,
+    scheduledToStartLatency,
+    HistogramBuckets.DEFAULT_1MS_100S
+);
+```
+
+## Testing
+
+The migration preserves existing timer behavior while adding histogram emission, so:
+
+- Existing timer-based tests continue to work
+- Existing timer-based dashboards/alerts continue to work
+- New histogram metrics are available for gradual migration
+
+## Timeline
+
+1. **Now**: Dual emission in place, both metrics available
+2. **Next Quarter**: Migrate dashboards and alerts to histograms
+3. **Future Release**: Remove timer emission, histogram-only
+
+## Questions?
+
+Contact the Cadence team for guidance on specific metrics or migration questions.

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
@@ -35,6 +35,10 @@ import com.uber.m3.util.Duration;
  *
  * <p>Example usage:
  *
+ * <p>In EMIT_BOTH mode, the timer uses the original metric name and the histogram uses the same
+ * name with a {@code _ns} suffix (e.g. {@code cadence-decision-poll-latency} for the timer and
+ * {@code cadence-decision-poll-latency_ns} for the histogram), consistent with the Go client.
+ *
  * <pre>{@code
  * // Direct latency recording
  * Duration latency = Duration.ofMillis(150);
@@ -102,19 +106,26 @@ public final class MetricsEmit {
   }
 
   /**
+   * Suffix appended to the timer metric name to form the histogram metric name when dual-emitting.
+   * Consistent with the Go client naming convention.
+   */
+  static final String HISTOGRAM_SUFFIX = "_ns";
+
+  /**
    * Records latency based on the current emit mode setting.
    *
    * <p>This helper function supports flexible metric emission during timer→histogram migration. The
    * behavior depends on the current emit mode:
    *
    * <ul>
-   *   <li>EMIT_TIMERS_ONLY: Only timer metrics are emitted
-   *   <li>EMIT_BOTH: Both timer and histogram metrics are emitted (default)
-   *   <li>EMIT_HISTOGRAMS_ONLY: Only histogram metrics are emitted
+   *   <li>EMIT_TIMERS_ONLY: Only timer metrics are emitted (using {@code name})
+   *   <li>EMIT_BOTH: Both timer and histogram metrics are emitted (timer uses {@code name},
+   *       histogram uses {@code name + "_ns"})
+   *   <li>EMIT_HISTOGRAMS_ONLY: Only histogram metrics are emitted (using {@code name + "_ns"})
    * </ul>
    *
    * @param scope The tally scope to emit metrics to
-   * @param name The metric name (without suffix)
+   * @param name The timer metric name; histogram name is derived by appending {@code _ns}
    * @param latency The duration to record
    * @param buckets The histogram bucket configuration to use
    */
@@ -126,10 +137,10 @@ public final class MetricsEmit {
         break;
       case EMIT_BOTH:
         scope.timer(name).record(latency);
-        scope.histogram(name, buckets).recordDuration(latency);
+        scope.histogram(name + HISTOGRAM_SUFFIX, buckets).recordDuration(latency);
         break;
       case EMIT_HISTOGRAMS_ONLY:
-        scope.histogram(name, buckets).recordDuration(latency);
+        scope.histogram(name + HISTOGRAM_SUFFIX, buckets).recordDuration(latency);
         break;
     }
   }
@@ -138,10 +149,10 @@ public final class MetricsEmit {
    * Creates a stopwatch that emits based on current emit mode setting.
    *
    * <p>Call .stop() on the returned stopwatch to record the duration. The behavior depends on the
-   * current emit mode.
+   * current emit mode. The timer uses {@code name} and the histogram uses {@code name + "_ns"}.
    *
    * @param scope The tally scope to emit metrics to
-   * @param name The metric name (without suffix)
+   * @param name The timer metric name; histogram name is derived by appending {@code _ns}
    * @param buckets The histogram bucket configuration to use
    * @return A dual stopwatch that records based on emit mode
    */
@@ -156,10 +167,10 @@ public final class MetricsEmit {
         break;
       case EMIT_BOTH:
         timerSW = scope.timer(name).start();
-        histogramSW = scope.histogram(name, buckets).start();
+        histogramSW = scope.histogram(name + HISTOGRAM_SUFFIX, buckets).start();
         break;
       case EMIT_HISTOGRAMS_ONLY:
-        histogramSW = scope.histogram(name, buckets).start();
+        histogramSW = scope.histogram(name + HISTOGRAM_SUFFIX, buckets).start();
         break;
     }
 

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
@@ -109,7 +109,7 @@ public final class MetricsEmit {
    * Suffix appended to the timer metric name to form the histogram metric name when dual-emitting.
    * Consistent with the Go client naming convention.
    */
-  static final String HISTOGRAM_SUFFIX = "_ns";
+  public static final String HISTOGRAM_SUFFIX = "_ns";
 
   /**
    * Records latency based on the current emit mode setting.

--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
@@ -1,0 +1,214 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.metrics;
+
+import com.uber.m3.tally.DurationBuckets;
+import com.uber.m3.tally.Scope;
+import com.uber.m3.tally.Stopwatch;
+import com.uber.m3.util.Duration;
+
+/**
+ * Helper utilities for dual-emitting metrics during timer to histogram migration.
+ *
+ * <p>This class provides utilities to support gradual migration from timer metrics to histogram
+ * metrics. By default, both timer and histogram metrics are emitted to support gradual
+ * dashboard/alert migration without requiring a flag day.
+ *
+ * <p>Migration path: 1. Use these helpers to emit both timers and histograms (default behavior) 2.
+ * Update dashboards/alerts to use histogram metrics 3. In a future release, remove timer emission
+ * and use histograms exclusively
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * // Direct latency recording
+ * Duration latency = Duration.ofMillis(150);
+ * MetricsEmit.emitLatency(scope, MetricsType.DECISION_POLL_LATENCY, latency, HistogramBuckets.DEFAULT_1MS_100S);
+ *
+ * // Using stopwatch
+ * DualStopwatch sw = MetricsEmit.startLatency(scope, MetricsType.ACTIVITY_EXEC_LATENCY, HistogramBuckets.DEFAULT_1MS_100S);
+ * // ... do work ...
+ * sw.stop();
+ *
+ * // Configure emission mode (optional, typically done at application startup)
+ * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
+ * }</pre>
+ */
+public final class MetricsEmit {
+
+  /** Metric emission mode controls which metrics are emitted for latency measurements. */
+  public enum MetricEmitMode {
+    /** Emit only timer metrics (legacy OSS behavior) */
+    EMIT_TIMERS_ONLY,
+    /** Emit both timer and histogram metrics (default for migration) */
+    EMIT_BOTH,
+    /** Emit only histogram metrics (post-migration) */
+    EMIT_HISTOGRAMS_ONLY
+  }
+
+  /**
+   * Current emission mode. Default is EMIT_BOTH for migration. This should be set during
+   * application initialization (e.g., in static initializer or before starting workers). It should
+   * NOT be changed dynamically after workers have started.
+   */
+  private static volatile MetricEmitMode currentEmitMode = MetricEmitMode.EMIT_BOTH;
+
+  /**
+   * Configures the metric emission strategy. This should be called during application
+   * initialization, before any metrics are emitted.
+   *
+   * @param mode The emission mode to use
+   *     <p>Example usage:
+   *     <pre>{@code
+   * // To use only timers (legacy behavior)
+   * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_TIMERS_ONLY);
+   *
+   * // To use both (default, for migration)
+   * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
+   *
+   * // To use only histograms (post-migration)
+   * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
+   * }</pre>
+   */
+  public static void setEmitMode(MetricEmitMode mode) {
+    if (mode == null) {
+      throw new IllegalArgumentException("MetricEmitMode cannot be null");
+    }
+    currentEmitMode = mode;
+  }
+
+  /**
+   * Returns the current emission mode.
+   *
+   * @return The current emission mode
+   */
+  public static MetricEmitMode getEmitMode() {
+    return currentEmitMode;
+  }
+
+  /**
+   * Records latency based on the current emit mode setting.
+   *
+   * <p>This helper function supports flexible metric emission during timer→histogram migration. The
+   * behavior depends on the current emit mode:
+   *
+   * <ul>
+   *   <li>EMIT_TIMERS_ONLY: Only timer metrics are emitted
+   *   <li>EMIT_BOTH: Both timer and histogram metrics are emitted (default)
+   *   <li>EMIT_HISTOGRAMS_ONLY: Only histogram metrics are emitted
+   * </ul>
+   *
+   * @param scope The tally scope to emit metrics to
+   * @param name The metric name (without suffix)
+   * @param latency The duration to record
+   * @param buckets The histogram bucket configuration to use
+   */
+  public static void emitLatency(
+      Scope scope, String name, Duration latency, DurationBuckets buckets) {
+    switch (currentEmitMode) {
+      case EMIT_TIMERS_ONLY:
+        scope.timer(name).record(latency);
+        break;
+      case EMIT_BOTH:
+        scope.timer(name).record(latency);
+        scope.histogram(name, buckets).recordDuration(latency);
+        break;
+      case EMIT_HISTOGRAMS_ONLY:
+        scope.histogram(name, buckets).recordDuration(latency);
+        break;
+    }
+  }
+
+  /**
+   * Creates a stopwatch that emits based on current emit mode setting.
+   *
+   * <p>Call .stop() on the returned stopwatch to record the duration. The behavior depends on the
+   * current emit mode.
+   *
+   * @param scope The tally scope to emit metrics to
+   * @param name The metric name (without suffix)
+   * @param buckets The histogram bucket configuration to use
+   * @return A dual stopwatch that records based on emit mode
+   */
+  public static DualStopwatch startLatency(Scope scope, String name, DurationBuckets buckets) {
+    MetricEmitMode mode = currentEmitMode;
+    Stopwatch timerSW = null;
+    Stopwatch histogramSW = null;
+
+    switch (mode) {
+      case EMIT_TIMERS_ONLY:
+        timerSW = scope.timer(name).start();
+        break;
+      case EMIT_BOTH:
+        timerSW = scope.timer(name).start();
+        histogramSW = scope.histogram(name, buckets).start();
+        break;
+      case EMIT_HISTOGRAMS_ONLY:
+        histogramSW = scope.histogram(name, buckets).start();
+        break;
+    }
+
+    return new DualStopwatch(timerSW, histogramSW, mode);
+  }
+
+  /**
+   * A stopwatch that emits metrics based on the emit mode setting.
+   *
+   * <p>This supports flexible metric emission during timer→histogram migration. The metrics emitted
+   * depend on the mode captured when the stopwatch was started.
+   */
+  public static class DualStopwatch {
+    private final Stopwatch timerSW;
+    private final Stopwatch histogramSW;
+    private final MetricEmitMode mode;
+
+    DualStopwatch(Stopwatch timerSW, Stopwatch histogramSW, MetricEmitMode mode) {
+      this.timerSW = timerSW;
+      this.histogramSW = histogramSW;
+      this.mode = mode;
+    }
+
+    /** Stops and records the elapsed time based on emit mode setting. */
+    public void stop() {
+      switch (mode) {
+        case EMIT_TIMERS_ONLY:
+          if (timerSW != null) {
+            timerSW.stop();
+          }
+          break;
+        case EMIT_BOTH:
+          if (timerSW != null) {
+            timerSW.stop();
+          }
+          if (histogramSW != null) {
+            histogramSW.stop();
+          }
+          break;
+        case EMIT_HISTOGRAMS_ONLY:
+          if (histogramSW != null) {
+            histogramSW.stop();
+          }
+          break;
+      }
+    }
+  }
+
+  private MetricsEmit() {
+    // Utility class - prevent instantiation
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ReplayDecider.java
@@ -24,6 +24,8 @@ import com.uber.cadence.*;
 import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.internal.common.OptionsUtils;
 import com.uber.cadence.internal.common.RpcRetryer;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.internal.replay.HistoryHelper.DecisionEvents;
@@ -35,7 +37,6 @@ import com.uber.cadence.internal.worker.WorkflowExecutionException;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.workflow.Functions;
 import com.uber.m3.tally.Scope;
-import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -299,7 +300,8 @@ class ReplayDecider implements Decider {
 
     long nanoTime = TimeUnit.NANOSECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
     com.uber.m3.util.Duration d = com.uber.m3.util.Duration.ofNanos(nanoTime - wfStartTimeNanos);
-    metricsScope.timer(MetricsType.WORKFLOW_E2E_LATENCY).record(d);
+    MetricsEmit.emitLatency(
+        metricsScope, MetricsType.WORKFLOW_E2E_LATENCY, d, HistogramBuckets.HIGH_1MS_24H);
   }
 
   private void updateTimers() {
@@ -667,7 +669,11 @@ class ReplayDecider implements Decider {
           }
 
           metricsScope.counter(MetricsType.WORKFLOW_GET_HISTORY_COUNTER).inc(1);
-          Stopwatch sw = metricsScope.timer(MetricsType.WORKFLOW_GET_HISTORY_LATENCY).start();
+          MetricsEmit.DualStopwatch sw =
+              MetricsEmit.startLatency(
+                  metricsScope,
+                  MetricsType.WORKFLOW_GET_HISTORY_LATENCY,
+                  HistogramBuckets.DEFAULT_1MS_100S);
           RetryOptions retryOptions =
               new RetryOptions.Builder()
                   .setExpiration(decisionTaskRemainingTime)

--- a/src/main/java/com/uber/cadence/internal/shadowing/ReplayWorkflowActivityImpl.java
+++ b/src/main/java/com/uber/cadence/internal/shadowing/ReplayWorkflowActivityImpl.java
@@ -24,6 +24,8 @@ import com.uber.cadence.activity.Activity;
 import com.uber.cadence.common.WorkflowExecutionHistory;
 import com.uber.cadence.internal.common.RpcRetryer;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.testing.TestEnvironmentOptions;
@@ -32,7 +34,6 @@ import com.uber.cadence.worker.Worker;
 import com.uber.cadence.worker.WorkflowImplementationOptions;
 import com.uber.cadence.workflow.Functions;
 import com.uber.m3.tally.Scope;
-import com.uber.m3.tally.Stopwatch;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -197,7 +198,9 @@ public final class ReplayWorkflowActivityImpl implements ReplayWorkflowActivity 
   protected boolean replayWorkflowHistory(
       String domain, WorkflowExecution execution, WorkflowExecutionHistory workflowHistory)
       throws Exception {
-    Stopwatch sw = this.metricsScope.timer(MetricsType.REPLAY_LATENCY).start();
+    MetricsEmit.DualStopwatch sw =
+        MetricsEmit.startLatency(
+            this.metricsScope, MetricsType.REPLAY_LATENCY, HistogramBuckets.DEFAULT_1MS_100S);
     try {
       worker.replayWorkflowExecution(workflowHistory);
     } catch (Exception e) {

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityPollTask.java
@@ -22,10 +22,11 @@ import static com.uber.cadence.internal.metrics.MetricsTagValue.SERVICE_BUSY;
 
 import com.google.common.collect.ImmutableMap;
 import com.uber.cadence.*;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
-import com.uber.m3.tally.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,11 @@ final class ActivityPollTask extends ActivityPollTaskBase {
   @Override
   protected PollForActivityTaskResponse pollTask() throws CadenceError {
     options.getMetricsScope().counter(MetricsType.ACTIVITY_POLL_COUNTER).inc(1);
-    Stopwatch sw = options.getMetricsScope().timer(MetricsType.ACTIVITY_POLL_LATENCY).start();
+    MetricsEmit.DualStopwatch sw =
+        MetricsEmit.startLatency(
+            options.getMetricsScope(),
+            MetricsType.ACTIVITY_POLL_LATENCY,
+            HistogramBuckets.DEFAULT_1MS_100S);
     PollForActivityTaskRequest pollRequest = new PollForActivityTaskRequest();
     pollRequest.setDomain(domain);
     pollRequest.setIdentity(options.getIdentity());

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityPollTaskBase.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityPollTaskBase.java
@@ -19,6 +19,8 @@ package com.uber.cadence.internal.worker;
 
 import com.uber.cadence.CadenceError;
 import com.uber.cadence.PollForActivityTaskResponse;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.m3.tally.Scope;
@@ -50,11 +52,12 @@ abstract class ActivityPollTaskBase implements Poller.PollTask<PollForActivityTa
                     MetricsTag.WORKFLOW_TYPE,
                     result.getWorkflowType().getName()));
     metricsScope.counter(MetricsType.ACTIVITY_POLL_SUCCEED_COUNTER).inc(1);
-    metricsScope
-        .timer(MetricsType.ACTIVITY_SCHEDULED_TO_START_LATENCY)
-        .record(
-            Duration.ofNanos(
-                result.getStartedTimestamp() - result.getScheduledTimestampOfThisAttempt()));
+    MetricsEmit.emitLatency(
+        metricsScope,
+        MetricsType.ACTIVITY_SCHEDULED_TO_START_LATENCY,
+        Duration.ofNanos(
+            result.getStartedTimestamp() - result.getScheduledTimestampOfThisAttempt()),
+        HistogramBuckets.HIGH_1MS_24H);
     return result;
   }
 

--- a/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityWorker.java
@@ -21,6 +21,8 @@ import com.uber.cadence.*;
 import com.uber.cadence.context.ContextPropagator;
 import com.uber.cadence.internal.common.RpcRetryer;
 import com.uber.cadence.internal.logging.LoggerTag;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.internal.tracing.TracingPropagator;
@@ -28,7 +30,6 @@ import com.uber.cadence.internal.worker.ActivityTaskHandler.Result;
 import com.uber.cadence.internal.worker.Poller.PollTask;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Scope;
-import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 import io.opentracing.Span;
@@ -127,11 +128,11 @@ public class ActivityWorker extends SuspendableWorkerBase {
                       MetricsTag.WORKFLOW_TYPE,
                       task.getWorkflowType().getName()));
 
-      metricsScope
-          .timer(MetricsType.ACTIVITY_SCHEDULED_TO_START_LATENCY)
-          .record(
-              Duration.ofNanos(
-                  task.getStartedTimestamp() - task.getScheduledTimestampOfThisAttempt()));
+      MetricsEmit.emitLatency(
+          metricsScope,
+          MetricsType.ACTIVITY_SCHEDULED_TO_START_LATENCY,
+          Duration.ofNanos(task.getStartedTimestamp() - task.getScheduledTimestampOfThisAttempt()),
+          HistogramBuckets.HIGH_1MS_24H);
 
       // The following tags are for logging.
       MDC.put(LoggerTag.ACTIVITY_ID, task.getActivityId());
@@ -143,25 +144,35 @@ public class ActivityWorker extends SuspendableWorkerBase {
       propagateContext(task);
       Span span = spanFactory.spanForExecuteActivity(task);
       try (io.opentracing.Scope scope = tracer.activateSpan(span)) {
-        Stopwatch sw = metricsScope.timer(MetricsType.ACTIVITY_EXEC_LATENCY).start();
+        MetricsEmit.DualStopwatch sw =
+            MetricsEmit.startLatency(
+                metricsScope, MetricsType.ACTIVITY_EXEC_LATENCY, HistogramBuckets.HIGH_1MS_24H);
         ActivityTaskHandler.Result response = handler.handle(task, metricsScope, false);
         sw.stop();
 
-        sw = metricsScope.timer(MetricsType.ACTIVITY_RESP_LATENCY).start();
+        sw =
+            MetricsEmit.startLatency(
+                metricsScope, MetricsType.ACTIVITY_RESP_LATENCY, HistogramBuckets.DEFAULT_1MS_100S);
         sendReply(task, response, metricsScope);
         sw.stop();
 
         long nanoTime =
             TimeUnit.NANOSECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
         Duration duration = Duration.ofNanos(nanoTime - task.getScheduledTimestampOfThisAttempt());
-        metricsScope.timer(MetricsType.ACTIVITY_E2E_LATENCY).record(duration);
+        MetricsEmit.emitLatency(
+            metricsScope,
+            MetricsType.ACTIVITY_E2E_LATENCY,
+            duration,
+            HistogramBuckets.HIGH_1MS_24H);
 
       } catch (CancellationException e) {
         RespondActivityTaskCanceledRequest cancelledRequest =
             new RespondActivityTaskCanceledRequest();
         cancelledRequest.setDetails(
             String.valueOf(e.getMessage()).getBytes(StandardCharsets.UTF_8));
-        Stopwatch sw = metricsScope.timer(MetricsType.ACTIVITY_RESP_LATENCY).start();
+        MetricsEmit.DualStopwatch sw =
+            MetricsEmit.startLatency(
+                metricsScope, MetricsType.ACTIVITY_RESP_LATENCY, HistogramBuckets.DEFAULT_1MS_100S);
         sendReply(task, new Result(null, null, cancelledRequest), metricsScope);
         sw.stop();
       } finally {

--- a/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/LocalActivityWorker.java
@@ -24,13 +24,14 @@ import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.common.RetryOptions;
 import com.uber.cadence.context.ContextPropagator;
 import com.uber.cadence.internal.common.LocalActivityMarkerData;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.internal.replay.ClockDecisionContext;
 import com.uber.cadence.internal.replay.ExecuteLocalActivityParameters;
 import com.uber.cadence.internal.tracing.TracingPropagator;
 import com.uber.m3.tally.Scope;
-import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -198,7 +199,11 @@ public final class LocalActivityWorker extends SuspendableWorkerBase {
       pollTask.setInput(task.params.getInput());
       pollTask.setAttempt(task.params.getAttempt());
 
-      Stopwatch sw = metricsScope.timer(MetricsType.LOCAL_ACTIVITY_EXECUTION_LATENCY).start();
+      MetricsEmit.DualStopwatch sw =
+          MetricsEmit.startLatency(
+              metricsScope,
+              MetricsType.LOCAL_ACTIVITY_EXECUTION_LATENCY,
+              HistogramBuckets.DEFAULT_1MS_100S);
       ActivityTaskHandler.Result result = handler.handle(pollTask, metricsScope, true);
       sw.stop();
       result.setAttempt(task.params.getAttempt());

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowPollTask.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowPollTask.java
@@ -22,11 +22,12 @@ import static com.uber.cadence.internal.metrics.MetricsTagValue.SERVICE_BUSY;
 
 import com.uber.cadence.*;
 import com.uber.cadence.common.BinaryChecksum;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Scope;
-import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 import java.util.Objects;
@@ -61,7 +62,9 @@ final class WorkflowPollTask implements Poller.PollTask<PollForDecisionTaskRespo
   @Override
   public PollForDecisionTaskResponse poll() throws CadenceError {
     metricScope.counter(MetricsType.DECISION_POLL_COUNTER).inc(1);
-    Stopwatch sw = metricScope.timer(MetricsType.DECISION_POLL_LATENCY).start();
+    MetricsEmit.DualStopwatch sw =
+        MetricsEmit.startLatency(
+            metricScope, MetricsType.DECISION_POLL_LATENCY, HistogramBuckets.DEFAULT_1MS_100S);
 
     PollForDecisionTaskRequest pollRequest = new PollForDecisionTaskRequest();
     pollRequest.setDomain(domain);
@@ -118,9 +121,13 @@ final class WorkflowPollTask implements Poller.PollTask<PollForDecisionTaskRespo
         metricScope.tagged(
             ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, result.getWorkflowType().getName()));
     metricsScope.counter(MetricsType.DECISION_POLL_SUCCEED_COUNTER).inc(1);
-    metricsScope
-        .timer(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY)
-        .record(Duration.ofNanos(result.getStartedTimestamp() - result.getScheduledTimestamp()));
+    Duration scheduledToStartLatency =
+        Duration.ofNanos(result.getStartedTimestamp() - result.getScheduledTimestamp());
+    MetricsEmit.emitLatency(
+        metricsScope,
+        MetricsType.DECISION_SCHEDULED_TO_START_LATENCY,
+        scheduledToStartLatency,
+        HistogramBuckets.DEFAULT_1MS_100S);
     sw.stop();
     return result;
   }

--- a/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
+++ b/src/main/java/com/uber/cadence/internal/worker/WorkflowWorker.java
@@ -24,12 +24,13 @@ import com.uber.cadence.common.WorkflowExecutionHistory;
 import com.uber.cadence.internal.common.RpcRetryer;
 import com.uber.cadence.internal.common.WorkflowExecutionUtils;
 import com.uber.cadence.internal.logging.LoggerTag;
+import com.uber.cadence.internal.metrics.HistogramBuckets;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.internal.worker.LocallyDispatchedActivityWorker.Task;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Scope;
-import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -201,11 +202,19 @@ public final class WorkflowWorker extends SuspendableWorkerBase
       }
 
       try {
-        Stopwatch sw = metricsScope.timer(MetricsType.DECISION_EXECUTION_LATENCY).start();
+        MetricsEmit.DualStopwatch sw =
+            MetricsEmit.startLatency(
+                metricsScope,
+                MetricsType.DECISION_EXECUTION_LATENCY,
+                HistogramBuckets.DEFAULT_1MS_100S);
         DecisionTaskHandler.Result response = handler.handleDecisionTask(task);
         sw.stop();
 
-        sw = metricsScope.timer(MetricsType.DECISION_RESPONSE_LATENCY).start();
+        sw =
+            MetricsEmit.startLatency(
+                metricsScope,
+                MetricsType.DECISION_RESPONSE_LATENCY,
+                HistogramBuckets.DEFAULT_1MS_100S);
         sendReply(service, task, response);
         sw.stop();
 

--- a/src/test/java/com/uber/cadence/internal/metrics/MetricsEmitTest.java
+++ b/src/test/java/com/uber/cadence/internal/metrics/MetricsEmitTest.java
@@ -58,7 +58,7 @@ public class MetricsEmitTest {
   @Test
   public void testEmitLatency_DualEmit() {
     when(mockScope.timer("test-metric")).thenReturn(mockTimer);
-    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockScope.histogram(eq("test-metric_ns"), any())).thenReturn(mockHistogram);
 
     Duration latency = Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(150));
     MetricsEmit.emitLatency(mockScope, "test-metric", latency, HistogramBuckets.DEFAULT_1MS_100S);
@@ -75,7 +75,7 @@ public class MetricsEmitTest {
 
     when(mockScope.timer("test-metric")).thenReturn(mockTimer);
     when(mockTimer.start()).thenReturn(mockTimerSW);
-    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockScope.histogram(eq("test-metric_ns"), any())).thenReturn(mockHistogram);
     when(mockHistogram.start()).thenReturn(mockHistogramSW);
 
     MetricsEmit.DualStopwatch sw =
@@ -96,7 +96,7 @@ public class MetricsEmitTest {
 
     when(mockScope.timer("test-metric")).thenReturn(mockTimer);
     when(mockTimer.start()).thenReturn(mockTimerSW);
-    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockScope.histogram(eq("test-metric_ns"), any())).thenReturn(mockHistogram);
     when(mockHistogram.start()).thenReturn(mockHistogramSW);
 
     MetricsEmit.DualStopwatch sw =
@@ -174,7 +174,7 @@ public class MetricsEmitTest {
   public void testEmitLatency_HistogramsOnly() {
     MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
 
-    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockScope.histogram(eq("test-metric_ns"), any())).thenReturn(mockHistogram);
 
     Duration latency = Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(150));
     MetricsEmit.emitLatency(mockScope, "test-metric", latency, HistogramBuckets.DEFAULT_1MS_100S);
@@ -209,7 +209,7 @@ public class MetricsEmitTest {
 
     Stopwatch mockHistogramSW = mock(Stopwatch.class);
 
-    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockScope.histogram(eq("test-metric_ns"), any())).thenReturn(mockHistogram);
     when(mockHistogram.start()).thenReturn(mockHistogramSW);
 
     MetricsEmit.DualStopwatch sw =

--- a/src/test/java/com/uber/cadence/internal/metrics/MetricsEmitTest.java
+++ b/src/test/java/com/uber/cadence/internal/metrics/MetricsEmitTest.java
@@ -1,0 +1,224 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.metrics;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.uber.cadence.internal.metrics.MetricsEmit.MetricEmitMode;
+import com.uber.m3.tally.Histogram;
+import com.uber.m3.tally.Scope;
+import com.uber.m3.tally.Stopwatch;
+import com.uber.m3.tally.Timer;
+import com.uber.m3.util.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MetricsEmitTest {
+
+  private Scope mockScope;
+  private Timer mockTimer;
+  private Histogram mockHistogram;
+  private MetricEmitMode originalMode;
+
+  @Before
+  public void setUp() {
+    mockScope = mock(Scope.class);
+    mockTimer = mock(Timer.class);
+    mockHistogram = mock(Histogram.class);
+    // Save original mode to restore after each test
+    originalMode = MetricsEmit.getEmitMode();
+    // Reset to default mode for each test
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
+  }
+
+  @After
+  public void tearDown() {
+    // Restore original mode after each test
+    MetricsEmit.setEmitMode(originalMode);
+  }
+
+  @Test
+  public void testEmitLatency_DualEmit() {
+    when(mockScope.timer("test-metric")).thenReturn(mockTimer);
+    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+
+    Duration latency = Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(150));
+    MetricsEmit.emitLatency(mockScope, "test-metric", latency, HistogramBuckets.DEFAULT_1MS_100S);
+
+    // Verify both timer and histogram received the latency
+    verify(mockTimer, times(1)).record(latency);
+    verify(mockHistogram, times(1)).recordDuration(latency);
+  }
+
+  @Test
+  public void testStartLatency_DualEmit() {
+    Stopwatch mockTimerSW = mock(Stopwatch.class);
+    Stopwatch mockHistogramSW = mock(Stopwatch.class);
+
+    when(mockScope.timer("test-metric")).thenReturn(mockTimer);
+    when(mockTimer.start()).thenReturn(mockTimerSW);
+    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockHistogram.start()).thenReturn(mockHistogramSW);
+
+    MetricsEmit.DualStopwatch sw =
+        MetricsEmit.startLatency(mockScope, "test-metric", HistogramBuckets.DEFAULT_1MS_100S);
+    sw.stop();
+
+    // Verify both stopwatches were started and stopped
+    verify(mockTimer, times(1)).start();
+    verify(mockHistogram, times(1)).start();
+    verify(mockTimerSW, times(1)).stop();
+    verify(mockHistogramSW, times(1)).stop();
+  }
+
+  @Test
+  public void testStartLatency_StopNotCalledTwice() {
+    Stopwatch mockTimerSW = mock(Stopwatch.class);
+    Stopwatch mockHistogramSW = mock(Stopwatch.class);
+
+    when(mockScope.timer("test-metric")).thenReturn(mockTimer);
+    when(mockTimer.start()).thenReturn(mockTimerSW);
+    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockHistogram.start()).thenReturn(mockHistogramSW);
+
+    MetricsEmit.DualStopwatch sw =
+        MetricsEmit.startLatency(mockScope, "test-metric", HistogramBuckets.DEFAULT_1MS_100S);
+
+    // Stop is not called yet
+    verify(mockTimerSW, never()).stop();
+    verify(mockHistogramSW, never()).stop();
+
+    sw.stop();
+
+    // Now stop should be called once on each
+    verify(mockTimerSW, times(1)).stop();
+    verify(mockHistogramSW, times(1)).stop();
+  }
+
+  @Test
+  public void testHistogramBuckets_Default1ms100s_NotNull() {
+    assertNotNull("DEFAULT_1MS_100S buckets should not be null", HistogramBuckets.DEFAULT_1MS_100S);
+  }
+
+  @Test
+  public void testHistogramBuckets_Low1ms100s_NotNull() {
+    assertNotNull("LOW_1MS_100S buckets should not be null", HistogramBuckets.LOW_1MS_100S);
+  }
+
+  @Test
+  public void testHistogramBuckets_High1ms24h_NotNull() {
+    assertNotNull("HIGH_1MS_24H buckets should not be null", HistogramBuckets.HIGH_1MS_24H);
+  }
+
+  @Test
+  public void testHistogramBuckets_Mid1ms24h_NotNull() {
+    assertNotNull("MID_1MS_24H buckets should not be null", HistogramBuckets.MID_1MS_24H);
+  }
+
+  @Test
+  public void testEmitMode_Default() {
+    // Default mode should be EMIT_BOTH
+    assertEquals(MetricEmitMode.EMIT_BOTH, MetricsEmit.getEmitMode());
+  }
+
+  @Test
+  public void testSetEmitMode() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_TIMERS_ONLY);
+    assertEquals(MetricEmitMode.EMIT_TIMERS_ONLY, MetricsEmit.getEmitMode());
+
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
+    assertEquals(MetricEmitMode.EMIT_HISTOGRAMS_ONLY, MetricsEmit.getEmitMode());
+
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
+    assertEquals(MetricEmitMode.EMIT_BOTH, MetricsEmit.getEmitMode());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetEmitMode_Null() {
+    MetricsEmit.setEmitMode(null);
+  }
+
+  @Test
+  public void testEmitLatency_TimersOnly() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_TIMERS_ONLY);
+
+    when(mockScope.timer("test-metric")).thenReturn(mockTimer);
+
+    Duration latency = Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(150));
+    MetricsEmit.emitLatency(mockScope, "test-metric", latency, HistogramBuckets.DEFAULT_1MS_100S);
+
+    // Verify only timer received the latency
+    verify(mockTimer, times(1)).record(latency);
+    verify(mockScope, never()).histogram(anyString(), any());
+  }
+
+  @Test
+  public void testEmitLatency_HistogramsOnly() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
+
+    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+
+    Duration latency = Duration.ofNanos(TimeUnit.MILLISECONDS.toNanos(150));
+    MetricsEmit.emitLatency(mockScope, "test-metric", latency, HistogramBuckets.DEFAULT_1MS_100S);
+
+    // Verify only histogram received the latency
+    verify(mockHistogram, times(1)).recordDuration(latency);
+    verify(mockScope, never()).timer(anyString());
+  }
+
+  @Test
+  public void testStartLatency_TimersOnly() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_TIMERS_ONLY);
+
+    Stopwatch mockTimerSW = mock(Stopwatch.class);
+
+    when(mockScope.timer("test-metric")).thenReturn(mockTimer);
+    when(mockTimer.start()).thenReturn(mockTimerSW);
+
+    MetricsEmit.DualStopwatch sw =
+        MetricsEmit.startLatency(mockScope, "test-metric", HistogramBuckets.DEFAULT_1MS_100S);
+    sw.stop();
+
+    // Verify only timer stopwatch was started and stopped
+    verify(mockTimer, times(1)).start();
+    verify(mockTimerSW, times(1)).stop();
+    verify(mockScope, never()).histogram(anyString(), any());
+  }
+
+  @Test
+  public void testStartLatency_HistogramsOnly() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
+
+    Stopwatch mockHistogramSW = mock(Stopwatch.class);
+
+    when(mockScope.histogram(eq("test-metric"), any())).thenReturn(mockHistogram);
+    when(mockHistogram.start()).thenReturn(mockHistogramSW);
+
+    MetricsEmit.DualStopwatch sw =
+        MetricsEmit.startLatency(mockScope, "test-metric", HistogramBuckets.DEFAULT_1MS_100S);
+    sw.stop();
+
+    // Verify only histogram stopwatch was started and stopped
+    verify(mockHistogram, times(1)).start();
+    verify(mockHistogramSW, times(1)).stop();
+    verify(mockScope, never()).timer(anyString());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
@@ -53,7 +53,8 @@ public class ActivityPollTaskTest {
     // Mock the Histogram and its Stopwatch (for dual-emit)
     Histogram histogram = mock(Histogram.class);
     Stopwatch histogramStopwatch = mock(Stopwatch.class);
-    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
+    when(metricsScope.histogram(
+            eq(MetricsType.ACTIVITY_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(histogram);
     when(histogram.start()).thenReturn(histogramStopwatch);
 
@@ -91,7 +92,8 @@ public class ActivityPollTaskTest {
     Timer timer = mock(Timer.class);
     Histogram histogram = mock(Histogram.class);
     when(metricsScope.timer(MetricsType.ACTIVITY_POLL_LATENCY)).thenReturn(timer);
-    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
+    when(metricsScope.histogram(
+            eq(MetricsType.ACTIVITY_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(histogram);
     Stopwatch timerSw = mock(Stopwatch.class);
     Stopwatch histogramSw = mock(Stopwatch.class);

--- a/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
@@ -25,6 +25,7 @@ import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Counter;
+import com.uber.m3.tally.Histogram;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.tally.Timer;
@@ -47,6 +48,13 @@ public class ActivityPollTaskTest {
     Stopwatch stopwatch = mock(Stopwatch.class);
     when(metricsScope.timer(MetricsType.ACTIVITY_POLL_LATENCY)).thenReturn(timer);
     when(timer.start()).thenReturn(stopwatch);
+
+    // Mock the Histogram and its Stopwatch (for dual-emit)
+    Histogram histogram = mock(Histogram.class);
+    Stopwatch histogramStopwatch = mock(Stopwatch.class);
+    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY), any()))
+        .thenReturn(histogram);
+    when(histogram.start()).thenReturn(histogramStopwatch);
 
     // Mock the Counter and its inc() method
     Counter counter = mock(Counter.class);
@@ -77,22 +85,29 @@ public class ActivityPollTaskTest {
     when(mockService.PollForActivityTask(any(PollForActivityTaskRequest.class)))
         .thenReturn(response);
 
-    // Mock the timer and stopwatch behavior
+    // Mock the timer and histogram behavior
     Scope metricsScope = options.getMetricsScope();
     Timer timer = mock(Timer.class);
+    Histogram histogram = mock(Histogram.class);
     when(metricsScope.timer(MetricsType.ACTIVITY_POLL_LATENCY)).thenReturn(timer);
-    Stopwatch sw = mock(Stopwatch.class);
-    when(timer.start()).thenReturn(sw);
+    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY), any()))
+        .thenReturn(histogram);
+    Stopwatch timerSw = mock(Stopwatch.class);
+    Stopwatch histogramSw = mock(Stopwatch.class);
+    when(timer.start()).thenReturn(timerSw);
+    when(histogram.start()).thenReturn(histogramSw);
 
     PollForActivityTaskResponse result = pollTask.pollTask();
 
     assertNotNull(result);
     assertArrayEquals("testToken".getBytes(), result.getTaskToken());
 
-    // Verify the counters and the timer behavior
+    // Verify the counters and the timer/histogram behavior (dual-emit)
     verify(metricsScope.counter(MetricsType.ACTIVITY_POLL_COUNTER), times(1)).inc(1);
     verify(timer, times(1)).start();
-    verify(sw, times(1)).stop();
+    verify(histogram, times(1)).start();
+    verify(timerSw, times(1)).stop();
+    verify(histogramSw, times(1)).stop();
   }
 
   @Test(expected = InternalServiceError.class)

--- a/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
 import com.uber.cadence.*;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
@@ -52,7 +53,7 @@ public class ActivityPollTaskTest {
     // Mock the Histogram and its Stopwatch (for dual-emit)
     Histogram histogram = mock(Histogram.class);
     Stopwatch histogramStopwatch = mock(Stopwatch.class);
-    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY), any()))
+    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(histogram);
     when(histogram.start()).thenReturn(histogramStopwatch);
 
@@ -90,7 +91,7 @@ public class ActivityPollTaskTest {
     Timer timer = mock(Timer.class);
     Histogram histogram = mock(Histogram.class);
     when(metricsScope.timer(MetricsType.ACTIVITY_POLL_LATENCY)).thenReturn(timer);
-    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY), any()))
+    when(metricsScope.histogram(eq(MetricsType.ACTIVITY_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(histogram);
     Stopwatch timerSw = mock(Stopwatch.class);
     Stopwatch histogramSw = mock(Stopwatch.class);

--- a/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
@@ -25,6 +25,7 @@ import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.m3.tally.Counter;
+import com.uber.m3.tally.Histogram;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.tally.Timer;
@@ -43,17 +44,18 @@ public class WorkflowPollTaskTest {
     mockService = mock(IWorkflowService.class);
     mockMetricScope = mock(Scope.class);
 
-    // Mock the Timer and Stopwatch
+    // Mock the Timer and Histogram for poll latency (dual-emit)
     Timer pollLatencyTimer = mock(Timer.class);
-    Timer scheduledToStartLatencyTimer = mock(Timer.class);
-    Stopwatch sw = mock(Stopwatch.class);
+    Histogram pollLatencyHistogram = mock(Histogram.class);
+    Stopwatch timerSw = mock(Stopwatch.class);
+    Stopwatch histogramSw = mock(Stopwatch.class);
 
     // Ensure timers and stopwatch are not null and return expected values
     when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
-    when(pollLatencyTimer.start()).thenReturn(sw);
-    when(mockMetricScope.timer(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY))
-        .thenReturn(scheduledToStartLatencyTimer);
-    doNothing().when(scheduledToStartLatencyTimer).record(any(Duration.class));
+    when(pollLatencyTimer.start()).thenReturn(timerSw);
+    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY), any()))
+        .thenReturn(pollLatencyHistogram);
+    when(pollLatencyHistogram.start()).thenReturn(histogramSw);
 
     // Mock counters for different metrics
     Counter pollCounter = mock(Counter.class);
@@ -99,22 +101,31 @@ public class WorkflowPollTaskTest {
     when(mockService.PollForDecisionTask(any(PollForDecisionTaskRequest.class)))
         .thenReturn(response);
 
-    // Mock the timer and stopwatch behavior
+    // Mock the timer and histogram behavior (dual-emit)
     Timer pollLatencyTimer = mock(Timer.class);
-    Timer scheduledToStartLatencyTimer = mock(Timer.class);
-    Stopwatch sw = mock(Stopwatch.class);
+    Histogram pollLatencyHistogram = mock(Histogram.class);
+    Stopwatch timerSw = mock(Stopwatch.class);
+    Stopwatch histogramSw = mock(Stopwatch.class);
     when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
-    when(pollLatencyTimer.start()).thenReturn(sw);
+    when(pollLatencyTimer.start()).thenReturn(timerSw);
+    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY), any()))
+        .thenReturn(pollLatencyHistogram);
+    when(pollLatencyHistogram.start()).thenReturn(histogramSw);
 
     // Mock the tagged scope for workflow type
     Scope taggedScope = mock(Scope.class);
     when(mockMetricScope.tagged(ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, "testWorkflowType")))
         .thenReturn(taggedScope);
 
-    // Ensure DECISION_SCHEDULED_TO_START_LATENCY timer in taggedScope is not null
+    // Mock scheduled-to-start latency timer and histogram (dual-emit)
+    Timer scheduledToStartLatencyTimer = mock(Timer.class);
+    Histogram scheduledToStartLatencyHistogram = mock(Histogram.class);
     when(taggedScope.timer(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY))
         .thenReturn(scheduledToStartLatencyTimer);
+    when(taggedScope.histogram(eq(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY), any()))
+        .thenReturn(scheduledToStartLatencyHistogram);
     doNothing().when(scheduledToStartLatencyTimer).record(any(Duration.class));
+    doNothing().when(scheduledToStartLatencyHistogram).recordDuration(any(Duration.class));
 
     // Mock counters for DECISION_POLL_COUNTER and DECISION_POLL_SUCCEED_COUNTER
     Counter pollCounter = mock(Counter.class);
@@ -128,16 +139,19 @@ public class WorkflowPollTaskTest {
     assertNotNull(result);
     assertArrayEquals("testToken".getBytes(), result.getTaskToken());
 
-    // Verify counter and timer behavior
+    // Verify counter and timer/histogram behavior (dual-emit)
     verify(pollCounter, times(1)).inc(1);
     verify(succeedCounter, times(1)).inc(1);
     verify(pollLatencyTimer, times(1)).start();
-    verify(sw, times(1)).stop();
+    verify(pollLatencyHistogram, times(1)).start();
+    verify(timerSw, times(1)).stop();
+    verify(histogramSw, times(1)).stop();
 
-    // Verify that record() on scheduledToStartLatencyTimer was called with correct duration
+    // Verify that record() on scheduledToStartLatency metrics was called with correct duration
     Duration expectedDuration =
-        Duration.ofNanos(result.getStartedTimestamp() - result.getScheduledTimestamp());
+        Duration.ofNanos(response.getStartedTimestamp() - response.getScheduledTimestamp());
     verify(scheduledToStartLatencyTimer, times(1)).record(eq(expectedDuration));
+    verify(scheduledToStartLatencyHistogram, times(1)).recordDuration(eq(expectedDuration));
   }
 
   @Test(expected = InternalServiceError.class)

--- a/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
 import com.uber.cadence.*;
+import com.uber.cadence.internal.metrics.MetricsEmit;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
 import com.uber.cadence.serviceclient.IWorkflowService;
@@ -53,7 +54,7 @@ public class WorkflowPollTaskTest {
     // Ensure timers and stopwatch are not null and return expected values
     when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
     when(pollLatencyTimer.start()).thenReturn(timerSw);
-    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY), any()))
+    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(pollLatencyHistogram);
     when(pollLatencyHistogram.start()).thenReturn(histogramSw);
 
@@ -108,7 +109,7 @@ public class WorkflowPollTaskTest {
     Stopwatch histogramSw = mock(Stopwatch.class);
     when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
     when(pollLatencyTimer.start()).thenReturn(timerSw);
-    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY), any()))
+    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(pollLatencyHistogram);
     when(pollLatencyHistogram.start()).thenReturn(histogramSw);
 
@@ -122,7 +123,7 @@ public class WorkflowPollTaskTest {
     Histogram scheduledToStartLatencyHistogram = mock(Histogram.class);
     when(taggedScope.timer(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY))
         .thenReturn(scheduledToStartLatencyTimer);
-    when(taggedScope.histogram(eq(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY), any()))
+    when(taggedScope.histogram(eq(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(scheduledToStartLatencyHistogram);
     doNothing().when(scheduledToStartLatencyTimer).record(any(Duration.class));
     doNothing().when(scheduledToStartLatencyHistogram).recordDuration(any(Duration.class));

--- a/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
@@ -54,7 +54,8 @@ public class WorkflowPollTaskTest {
     // Ensure timers and stopwatch are not null and return expected values
     when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
     when(pollLatencyTimer.start()).thenReturn(timerSw);
-    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
+    when(mockMetricScope.histogram(
+            eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(pollLatencyHistogram);
     when(pollLatencyHistogram.start()).thenReturn(histogramSw);
 
@@ -109,7 +110,8 @@ public class WorkflowPollTaskTest {
     Stopwatch histogramSw = mock(Stopwatch.class);
     when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
     when(pollLatencyTimer.start()).thenReturn(timerSw);
-    when(mockMetricScope.histogram(eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
+    when(mockMetricScope.histogram(
+            eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(pollLatencyHistogram);
     when(pollLatencyHistogram.start()).thenReturn(histogramSw);
 
@@ -123,7 +125,9 @@ public class WorkflowPollTaskTest {
     Histogram scheduledToStartLatencyHistogram = mock(Histogram.class);
     when(taggedScope.timer(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY))
         .thenReturn(scheduledToStartLatencyTimer);
-    when(taggedScope.histogram(eq(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
+    when(taggedScope.histogram(
+            eq(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX),
+            any()))
         .thenReturn(scheduledToStartLatencyHistogram);
     doNothing().when(scheduledToStartLatencyTimer).record(any(Duration.class));
     doNothing().when(scheduledToStartLatencyHistogram).recordDuration(any(Duration.class));


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Start dual emitting histogram metrics as part of timer -> histogram metrics migration
Added migration doc to example the changes

<!-- Tell your future self why have you made these changes -->
**Why?**
Time -> histogram migration
https://github.com/cadence-workflow/cadence/issues/7741

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**
Backward compatibility, only risk is the metrics storage usage increase

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
