### PR TITLE
feat: Add options to get version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add GetVersionOptions to Workflow.getVersion() for controlled version selection (executeWithVersion, executeWithMinVersion)
+
 ## 3.12.7
 - Release use versions from git tags instead of static value (#1002)
 - support for testrunner for java in vscode (#1001)

--- a/src/main/java/com/uber/cadence/internal/replay/ClockDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ClockDecisionContext.java
@@ -33,6 +33,7 @@ import com.uber.cadence.internal.worker.LocalActivityWorker;
 import com.uber.cadence.workflow.ActivityFailureException;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Functions.Func1;
+import com.uber.cadence.workflow.GetVersionOptions;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -320,6 +321,24 @@ public final class ClockDecisionContext {
 
   GetVersionResult getVersion(
       String changeId, DataConverter converter, int minSupported, int maxSupported) {
+    return getVersion(changeId, converter, minSupported, maxSupported, null);
+  }
+
+  GetVersionResult getVersion(
+      String changeId,
+      DataConverter converter,
+      int minSupported,
+      int maxSupported,
+      GetVersionOptions options) {
+
+    if (options != null && options.getCustomVersion() != null) {
+      int cv = options.getCustomVersion();
+      if (cv < minSupported || cv > maxSupported) {
+        throw new IllegalArgumentException(
+            "customVersion " + cv + " is not within [" + minSupported + ", " + maxSupported + "]");
+      }
+    }
+
     Predicate<MarkerRecordedEventAttributes> changeIdEquals =
         (attributes) -> {
           MarkerHandler.MarkerInterface markerData =
@@ -336,14 +355,25 @@ public final class ClockDecisionContext {
               if (stored.isPresent()) {
                 return Optional.empty();
               }
-              return Optional.of(converter.toData(maxSupported));
+              // Select version based on options priority
+              int versionToRecord;
+              if (options != null && options.getCustomVersion() != null) {
+                versionToRecord = options.getCustomVersion(); // priority #2
+              } else if (options != null && options.isUseMinVersion()) {
+                versionToRecord = minSupported; // priority #3
+              } else {
+                versionToRecord = maxSupported; // priority #4 (default)
+              }
+              return Optional.of(converter.toData(versionToRecord));
             });
 
     final boolean isNewlyAdded = result.isNewlyStored();
     Map<String, Object> searchAttributesForChangeVersion = null;
     if (isNewlyAdded) {
+      Integer recordedVersion =
+          converter.fromData(result.getStoredData().get(), Integer.class, Integer.class);
       searchAttributesForChangeVersion =
-          createSearchAttributesForChangeVersion(changeId, maxSupported, versionMap);
+          createSearchAttributesForChangeVersion(changeId, recordedVersion, versionMap);
     }
 
     Integer version = versionMap.get(changeId);

--- a/src/main/java/com/uber/cadence/internal/replay/ClockDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/ClockDecisionContext.java
@@ -331,14 +331,6 @@ public final class ClockDecisionContext {
       int maxSupported,
       GetVersionOptions options) {
 
-    if (options != null && options.getCustomVersion() != null) {
-      int cv = options.getCustomVersion();
-      if (cv < minSupported || cv > maxSupported) {
-        throw new IllegalArgumentException(
-            "customVersion " + cv + " is not within [" + minSupported + ", " + maxSupported + "]");
-      }
-    }
-
     Predicate<MarkerRecordedEventAttributes> changeIdEquals =
         (attributes) -> {
           MarkerHandler.MarkerInterface markerData =
@@ -358,7 +350,18 @@ public final class ClockDecisionContext {
               // Select version based on options priority
               int versionToRecord;
               if (options != null && options.getCustomVersion() != null) {
-                versionToRecord = options.getCustomVersion(); // priority #2
+                int cv = options.getCustomVersion();
+                if (cv < minSupported || cv > maxSupported) {
+                  throw new IllegalArgumentException(
+                      "customVersion "
+                          + cv
+                          + " is not within ["
+                          + minSupported
+                          + ", "
+                          + maxSupported
+                          + "]");
+                }
+                versionToRecord = cv; // priority #2
               } else if (options != null && options.isUseMinVersion()) {
                 versionToRecord = minSupported; // priority #3
               } else {

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -25,6 +25,7 @@ import com.uber.cadence.context.ContextPropagator;
 import com.uber.cadence.converter.DataConverter;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Functions.Func1;
+import com.uber.cadence.workflow.GetVersionOptions;
 import com.uber.cadence.workflow.Promise;
 import com.uber.m3.tally.Scope;
 import java.time.Duration;
@@ -193,6 +194,15 @@ public interface DecisionContext extends ReplayAware {
    * @return version
    */
   int getVersion(String changeID, DataConverter dataConverter, int minSupported, int maxSupported);
+
+  default int getVersion(
+      String changeID,
+      DataConverter dataConverter,
+      int minSupported,
+      int maxSupported,
+      GetVersionOptions options) {
+    return getVersion(changeID, dataConverter, minSupported, maxSupported);
+  }
 
   Random newRandom();
 

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContext.java
@@ -195,6 +195,10 @@ public interface DecisionContext extends ReplayAware {
    */
   int getVersion(String changeID, DataConverter dataConverter, int minSupported, int maxSupported);
 
+  /**
+   * @implNote Custom implementations should override this method to pass {@code options} through.
+   *     The default delegates to the 4-arg overload, silently dropping options.
+   */
   default int getVersion(
       String changeID,
       DataConverter dataConverter,

--- a/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
+++ b/src/main/java/com/uber/cadence/internal/replay/DecisionContextImpl.java
@@ -35,6 +35,7 @@ import com.uber.cadence.internal.worker.LocalActivityWorker;
 import com.uber.cadence.internal.worker.SingleWorkerOptions;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Functions.Func1;
+import com.uber.cadence.workflow.GetVersionOptions;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.Workflow;
 import com.uber.m3.tally.Scope;
@@ -292,8 +293,18 @@ final class DecisionContextImpl implements DecisionContext, HistoryEventHandler 
   @Override
   public int getVersion(
       String changeID, DataConverter converter, int minSupported, int maxSupported) {
+    return getVersion(changeID, converter, minSupported, maxSupported, null);
+  }
+
+  @Override
+  public int getVersion(
+      String changeID,
+      DataConverter converter,
+      int minSupported,
+      int maxSupported,
+      GetVersionOptions options) {
     final ClockDecisionContext.GetVersionResult results =
-        workflowClock.getVersion(changeID, converter, minSupported, maxSupported);
+        workflowClock.getVersion(changeID, converter, minSupported, maxSupported, options);
     if (results.shouldUpdateCadenceChangeVersion()) {
       upsertSearchAttributes(
           InternalUtils.convertMapToSearchAttributes(

--- a/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/DeterministicRunnerImpl.java
@@ -36,6 +36,7 @@ import com.uber.cadence.internal.replay.SignalExternalWorkflowParameters;
 import com.uber.cadence.internal.replay.StartChildWorkflowExecutionParameters;
 import com.uber.cadence.workflow.Functions.Func;
 import com.uber.cadence.workflow.Functions.Func1;
+import com.uber.cadence.workflow.GetVersionOptions;
 import com.uber.cadence.workflow.Promise;
 import com.uber.m3.tally.Scope;
 import java.time.Duration;
@@ -692,6 +693,16 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     @Override
     public int getVersion(
         String changeID, DataConverter converter, int minSupported, int maxSupported) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public int getVersion(
+        String changeID,
+        DataConverter converter,
+        int minSupported,
+        int maxSupported,
+        GetVersionOptions options) {
       throw new UnsupportedOperationException("not implemented");
     }
 

--- a/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
+++ b/src/main/java/com/uber/cadence/internal/sync/SyncDecisionContext.java
@@ -54,6 +54,7 @@ import com.uber.cadence.workflow.CompletablePromise;
 import com.uber.cadence.workflow.ContinueAsNewOptions;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.Functions.Func;
+import com.uber.cadence.workflow.GetVersionOptions;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.SignalExternalWorkflowException;
 import com.uber.cadence.workflow.Workflow;
@@ -618,6 +619,12 @@ final class SyncDecisionContext implements WorkflowInterceptor {
   @Override
   public int getVersion(String changeID, int minSupported, int maxSupported) {
     return context.getVersion(changeID, converter, minSupported, maxSupported);
+  }
+
+  @Override
+  public int getVersion(
+      String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
+    return context.getVersion(changeID, converter, minSupported, maxSupported, options);
   }
 
   void fireTimers() {

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowInternal.java
@@ -36,6 +36,7 @@ import com.uber.cadence.workflow.ContinueAsNewOptions;
 import com.uber.cadence.workflow.ExternalWorkflowStub;
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.Functions.Func;
+import com.uber.cadence.workflow.GetVersionOptions;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.QueryMethod;
 import com.uber.cadence.workflow.Workflow;
@@ -250,7 +251,12 @@ public final class WorkflowInternal {
   }
 
   public static int getVersion(String changeID, int minSupported, int maxSupported) {
-    return getWorkflowInterceptor().getVersion(changeID, minSupported, maxSupported);
+    return getVersion(changeID, minSupported, maxSupported, null);
+  }
+
+  public static int getVersion(
+      String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
+    return getWorkflowInterceptor().getVersion(changeID, minSupported, maxSupported, options);
   }
 
   public static <U> Promise<List<U>> promiseAllOf(Collection<Promise<U>> promises) {

--- a/src/main/java/com/uber/cadence/workflow/GetVersionOptions.java
+++ b/src/main/java/com/uber/cadence/workflow/GetVersionOptions.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * <p>Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ * <p>http://aws.amazon.com/apache2.0
+ *
+ * <p>or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.uber.cadence.workflow;
+
+/**
+ * Options for controlling version selection behavior in {@link Workflow#getVersion}.
+ *
+ * <p>When no cached version exists for a changeID, these options control which version is recorded:
+ *
+ * <ul>
+ *   <li>{@link #executeWithVersion(int)} — Forces a specific version to be used.
+ *   <li>{@link #executeWithMinVersion()} — Forces {@code minSupported} to be used.
+ *   <li>Default (no options) — Uses {@code maxSupported}.
+ * </ul>
+ *
+ * <p>If a version is already cached for the changeID, options are ignored and the cached version is
+ * returned.
+ */
+public final class GetVersionOptions {
+  private final Integer customVersion; // null = not set; boxed to distinguish "absent" from 0
+  private final boolean useMinVersion;
+
+  private GetVersionOptions(Integer customVersion, boolean useMinVersion) {
+    this.customVersion = customVersion;
+    this.useMinVersion = useMinVersion;
+  }
+
+  /** Returns the custom version to use, or {@code null} if not set. */
+  public Integer getCustomVersion() {
+    return customVersion;
+  }
+
+  /** Returns {@code true} if minSupported should be used instead of maxSupported. */
+  public boolean isUseMinVersion() {
+    return useMinVersion;
+  }
+
+  /**
+   * Creates options that force execution with a specific version.
+   *
+   * @param version the version to use; must not be DEFAULT_VERSION (-1)
+   * @throws IllegalArgumentException if version is DEFAULT_VERSION (-1)
+   */
+  public static GetVersionOptions executeWithVersion(int version) {
+    return new Builder().setCustomVersion(version).build();
+  }
+
+  /** Creates options that force execution with minSupported version. */
+  public static GetVersionOptions executeWithMinVersion() {
+    return new Builder().setUseMinVersion(true).build();
+  }
+
+  @Override
+  public String toString() {
+    return "GetVersionOptions{customVersion="
+        + customVersion
+        + ", useMinVersion="
+        + useMinVersion
+        + "}";
+  }
+
+  public static final class Builder {
+    private Integer customVersion;
+    private boolean useMinVersion;
+
+    /**
+     * Sets a specific version to use when recording a new version marker.
+     *
+     * @param version the version to use; must not be DEFAULT_VERSION (-1)
+     * @throws IllegalArgumentException if version is DEFAULT_VERSION (-1)
+     */
+    public Builder setCustomVersion(int version) {
+      if (version == -1) {
+        throw new IllegalArgumentException("customVersion cannot be DEFAULT_VERSION (-1)");
+      }
+      this.customVersion = version;
+      return this;
+    }
+
+    /** Sets whether to use minSupported instead of maxSupported. */
+    public Builder setUseMinVersion(boolean useMinVersion) {
+      this.useMinVersion = useMinVersion;
+      return this;
+    }
+
+    /**
+     * Builds the options.
+     *
+     * @throws IllegalArgumentException if both customVersion and useMinVersion are set
+     */
+    public GetVersionOptions build() {
+      if (customVersion != null && useMinVersion) {
+        throw new IllegalArgumentException("Cannot set both customVersion and useMinVersion");
+      }
+      return new GetVersionOptions(customVersion, useMinVersion);
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/workflow/GetVersionOptions.java
+++ b/src/main/java/com/uber/cadence/workflow/GetVersionOptions.java
@@ -78,12 +78,12 @@ public final class GetVersionOptions {
     /**
      * Sets a specific version to use when recording a new version marker.
      *
-     * @param version the version to use; must not be DEFAULT_VERSION (-1)
-     * @throws IllegalArgumentException if version is DEFAULT_VERSION (-1)
+     * @param version the version to use; must be non-negative
+     * @throws IllegalArgumentException if version is negative
      */
     public Builder setCustomVersion(int version) {
-      if (version == -1) {
-        throw new IllegalArgumentException("customVersion cannot be DEFAULT_VERSION (-1)");
+      if (version < 0) {
+        throw new IllegalArgumentException("customVersion must be non-negative, got: " + version);
       }
       this.customVersion = version;
       return this;

--- a/src/main/java/com/uber/cadence/workflow/Workflow.java
+++ b/src/main/java/com/uber/cadence/workflow/Workflow.java
@@ -1145,6 +1145,34 @@ public final class Workflow {
   }
 
   /**
+   * Get Version is used to safely perform backwards incompatible changes to workflow definitions.
+   * This overload accepts options to control version selection behavior.
+   *
+   * @param options controls which version is recorded when no cached version exists
+   */
+  public static int getVersion(
+      String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
+    return WorkflowInternal.getVersion(changeID, minSupported, maxSupported, options);
+  }
+
+  /**
+   * Convenience method that forces first-write execution with a specific version.
+   *
+   * @param customVersion the version to use; must be within [minSupported, maxSupported]
+   */
+  public static int getVersionWithCustomVersion(
+      String changeID, int minSupported, int maxSupported, int customVersion) {
+    return WorkflowInternal.getVersion(
+        changeID, minSupported, maxSupported, GetVersionOptions.executeWithVersion(customVersion));
+  }
+
+  /** Convenience method that forces first-write execution with minSupported version. */
+  public static int getVersionWithMinVersion(String changeID, int minSupported, int maxSupported) {
+    return WorkflowInternal.getVersion(
+        changeID, minSupported, maxSupported, GetVersionOptions.executeWithMinVersion());
+  }
+
+  /**
    * Get scope for reporting business metrics in workflow logic. This should be used instead of
    * creating new metrics scopes as it is able to dedup metrics during replay.
    *

--- a/src/main/java/com/uber/cadence/workflow/WorkflowInterceptor.java
+++ b/src/main/java/com/uber/cadence/workflow/WorkflowInterceptor.java
@@ -127,6 +127,11 @@ public interface WorkflowInterceptor {
 
   int getVersion(String changeID, int minSupported, int maxSupported);
 
+  /**
+   * @implNote Custom implementations should override this method to pass {@code options} through
+   *     the interceptor chain. The default delegates to the 3-arg overload, silently dropping
+   *     options.
+   */
   default int getVersion(
       String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
     return getVersion(changeID, minSupported, maxSupported);

--- a/src/main/java/com/uber/cadence/workflow/WorkflowInterceptor.java
+++ b/src/main/java/com/uber/cadence/workflow/WorkflowInterceptor.java
@@ -127,6 +127,11 @@ public interface WorkflowInterceptor {
 
   int getVersion(String changeID, int minSupported, int maxSupported);
 
+  default int getVersion(
+      String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
+    return getVersion(changeID, minSupported, maxSupported);
+  }
+
   void continueAsNew(
       Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args);
 

--- a/src/main/java/com/uber/cadence/workflow/WorkflowInterceptorBase.java
+++ b/src/main/java/com/uber/cadence/workflow/WorkflowInterceptorBase.java
@@ -135,6 +135,12 @@ public class WorkflowInterceptorBase implements WorkflowInterceptor {
   }
 
   @Override
+  public int getVersion(
+      String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
+    return next.getVersion(changeID, minSupported, maxSupported, options);
+  }
+
+  @Override
   public void continueAsNew(
       Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
     next.continueAsNew(workflowType, options, args);

--- a/src/test/java/com/uber/cadence/internal/replay/ClockDecisionContextVersionOptionsTest.java
+++ b/src/test/java/com/uber/cadence/internal/replay/ClockDecisionContextVersionOptionsTest.java
@@ -1,0 +1,155 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.replay;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.uber.cadence.converter.DataConverter;
+import com.uber.cadence.converter.JsonDataConverter;
+import com.uber.cadence.workflow.GetVersionOptions;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClockDecisionContextVersionOptionsTest {
+
+  private DecisionsHelper decisions;
+  private ReplayDecider replayDecider;
+  private ClockDecisionContext context;
+  private final DataConverter converter = JsonDataConverter.getInstance();
+
+  @Before
+  public void setUp() {
+    decisions = mock(DecisionsHelper.class);
+    replayDecider = mock(ReplayDecider.class);
+    Lock lock = mock(Lock.class);
+    Condition condition = mock(Condition.class);
+
+    when(replayDecider.getLock()).thenReturn(lock);
+    when(lock.newCondition()).thenReturn(condition);
+    when(decisions.getNextDecisionEventId()).thenReturn(1L, 2L, 3L, 4L, 5L);
+
+    context = new ClockDecisionContext(decisions, null, replayDecider, converter);
+    context.setReplaying(false);
+  }
+
+  @Test
+  public void testDefaultBehaviorRecordsMaxSupported() {
+    ClockDecisionContext.GetVersionResult result =
+        context.getVersion("change1", converter, 1, 3, null);
+    assertEquals(3, result.getVersion());
+    assertTrue(result.shouldUpdateCadenceChangeVersion());
+  }
+
+  @Test
+  public void testCustomVersionRecordsSpecifiedVersion() {
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(2);
+    ClockDecisionContext.GetVersionResult result =
+        context.getVersion("change1", converter, 1, 3, options);
+    assertEquals(2, result.getVersion());
+    assertTrue(result.shouldUpdateCadenceChangeVersion());
+  }
+
+  @Test
+  public void testMinVersionRecordsMinSupported() {
+    GetVersionOptions options = GetVersionOptions.executeWithMinVersion();
+    ClockDecisionContext.GetVersionResult result =
+        context.getVersion("change1", converter, 1, 3, options);
+    assertEquals(1, result.getVersion());
+    assertTrue(result.shouldUpdateCadenceChangeVersion());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCustomVersionBelowRangeThrows() {
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(0);
+    context.getVersion("change1", converter, 1, 3, options);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCustomVersionAboveRangeThrows() {
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(5);
+    context.getVersion("change1", converter, 1, 3, options);
+  }
+
+  @Test
+  public void testCachedVersionIgnoresOptions() {
+    // First call records version 3 (default, no options)
+    ClockDecisionContext.GetVersionResult firstResult =
+        context.getVersion("change1", converter, 1, 3, null);
+    assertEquals(3, firstResult.getVersion());
+
+    // Second call with customVersion=2 should still return 3 (cached)
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(2);
+    ClockDecisionContext.GetVersionResult secondResult =
+        context.getVersion("change1", converter, 1, 3, options);
+    assertEquals(3, secondResult.getVersion());
+    assertFalse(secondResult.shouldUpdateCadenceChangeVersion());
+  }
+
+  @Test
+  public void testCachedVersionIgnoresMinVersionOption() {
+    // First call records version 3 (default)
+    context.getVersion("change1", converter, 1, 3, null);
+
+    // Second call with useMinVersion should still return 3
+    GetVersionOptions options = GetVersionOptions.executeWithMinVersion();
+    ClockDecisionContext.GetVersionResult result =
+        context.getVersion("change1", converter, 1, 3, options);
+    assertEquals(3, result.getVersion());
+    assertFalse(result.shouldUpdateCadenceChangeVersion());
+  }
+
+  @Test
+  public void testDifferentChangeIdsAreIndependent() {
+    // change1 uses custom version 2
+    GetVersionOptions options1 = GetVersionOptions.executeWithVersion(2);
+    ClockDecisionContext.GetVersionResult result1 =
+        context.getVersion("change1", converter, 1, 3, options1);
+    assertEquals(2, result1.getVersion());
+
+    // change2 uses min version
+    GetVersionOptions options2 = GetVersionOptions.executeWithMinVersion();
+    ClockDecisionContext.GetVersionResult result2 =
+        context.getVersion("change2", converter, 1, 3, options2);
+    assertEquals(1, result2.getVersion());
+  }
+
+  @Test
+  public void testNullOptionsUsesDefaultBehavior() {
+    ClockDecisionContext.GetVersionResult result =
+        context.getVersion("change1", converter, 0, 5, null);
+    assertEquals(5, result.getVersion());
+  }
+
+  @Test
+  public void testCustomVersionAtRangeBoundaries() {
+    // Custom version equals minSupported
+    GetVersionOptions optionsMin = GetVersionOptions.executeWithVersion(1);
+    ClockDecisionContext.GetVersionResult resultMin =
+        context.getVersion("change1", converter, 1, 3, optionsMin);
+    assertEquals(1, resultMin.getVersion());
+
+    // Custom version equals maxSupported
+    GetVersionOptions optionsMax = GetVersionOptions.executeWithVersion(3);
+    ClockDecisionContext.GetVersionResult resultMax =
+        context.getVersion("change2", converter, 1, 3, optionsMax);
+    assertEquals(3, resultMax.getVersion());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/replay/ClockDecisionContextVersionOptionsTest.java
+++ b/src/test/java/com/uber/cadence/internal/replay/ClockDecisionContextVersionOptionsTest.java
@@ -152,4 +152,17 @@ public class ClockDecisionContextVersionOptionsTest {
         context.getVersion("change2", converter, 1, 3, optionsMax);
     assertEquals(3, resultMax.getVersion());
   }
+
+  @Test
+  public void testOutOfRangeCustomVersionIgnoredWhenCached() {
+    // First call records version 3 (default, maxSupported)
+    context.getVersion("change1", converter, 1, 3, null);
+
+    // Second call with customVersion=5 which is outside [1,3].
+    // Should NOT throw because a cached version (3) exists and options are ignored.
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(5);
+    ClockDecisionContext.GetVersionResult result =
+        context.getVersion("change1", converter, 1, 3, options);
+    assertEquals(3, result.getVersion());
+  }
 }

--- a/src/test/java/com/uber/cadence/workflow/GetVersionOptionsTest.java
+++ b/src/test/java/com/uber/cadence/workflow/GetVersionOptionsTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * <p>Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ * <p>http://aws.amazon.com/apache2.0
+ *
+ * <p>or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.uber.cadence.workflow;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class GetVersionOptionsTest {
+
+  @Test
+  public void testDefaultBuild() {
+    GetVersionOptions options = new GetVersionOptions.Builder().build();
+    assertNull(options.getCustomVersion());
+    assertFalse(options.isUseMinVersion());
+  }
+
+  @Test
+  public void testExecuteWithVersionFactory() {
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(2);
+    assertEquals(Integer.valueOf(2), options.getCustomVersion());
+    assertFalse(options.isUseMinVersion());
+  }
+
+  @Test
+  public void testExecuteWithMinVersionFactory() {
+    GetVersionOptions options = GetVersionOptions.executeWithMinVersion();
+    assertNull(options.getCustomVersion());
+    assertTrue(options.isUseMinVersion());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMutualExclusionThrows() {
+    new GetVersionOptions.Builder().setCustomVersion(2).setUseMinVersion(true).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCustomVersionCannotBeDefaultVersion() {
+    GetVersionOptions.executeWithVersion(-1);
+  }
+
+  @Test
+  public void testToString() {
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(3);
+    assertEquals("GetVersionOptions{customVersion=3, useMinVersion=false}", options.toString());
+  }
+
+  @Test
+  public void testExecuteWithVersionZero() {
+    GetVersionOptions options = GetVersionOptions.executeWithVersion(0);
+    assertEquals(Integer.valueOf(0), options.getCustomVersion());
+  }
+}

--- a/src/test/java/com/uber/cadence/workflow/GetVersionOptionsTest.java
+++ b/src/test/java/com/uber/cadence/workflow/GetVersionOptionsTest.java
@@ -51,6 +51,11 @@ public class GetVersionOptionsTest {
     GetVersionOptions.executeWithVersion(-1);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testCustomVersionCannotBeNegative() {
+    GetVersionOptions.executeWithVersion(-2);
+  }
+
   @Test
   public void testToString() {
     GetVersionOptions options = GetVersionOptions.executeWithVersion(3);

--- a/src/test/java/com/uber/cadence/workflow/interceptors/SignalWorkflowInterceptor.java
+++ b/src/test/java/com/uber/cadence/workflow/interceptors/SignalWorkflowInterceptor.java
@@ -23,6 +23,7 @@ import com.uber.cadence.activity.LocalActivityOptions;
 import com.uber.cadence.internal.sync.SyncWorkflowDefinition;
 import com.uber.cadence.internal.worker.WorkflowExecutionException;
 import com.uber.cadence.workflow.*;
+import com.uber.cadence.workflow.GetVersionOptions;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.Map;
@@ -155,6 +156,12 @@ public class SignalWorkflowInterceptor implements WorkflowInterceptor {
   @Override
   public int getVersion(String changeID, int minSupported, int maxSupported) {
     return next.getVersion(changeID, minSupported, maxSupported);
+  }
+
+  @Override
+  public int getVersion(
+      String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
+    return next.getVersion(changeID, minSupported, maxSupported, options);
   }
 
   @Override

--- a/src/test/java/com/uber/cadence/workflow/interceptors/TracingWorkflowInterceptorFactory.java
+++ b/src/test/java/com/uber/cadence/workflow/interceptors/TracingWorkflowInterceptorFactory.java
@@ -23,6 +23,7 @@ import com.uber.cadence.activity.LocalActivityOptions;
 import com.uber.cadence.internal.sync.SyncWorkflowDefinition;
 import com.uber.cadence.internal.worker.WorkflowExecutionException;
 import com.uber.cadence.workflow.*;
+import com.uber.cadence.workflow.GetVersionOptions;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.*;
@@ -205,6 +206,13 @@ public class TracingWorkflowInterceptorFactory
     public int getVersion(String changeID, int minSupported, int maxSupported) {
       trace.add("getVersion");
       return next.getVersion(changeID, minSupported, maxSupported);
+    }
+
+    @Override
+    public int getVersion(
+        String changeID, int minSupported, int maxSupported, GetVersionOptions options) {
+      trace.add("getVersion");
+      return next.getVersion(changeID, minSupported, maxSupported, options);
     }
 
     @Override


### PR DESCRIPTION
**What changed?**

Port `ExecuteWithVersion` and `ExecuteWithMinVersion` options from the Go client ([#1427](https://github.com/cadence-workflow/cadence-go-client/pull/1427), [#1428](https://github.com/cadence-workflow/cadence-go-client/pull/1428)) to the Java client.

- Added `GetVersionOptions` immutable value class with `Builder`, factory methods (`executeWithVersion(int)`, `executeWithMinVersion()`), and validation.
- Added `getVersion` overloads accepting `GetVersionOptions` throughout the call chain: `Workflow` → `WorkflowInternal` → `WorkflowInterceptor` / `WorkflowInterceptorBase` → `SyncDecisionContext` → `DecisionContext` / `DecisionContextImpl` → `ClockDecisionContext`.
- Added convenience methods `Workflow.getVersionWithCustomVersion()` and `Workflow.getVersionWithMinVersion()`.
- Fixed `ClockDecisionContext` to write the actual recorded version (not always `maxSupported`) to the `CadenceChangeVersion` search attribute.

Version selection priority (options only apply when no cached version exists for changeID):
1. Already cached → return cached (options ignored)
2. `customVersion` set → use that version
3. `useMinVersion=true` → use `minSupported`
4. Default → use `maxSupported` (existing behavior, unchanged)

**Why?**

Enables a safe three-step deployment strategy: (1) deploy code supporting both old and new versions, (2) selectively activate the new version via options without a code deploy, (3) retire old code. The Go client already supports this; the Java client needs parity.

**How did you test it?**

- `GetVersionOptionsTest` — 7 unit tests covering builder, factory methods, mutual exclusion validation, DEFAULT_VERSION rejection, and edge cases.
- Compilation verified: `./gradlew compileJava compileTestJava` — BUILD SUCCESSFUL.
- Existing `testGetVersion`, `testGetVersion2`, `testGetVersionWithoutDecisionEvent` should remain green (no behavior change when options are null).

**Potential risks**

- Low risk. All new method overloads use `default` methods on interfaces (`WorkflowInterceptor`, `DecisionContext`) for backward compatibility — existing implementations compile without changes.
- When `options` is `null` (the default path), behavior is identical to the original code.
- The search attribute fix (using recorded version instead of `maxSupported`) changes what gets written to `CadenceChangeVersion` only when options cause a non-maxSupported version to be recorded. Without options, the behavior is unchanged.

**Release notes**

- Added `GetVersionOptions` to control version selection in `Workflow.getVersion()`. New options `executeWithVersion(int)` and `executeWithMinVersion()` allow operators to control which version is recorded on first-write without deploying new code.

**Documentation Changes**

- Updated `CHANGELOG.md` with new entry under `Unreleased`.
- The [Java client versioning docs](https://cadenceworkflow.io/docs/java-client/versioning) is also updated to document the new `GetVersionOptions` parameter, convenience methods, and the three-step deployment strategy through [cadence-workflow/Cadence-Docs#323](https://github.com/cadence-workflow/Cadence-Docs/pull/323)