### PR TITLE
feat(schedules): Add Schedules API to WorkflowClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dependencies {
 license {
     header rootProject.file('license-header.txt')
     skipExistingHeaders true
-    excludes(["**/*.json", "**/idls","com/uber/cadence/*.java", "com/uber/cadence/shadower/*.java"]) // config files and generated code
+    excludes(["**/*.json", "**/idls","com/uber/cadence/*.java", "com/uber/cadence/shadower/*.java", "com/uber/cadence/client/schedule/*.java", "**/client/schedule/*.java"]) // config files and generated code
 }
 
 task printVersion {
@@ -194,7 +194,11 @@ task replaceGeneratedSources {
 
         def content = file.text
 
-        def updated = content.replaceFirst(
+        // Remove any pre-existing @SuppressWarnings("deprecation") annotations immediately before the class
+        // (newer protoc versions may already emit them, so we normalize to exactly one)
+        def stripped = content.replaceAll(/@SuppressWarnings\("deprecation"\)\n(?=@SuppressWarnings|public\s+.*class\s+ActiveClusterSelectionPolicy)/, '')
+
+        def updated = stripped.replaceFirst(
             /public\s+.*class\s+ActiveClusterSelectionPolicy/,
             '@SuppressWarnings("deprecation")\n$0'
         )

--- a/src/gen/java/com/uber/cadence/BackfillScheduleRequest.java
+++ b/src/gen/java/com/uber/cadence/BackfillScheduleRequest.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import com.uber.cadence.client.schedule.ScheduleOverlapPolicy;
+import java.time.Instant;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class BackfillScheduleRequest {
+  private String domain;
+  private String scheduleId;
+  private Instant startTime;
+  private Instant endTime;
+  private ScheduleOverlapPolicy overlapPolicy;
+  private String backfillId;
+}

--- a/src/gen/java/com/uber/cadence/CreateScheduleRequest.java
+++ b/src/gen/java/com/uber/cadence/CreateScheduleRequest.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import com.uber.cadence.client.schedule.ScheduleAction;
+import com.uber.cadence.client.schedule.SchedulePolicies;
+import com.uber.cadence.client.schedule.ScheduleSpec;
+import java.util.*;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class CreateScheduleRequest {
+  private String domain;
+  private String scheduleId;
+  private ScheduleSpec spec;
+  private ScheduleAction action;
+  private SchedulePolicies policies;
+  private Memo memo;
+  private SearchAttributes searchAttributes;
+}

--- a/src/gen/java/com/uber/cadence/CreateScheduleResponse.java
+++ b/src/gen/java/com/uber/cadence/CreateScheduleResponse.java
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class CreateScheduleResponse {
+  private String scheduleId;
+}

--- a/src/gen/java/com/uber/cadence/DeleteScheduleRequest.java
+++ b/src/gen/java/com/uber/cadence/DeleteScheduleRequest.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class DeleteScheduleRequest {
+  private String domain;
+  private String scheduleId;
+}

--- a/src/gen/java/com/uber/cadence/DescribeScheduleRequest.java
+++ b/src/gen/java/com/uber/cadence/DescribeScheduleRequest.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class DescribeScheduleRequest {
+  private String domain;
+  private String scheduleId;
+}

--- a/src/gen/java/com/uber/cadence/DescribeScheduleResponse.java
+++ b/src/gen/java/com/uber/cadence/DescribeScheduleResponse.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import com.uber.cadence.client.schedule.ScheduleAction;
+import com.uber.cadence.client.schedule.ScheduleInfo;
+import com.uber.cadence.client.schedule.SchedulePolicies;
+import com.uber.cadence.client.schedule.ScheduleSpec;
+import com.uber.cadence.client.schedule.ScheduleState;
+import java.util.*;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class DescribeScheduleResponse {
+  private ScheduleSpec spec;
+  private ScheduleAction action;
+  private SchedulePolicies policies;
+  private ScheduleState state;
+  private ScheduleInfo info;
+  private Memo memo;
+  private SearchAttributes searchAttributes;
+}

--- a/src/gen/java/com/uber/cadence/ListSchedulesRequest.java
+++ b/src/gen/java/com/uber/cadence/ListSchedulesRequest.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class ListSchedulesRequest {
+  private String domain;
+  private int pageSize;
+  private byte[] nextPageToken;
+}

--- a/src/gen/java/com/uber/cadence/ListSchedulesResponse.java
+++ b/src/gen/java/com/uber/cadence/ListSchedulesResponse.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import com.uber.cadence.client.schedule.ScheduleListEntry;
+import java.util.*;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class ListSchedulesResponse {
+  private List<ScheduleListEntry> schedules = new ArrayList<>();
+  private byte[] nextPageToken;
+}

--- a/src/gen/java/com/uber/cadence/PauseScheduleRequest.java
+++ b/src/gen/java/com/uber/cadence/PauseScheduleRequest.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class PauseScheduleRequest {
+  private String domain;
+  private String scheduleId;
+  private String reason;
+  private String identity;
+}

--- a/src/gen/java/com/uber/cadence/UnpauseScheduleRequest.java
+++ b/src/gen/java/com/uber/cadence/UnpauseScheduleRequest.java
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class UnpauseScheduleRequest {
+  private String domain;
+  private String scheduleId;
+  private String reason;
+  /** Nullable. If null, uses the schedule's configured catch-up policy. */
+  private ScheduleCatchUpPolicy catchUpPolicy;
+}

--- a/src/gen/java/com/uber/cadence/UpdateScheduleRequest.java
+++ b/src/gen/java/com/uber/cadence/UpdateScheduleRequest.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence;
+
+import com.uber.cadence.client.schedule.ScheduleAction;
+import com.uber.cadence.client.schedule.SchedulePolicies;
+import com.uber.cadence.client.schedule.ScheduleSpec;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class UpdateScheduleRequest {
+  private String domain;
+  private String scheduleId;
+  private ScheduleSpec spec;
+  private ScheduleAction action;
+  private SchedulePolicies policies;
+  private SearchAttributes searchAttributes;
+}

--- a/src/main/java/com/uber/cadence/client/WorkflowClient.java
+++ b/src/main/java/com/uber/cadence/client/WorkflowClient.java
@@ -21,6 +21,14 @@ import com.uber.cadence.CadenceError;
 import com.uber.cadence.RefreshWorkflowTasksRequest;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.activity.Activity;
+import com.uber.cadence.client.schedule.ListSchedulesResult;
+import com.uber.cadence.client.schedule.ScheduleAction;
+import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
+import com.uber.cadence.client.schedule.ScheduleDescription;
+import com.uber.cadence.client.schedule.ScheduleOverlapPolicy;
+import com.uber.cadence.client.schedule.SchedulePolicies;
+import com.uber.cadence.client.schedule.ScheduleSpec;
+import com.uber.cadence.client.schedule.ScheduleState;
 import com.uber.cadence.internal.sync.WorkflowClientInternal;
 import com.uber.cadence.serviceclient.IWorkflowService;
 import com.uber.cadence.workflow.Functions;
@@ -261,6 +269,123 @@ public interface WorkflowClient {
    */
   void refreshWorkflowTasks(RefreshWorkflowTasksRequest refreshWorkflowTasksRequest)
       throws CadenceError;
+
+  /**
+   * Creates a new schedule in the current domain.
+   *
+   * @param scheduleId unique identifier for the schedule within the domain
+   * @param spec when the schedule should fire (cron expression, start/end time, jitter)
+   * @param action what to do when the schedule fires (start a workflow)
+   * @param policies overlap, catch-up, and failure-handling policies; {@code null} uses server
+   *     defaults
+   * @param state initial pause state; {@code null} starts unpaused
+   * @param memo optional key-value annotations attached to the schedule; {@code null} means none
+   * @throws com.uber.cadence.EntityNotExistsError if the domain does not exist
+   * @throws com.uber.cadence.DomainNotActiveError if the domain is not active in this cluster
+   */
+  void createSchedule(
+      String scheduleId,
+      ScheduleSpec spec,
+      ScheduleAction action,
+      SchedulePolicies policies,
+      ScheduleState state,
+      java.util.Map<String, Object> memo)
+      throws CadenceError;
+
+  /**
+   * Returns the full configuration and current runtime state of a schedule.
+   *
+   * @param scheduleId the schedule to describe
+   * @return mutable description that can be passed to {@link #updateSchedule}
+   * @throws com.uber.cadence.EntityNotExistsError if the schedule does not exist
+   */
+  ScheduleDescription describeSchedule(String scheduleId) throws CadenceError;
+
+  /**
+   * Updates a schedule using a describe-first (read-modify-write) pattern.
+   *
+   * <p>The {@code updater} function receives the current {@link
+   * com.uber.cadence.client.ScheduleDescription} fetched from the server and must return the
+   * desired new state. The SDK then applies the mutation and sends a single update to the server.
+   * Never write field values directly without fetching current state first; the server replaces the
+   * entire schedule on every update.
+   *
+   * @param scheduleId the schedule to update
+   * @param updater function that receives the current description and returns the updated one
+   * @throws com.uber.cadence.EntityNotExistsError if the schedule does not exist
+   */
+  void updateSchedule(
+      String scheduleId,
+      java.util.function.Function<ScheduleDescription, ScheduleDescription> updater)
+      throws CadenceError;
+
+  /**
+   * Permanently deletes a schedule. Any in-flight workflow runs started by the schedule are not
+   * affected.
+   *
+   * @param scheduleId the schedule to delete
+   * @throws com.uber.cadence.EntityNotExistsError if the schedule does not exist
+   */
+  void deleteSchedule(String scheduleId) throws CadenceError;
+
+  /**
+   * Pauses a schedule, preventing new workflow runs from being started. Already-running workflows
+   * are not affected.
+   *
+   * @param scheduleId the schedule to pause
+   * @param reason human-readable reason logged with the pause event
+   * @throws com.uber.cadence.EntityNotExistsError if the schedule does not exist
+   */
+  void pauseSchedule(String scheduleId, String reason) throws CadenceError;
+
+  /**
+   * Resumes a paused schedule. Uses the catch-up policy configured in {@link
+   * com.uber.cadence.client.SchedulePolicies#getCatchUpPolicy()}.
+   *
+   * @param scheduleId the schedule to unpause
+   * @param reason human-readable reason logged with the unpause event
+   * @throws com.uber.cadence.EntityNotExistsError if the schedule does not exist
+   */
+  void unpauseSchedule(String scheduleId, String reason) throws CadenceError;
+
+  /**
+   * Resumes a paused schedule with an explicit catch-up policy override for this unpause only.
+   *
+   * @param scheduleId the schedule to unpause
+   * @param reason human-readable reason logged with the unpause event
+   * @param catchUpPolicy overrides the schedule's configured catch-up policy for this unpause only;
+   *     {@code null} uses the schedule's configured policy
+   * @throws com.uber.cadence.EntityNotExistsError if the schedule does not exist
+   */
+  void unpauseSchedule(String scheduleId, String reason, ScheduleCatchUpPolicy catchUpPolicy)
+      throws CadenceError;
+
+  /**
+   * Triggers workflow runs for a historical time range, as if the schedule had been active during
+   * that period. Useful for backfilling missed runs after an extended pause or outage.
+   *
+   * @param scheduleId the schedule to backfill
+   * @param startTime start of the backfill time range (inclusive)
+   * @param endTime end of the backfill time range (inclusive)
+   * @param overlapPolicy how to handle overlap with already-running workflows; {@code null} uses
+   *     the schedule's configured overlap policy
+   * @throws com.uber.cadence.EntityNotExistsError if the schedule does not exist
+   */
+  void backfillSchedule(
+      String scheduleId,
+      java.time.Instant startTime,
+      java.time.Instant endTime,
+      ScheduleOverlapPolicy overlapPolicy)
+      throws CadenceError;
+
+  /**
+   * Returns a page of schedules in the current domain.
+   *
+   * @param pageSize maximum number of entries to return
+   * @param nextPageToken pagination token from a previous call; {@code null} for the first page
+   * @return result containing schedule entries and a token for the next page
+   */
+  ListSchedulesResult listSchedules(int pageSize, byte[] nextPageToken) throws CadenceError;
 
   /**
    * Executes zero argument workflow with void return type

--- a/src/main/java/com/uber/cadence/client/schedule/ListSchedulesResult.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ListSchedulesResult.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import java.util.List;
+
+/**
+ * Result of a {@link com.uber.cadence.client.WorkflowClient#listSchedules} call.
+ *
+ * <p>To page through all schedules:
+ *
+ * <pre>{@code
+ * byte[] token = null;
+ * do {
+ *     ListSchedulesResult result = client.listSchedules(100, token);
+ *     for (ScheduleListEntry entry : result.getSchedules()) {
+ *         System.out.println(entry.getScheduleId());
+ *     }
+ *     token = result.getNextPageToken();
+ * } while (token != null && token.length > 0);
+ * }</pre>
+ */
+public final class ListSchedulesResult {
+
+  private final List<ScheduleListEntry> schedules;
+  private final byte[] nextPageToken;
+
+  public ListSchedulesResult(List<ScheduleListEntry> schedules, byte[] nextPageToken) {
+    this.schedules = schedules;
+    this.nextPageToken = nextPageToken;
+  }
+
+  /** Schedules in this page. May be empty on the last page. */
+  public List<ScheduleListEntry> getSchedules() {
+    return schedules;
+  }
+
+  /**
+   * Opaque token to pass as {@code nextPageToken} on the next {@code listSchedules} call. {@code
+   * null} or empty byte array means no more pages.
+   */
+  public byte[] getNextPageToken() {
+    return nextPageToken;
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleAction.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleAction.java
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import com.uber.cadence.common.RetryOptions;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Defines what the schedule does when it fires: starts a new workflow execution.
+ *
+ * <p>Currently the only supported action is {@link StartWorkflowAction}; the outer {@link
+ * ScheduleAction} wrapper is kept to allow additional action types in the future.
+ *
+ * <p>Construct via {@link #newBuilder()}:
+ *
+ * <pre>{@code
+ * ScheduleAction action = ScheduleAction.newBuilder()
+ *     .setStartWorkflow(StartWorkflowAction.newBuilder()
+ *         .setWorkflowType("MyWorkflow")
+ *         .setTaskList("my-task-list")
+ *         .setExecutionStartToCloseTimeout(Duration.ofHours(1))
+ *         .build())
+ *     .build();
+ * }</pre>
+ */
+public final class ScheduleAction {
+
+  private final StartWorkflowAction startWorkflow;
+
+  private ScheduleAction(Builder b) {
+    this.startWorkflow = b.startWorkflow;
+  }
+
+  /** The workflow to start on each trigger. Exactly one action field must be non-null. */
+  public StartWorkflowAction getStartWorkflow() {
+    return startWorkflow;
+  }
+
+  /** Returns a new builder pre-populated with the values from this instance. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  /** Returns a new empty builder. */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ScheduleAction)) return false;
+    ScheduleAction that = (ScheduleAction) o;
+    return Objects.equals(startWorkflow, that.startWorkflow);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startWorkflow);
+  }
+
+  @Override
+  public String toString() {
+    return "ScheduleAction{startWorkflow=" + startWorkflow + '}';
+  }
+
+  public static final class Builder {
+
+    private StartWorkflowAction startWorkflow;
+
+    private Builder() {}
+
+    private Builder(ScheduleAction src) {
+      this.startWorkflow = src.startWorkflow;
+    }
+
+    /** @see ScheduleAction#getStartWorkflow() */
+    public Builder setStartWorkflow(StartWorkflowAction startWorkflow) {
+      this.startWorkflow = startWorkflow;
+      return this;
+    }
+
+    public ScheduleAction build() {
+      if (startWorkflow == null) {
+        throw new IllegalStateException("ScheduleAction requires startWorkflow to be set");
+      }
+      return new ScheduleAction(this);
+    }
+  }
+
+  /**
+   * Configures the workflow execution started on each schedule trigger.
+   *
+   * <p>Construct via {@link #newBuilder()}.
+   */
+  public static final class StartWorkflowAction {
+
+    private final String workflowType;
+    private final String taskList;
+    private final byte[] input;
+    private final String workflowIdPrefix;
+    private final Duration executionStartToCloseTimeout;
+    private final Duration taskStartToCloseTimeout;
+    private final RetryOptions retryOptions;
+    private final Map<String, Object> memo;
+    private final Map<String, Object> searchAttributes;
+
+    private StartWorkflowAction(Builder b) {
+      this.workflowType = b.workflowType;
+      this.taskList = b.taskList;
+      this.input = b.input;
+      this.workflowIdPrefix = b.workflowIdPrefix;
+      this.executionStartToCloseTimeout = b.executionStartToCloseTimeout;
+      this.taskStartToCloseTimeout = b.taskStartToCloseTimeout;
+      this.retryOptions = b.retryOptions;
+      this.memo = b.memo;
+      this.searchAttributes = b.searchAttributes;
+    }
+
+    /** Workflow type (name) to start. */
+    public String getWorkflowType() {
+      return workflowType;
+    }
+
+    /** Task list on which the workflow decision tasks are dispatched. */
+    public String getTaskList() {
+      return taskList;
+    }
+
+    /** Serialized input payload for the workflow. {@code null} means no input. */
+    public byte[] getInput() {
+      return input;
+    }
+
+    /**
+     * Prefix used when generating workflow IDs for triggered runs. The scheduler appends a
+     * timestamp suffix to ensure uniqueness. {@code null} uses the schedule ID as prefix.
+     */
+    public String getWorkflowIdPrefix() {
+      return workflowIdPrefix;
+    }
+
+    /** Maximum wall-clock time a triggered workflow execution may run. */
+    public Duration getExecutionStartToCloseTimeout() {
+      return executionStartToCloseTimeout;
+    }
+
+    /** Maximum time a single decision task may take. */
+    public Duration getTaskStartToCloseTimeout() {
+      return taskStartToCloseTimeout;
+    }
+
+    /** Retry policy applied to triggered workflow executions. {@code null} means no retries. */
+    public RetryOptions getRetryOptions() {
+      return retryOptions;
+    }
+
+    /** Memo key/value pairs attached to triggered workflow executions. */
+    public Map<String, Object> getMemo() {
+      return memo;
+    }
+
+    /** Search attributes attached to triggered workflow executions. */
+    public Map<String, Object> getSearchAttributes() {
+      return searchAttributes;
+    }
+
+    /** Returns a new builder pre-populated with the values from this instance. */
+    public Builder toBuilder() {
+      return new Builder(this);
+    }
+
+    /** Returns a new empty builder. */
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof StartWorkflowAction)) return false;
+      StartWorkflowAction that = (StartWorkflowAction) o;
+      return Objects.equals(workflowType, that.workflowType)
+          && Objects.equals(taskList, that.taskList)
+          && Objects.equals(workflowIdPrefix, that.workflowIdPrefix)
+          && Objects.equals(executionStartToCloseTimeout, that.executionStartToCloseTimeout)
+          && Objects.equals(taskStartToCloseTimeout, that.taskStartToCloseTimeout)
+          && Objects.equals(retryOptions, that.retryOptions);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          workflowType,
+          taskList,
+          workflowIdPrefix,
+          executionStartToCloseTimeout,
+          taskStartToCloseTimeout,
+          retryOptions);
+    }
+
+    @Override
+    public String toString() {
+      return "StartWorkflowAction{"
+          + "workflowType='"
+          + workflowType
+          + "', taskList='"
+          + taskList
+          + "', workflowIdPrefix='"
+          + workflowIdPrefix
+          + "', executionStartToCloseTimeout="
+          + executionStartToCloseTimeout
+          + '}';
+    }
+
+    public static final class Builder {
+
+      private String workflowType;
+      private String taskList;
+      private byte[] input;
+      private String workflowIdPrefix;
+      private Duration executionStartToCloseTimeout;
+      private Duration taskStartToCloseTimeout;
+      private RetryOptions retryOptions;
+      private Map<String, Object> memo;
+      private Map<String, Object> searchAttributes;
+
+      private Builder() {}
+
+      private Builder(StartWorkflowAction src) {
+        this.workflowType = src.workflowType;
+        this.taskList = src.taskList;
+        this.input = src.input;
+        this.workflowIdPrefix = src.workflowIdPrefix;
+        this.executionStartToCloseTimeout = src.executionStartToCloseTimeout;
+        this.taskStartToCloseTimeout = src.taskStartToCloseTimeout;
+        this.retryOptions = src.retryOptions;
+        this.memo = src.memo;
+        this.searchAttributes = src.searchAttributes;
+      }
+
+      /** @see StartWorkflowAction#getWorkflowType() */
+      public Builder setWorkflowType(String workflowType) {
+        this.workflowType = workflowType;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getTaskList() */
+      public Builder setTaskList(String taskList) {
+        this.taskList = taskList;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getInput() */
+      public Builder setInput(byte[] input) {
+        this.input = input;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getWorkflowIdPrefix() */
+      public Builder setWorkflowIdPrefix(String workflowIdPrefix) {
+        this.workflowIdPrefix = workflowIdPrefix;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getExecutionStartToCloseTimeout() */
+      public Builder setExecutionStartToCloseTimeout(Duration executionStartToCloseTimeout) {
+        this.executionStartToCloseTimeout = executionStartToCloseTimeout;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getTaskStartToCloseTimeout() */
+      public Builder setTaskStartToCloseTimeout(Duration taskStartToCloseTimeout) {
+        this.taskStartToCloseTimeout = taskStartToCloseTimeout;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getRetryOptions() */
+      public Builder setRetryOptions(RetryOptions retryOptions) {
+        this.retryOptions = retryOptions;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getMemo() */
+      public Builder setMemo(Map<String, Object> memo) {
+        this.memo = memo;
+        return this;
+      }
+
+      /** @see StartWorkflowAction#getSearchAttributes() */
+      public Builder setSearchAttributes(Map<String, Object> searchAttributes) {
+        this.searchAttributes = searchAttributes;
+        return this;
+      }
+
+      public StartWorkflowAction build() {
+        if (workflowType == null || workflowType.isEmpty()) {
+          throw new IllegalStateException("StartWorkflowAction requires workflowType");
+        }
+        if (taskList == null || taskList.isEmpty()) {
+          throw new IllegalStateException("StartWorkflowAction requires taskList");
+        }
+        return new StartWorkflowAction(this);
+      }
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleCatchUpPolicy.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleCatchUpPolicy.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+/**
+ * Defines how missed runs are handled when a schedule is unpaused or when the server recovers from
+ * downtime.
+ *
+ * <p>Catch-up runs are still subject to the configured {@link ScheduleOverlapPolicy}: if the buffer
+ * or concurrency limit is reached, excess catch-up runs are dropped.
+ *
+ * <p>The catch-up window (maximum look-back horizon) is configured separately via {@link
+ * SchedulePolicies#getCatchUpWindow()}.
+ */
+public enum ScheduleCatchUpPolicy {
+  /**
+   * Skip all missed runs. Only future runs will execute.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_CATCH_UP_POLICY_SKIP}.
+   */
+  SKIP,
+
+  /**
+   * Execute only the single most-recently missed scheduled time, skipping all others.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_CATCH_UP_POLICY_ONE}.
+   */
+  ONE,
+
+  /**
+   * Execute a run for every missed scheduled time within the catch-up window.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_CATCH_UP_POLICY_ALL}.
+   */
+  ALL,
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleDescription.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleDescription.java
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Full description of a schedule as returned by {@link
+ * com.uber.cadence.client.WorkflowClient#describeSchedule}.
+ *
+ * <p>This object is also the input to the {@code updater} function passed to {@link
+ * com.uber.cadence.client.WorkflowClient#updateSchedule}. Mutations applied inside the updater are
+ * collected and sent to the server atomically as part of the describe-first read-modify-write
+ * cycle.
+ *
+ * <pre>{@code
+ * client.updateSchedule(scheduleId, desc -> {
+ *     desc.setSpec(desc.getSpec().toBuilder()
+ *         .setCronExpression("0 0,6,12,18 * * *")
+ *         .build());
+ *     desc.getPolicies().toBuilder()
+ *         .setOverlapPolicy(ScheduleOverlapPolicy.SKIP_NEW);
+ *     return desc;
+ * });
+ * }</pre>
+ */
+public final class ScheduleDescription {
+
+  private ScheduleSpec spec;
+  private ScheduleAction action;
+  private SchedulePolicies policies;
+  private ScheduleState state;
+  private ScheduleInfo info;
+  private Map<String, Object> memo;
+  private Map<String, Object> searchAttributes;
+
+  public ScheduleDescription(
+      ScheduleSpec spec,
+      ScheduleAction action,
+      SchedulePolicies policies,
+      ScheduleState state,
+      ScheduleInfo info,
+      Map<String, Object> memo,
+      Map<String, Object> searchAttributes) {
+    this.spec = spec;
+    this.action = action;
+    this.policies = policies;
+    this.state = state;
+    this.info = info;
+    this.memo = memo;
+    this.searchAttributes = searchAttributes;
+  }
+
+  /** The trigger spec (cron, start/end times, jitter). */
+  public ScheduleSpec getSpec() {
+    return spec;
+  }
+
+  /**
+   * Replaces the spec. Call this inside an updater to change when the schedule fires.
+   *
+   * @see com.uber.cadence.client.WorkflowClient#updateSchedule
+   */
+  public ScheduleDescription setSpec(ScheduleSpec spec) {
+    this.spec = Objects.requireNonNull(spec, "spec");
+    return this;
+  }
+
+  /** The action executed on each trigger. */
+  public ScheduleAction getAction() {
+    return action;
+  }
+
+  /**
+   * Replaces the action. Call this inside an updater to change what workflow is started.
+   *
+   * @see com.uber.cadence.client.WorkflowClient#updateSchedule
+   */
+  public ScheduleDescription setAction(ScheduleAction action) {
+    this.action = Objects.requireNonNull(action, "action");
+    return this;
+  }
+
+  /** Overlap, catch-up, and failure-handling policies. */
+  public SchedulePolicies getPolicies() {
+    return policies;
+  }
+
+  /**
+   * Replaces the policies. Call this inside an updater to change overlap or catch-up behavior.
+   *
+   * @see com.uber.cadence.client.WorkflowClient#updateSchedule
+   */
+  public ScheduleDescription setPolicies(SchedulePolicies policies) {
+    this.policies = Objects.requireNonNull(policies, "policies");
+    return this;
+  }
+
+  /**
+   * Current pause state. Read-only; use {@link
+   * com.uber.cadence.client.WorkflowClient#pauseSchedule} to pause.
+   */
+  public ScheduleState getState() {
+    return state;
+  }
+
+  /** Runtime statistics (last run, next run, total runs, etc.). */
+  public ScheduleInfo getInfo() {
+    return info;
+  }
+
+  /** Memo key/value pairs attached to the schedule itself (not to triggered workflows). */
+  public Map<String, Object> getMemo() {
+    return memo;
+  }
+
+  /**
+   * Replaces the search attributes on the schedule.
+   *
+   * @see com.uber.cadence.client.WorkflowClient#updateSchedule
+   */
+  public ScheduleDescription setSearchAttributes(Map<String, Object> searchAttributes) {
+    this.searchAttributes = searchAttributes;
+    return this;
+  }
+
+  /** Search attributes attached to the schedule. */
+  public Map<String, Object> getSearchAttributes() {
+    return searchAttributes;
+  }
+
+  @Override
+  public String toString() {
+    return "ScheduleDescription{"
+        + "spec="
+        + spec
+        + ", action="
+        + action
+        + ", policies="
+        + policies
+        + ", state="
+        + state
+        + '}';
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleInfo.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleInfo.java
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Immutable runtime statistics for a schedule returned by {@link
+ * com.uber.cadence.client.WorkflowClient#describeSchedule}.
+ */
+public final class ScheduleInfo {
+
+  private final Instant lastRunTime;
+  private final Instant nextRunTime;
+  private final long totalRuns;
+  private final Instant createTime;
+  private final Instant lastUpdateTime;
+  private final List<BackfillInfo> ongoingBackfills;
+  private final long missedRuns;
+  private final long skippedRuns;
+
+  public ScheduleInfo(
+      Instant lastRunTime,
+      Instant nextRunTime,
+      long totalRuns,
+      Instant createTime,
+      Instant lastUpdateTime,
+      List<BackfillInfo> ongoingBackfills,
+      long missedRuns,
+      long skippedRuns) {
+    this.lastRunTime = lastRunTime;
+    this.nextRunTime = nextRunTime;
+    this.totalRuns = totalRuns;
+    this.createTime = createTime;
+    this.lastUpdateTime = lastUpdateTime;
+    this.ongoingBackfills = ongoingBackfills;
+    this.missedRuns = missedRuns;
+    this.skippedRuns = skippedRuns;
+  }
+
+  /** When the last workflow was triggered. {@code null} if the schedule has never fired. */
+  public Instant getLastRunTime() {
+    return lastRunTime;
+  }
+
+  /** When the next workflow will be triggered. */
+  public Instant getNextRunTime() {
+    return nextRunTime;
+  }
+
+  /** Total number of workflows started by this schedule (regular, catch-up, and backfill). */
+  public long getTotalRuns() {
+    return totalRuns;
+  }
+
+  /** When the schedule was created. */
+  public Instant getCreateTime() {
+    return createTime;
+  }
+
+  /** When the schedule was last updated. */
+  public Instant getLastUpdateTime() {
+    return lastUpdateTime;
+  }
+
+  /** Currently active backfill operations. Empty when no backfill is in progress. */
+  public List<BackfillInfo> getOngoingBackfills() {
+    return ongoingBackfills;
+  }
+
+  /** Number of missed runs that were skipped by the catch-up policy (e.g. due to downtime). */
+  public long getMissedRuns() {
+    return missedRuns;
+  }
+
+  /**
+   * Number of runs skipped due to the overlap policy (e.g. {@link ScheduleOverlapPolicy#SKIP_NEW}).
+   */
+  public long getSkippedRuns() {
+    return skippedRuns;
+  }
+
+  @Override
+  public String toString() {
+    return "ScheduleInfo{"
+        + "lastRunTime="
+        + lastRunTime
+        + ", nextRunTime="
+        + nextRunTime
+        + ", totalRuns="
+        + totalRuns
+        + ", createTime="
+        + createTime
+        + ", missedRuns="
+        + missedRuns
+        + ", skippedRuns="
+        + skippedRuns
+        + '}';
+  }
+
+  /** Progress of an ongoing backfill operation. */
+  public static final class BackfillInfo {
+
+    private final String backfillId;
+    private final Instant startTime;
+    private final Instant endTime;
+    private final int runsCompleted;
+    private final int runsTotal;
+
+    public BackfillInfo(
+        String backfillId, Instant startTime, Instant endTime, int runsCompleted, int runsTotal) {
+      this.backfillId = backfillId;
+      this.startTime = startTime;
+      this.endTime = endTime;
+      this.runsCompleted = runsCompleted;
+      this.runsTotal = runsTotal;
+    }
+
+    /** Client-provided or server-assigned backfill identifier. */
+    public String getBackfillId() {
+      return backfillId;
+    }
+
+    /** Start of the backfill time range. */
+    public Instant getStartTime() {
+      return startTime;
+    }
+
+    /** End of the backfill time range. */
+    public Instant getEndTime() {
+      return endTime;
+    }
+
+    /** Number of runs completed so far. */
+    public int getRunsCompleted() {
+      return runsCompleted;
+    }
+
+    /** Total number of runs in this backfill range. */
+    public int getRunsTotal() {
+      return runsTotal;
+    }
+
+    @Override
+    public String toString() {
+      return "BackfillInfo{"
+          + "backfillId='"
+          + backfillId
+          + "', startTime="
+          + startTime
+          + ", endTime="
+          + endTime
+          + ", runsCompleted="
+          + runsCompleted
+          + ", runsTotal="
+          + runsTotal
+          + '}';
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleListEntry.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleListEntry.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+/**
+ * A single entry returned by {@link com.uber.cadence.client.WorkflowClient#listSchedules}.
+ *
+ * <p>Contains only the data available from the visibility store. For full detail including policies
+ * and runtime info, call {@link com.uber.cadence.client.WorkflowClient#describeSchedule}.
+ */
+public final class ScheduleListEntry {
+
+  private final String scheduleId;
+  private final String workflowType;
+  private final ScheduleState state;
+  private final String cronExpression;
+
+  public ScheduleListEntry(
+      String scheduleId, String workflowType, ScheduleState state, String cronExpression) {
+    this.scheduleId = scheduleId;
+    this.workflowType = workflowType;
+    this.state = state;
+    this.cronExpression = cronExpression;
+  }
+
+  /** The unique schedule identifier within the domain. */
+  public String getScheduleId() {
+    return scheduleId;
+  }
+
+  /** Workflow type configured in the schedule action. */
+  public String getWorkflowType() {
+    return workflowType;
+  }
+
+  /** Current pause state of the schedule. */
+  public ScheduleState getState() {
+    return state;
+  }
+
+  /** Cron expression configured in the spec. */
+  public String getCronExpression() {
+    return cronExpression;
+  }
+
+  @Override
+  public String toString() {
+    return "ScheduleListEntry{"
+        + "scheduleId='"
+        + scheduleId
+        + "', workflowType='"
+        + workflowType
+        + "', cronExpression='"
+        + cronExpression
+        + "', paused="
+        + (state != null && state.isPaused())
+        + '}';
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleOverlapPolicy.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleOverlapPolicy.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+/**
+ * Defines what happens when a new scheduled run is triggered while a previous one is still running.
+ *
+ * <p>Behavior is not retroactive on update: existing runs keep running under the old policy; only
+ * new fires observe the updated policy. See {@link
+ * com.uber.cadence.client.WorkflowClient#updateSchedule} for detail.
+ */
+public enum ScheduleOverlapPolicy {
+  /**
+   * Skip the new run if the previous workflow is still running. This is the default.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_OVERLAP_POLICY_SKIP_NEW}.
+   */
+  SKIP_NEW,
+
+  /**
+   * Buffer new runs and execute them sequentially after the current run completes.
+   *
+   * <p>The maximum queue depth is controlled by {@link SchedulePolicies#getBufferLimit()}. A limit
+   * of 0 means unlimited. When updating from BUFFER to any other policy the queued runs are
+   * dropped.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_OVERLAP_POLICY_BUFFER}.
+   */
+  BUFFER,
+
+  /**
+   * Allow multiple runs to execute concurrently with no ordering guarantee.
+   *
+   * <p>The maximum concurrency is controlled by {@link SchedulePolicies#getConcurrencyLimit()}. A
+   * limit of 0 means unlimited.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_OVERLAP_POLICY_CONCURRENT}.
+   */
+  CONCURRENT,
+
+  /**
+   * Cancel the previous run gracefully, then start the new one.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_OVERLAP_POLICY_CANCEL_PREVIOUS}.
+   */
+  CANCEL_PREVIOUS,
+
+  /**
+   * Terminate the previous run immediately, then start the new one.
+   *
+   * <p>Equivalent to proto {@code SCHEDULE_OVERLAP_POLICY_TERMINATE_PREVIOUS}.
+   */
+  TERMINATE_PREVIOUS,
+}

--- a/src/main/java/com/uber/cadence/client/schedule/SchedulePolicies.java
+++ b/src/main/java/com/uber/cadence/client/schedule/SchedulePolicies.java
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Configures schedule behavior: overlap, catch-up, and failure-handling policies.
+ *
+ * <p>Construct via {@link #newBuilder()}:
+ *
+ * <pre>{@code
+ * SchedulePolicies policies = SchedulePolicies.newBuilder()
+ *     .setOverlapPolicy(ScheduleOverlapPolicy.SKIP_NEW)
+ *     .setCatchUpPolicy(ScheduleCatchUpPolicy.ONE)
+ *     .setPauseOnFailure(true)
+ *     .build();
+ * }</pre>
+ *
+ * <h3>Overlap policy behavior on update</h3>
+ *
+ * <p>Policy changes on {@link com.uber.cadence.client.WorkflowClient#updateSchedule} are <em>not
+ * retroactive</em>:
+ *
+ * <ul>
+ *   <li>CONCURRENT → SKIP_NEW/CANCEL/TERMINATE: only the LastStartedWorkflow is checked on the next
+ *       fire; other concurrent runs keep running untracked.
+ *   <li>CONCURRENT unbounded → bounded ({@code concurrencyLimit} = N): existing runs are not
+ *       counted against the new limit; cap is enforced for new fires only.
+ *   <li>BUFFER → any: the buffered queue is cleared immediately; no buffered fires carry over.
+ *   <li>any → BUFFER: buffering starts accumulating from the next fire onward.
+ * </ul>
+ */
+public final class SchedulePolicies {
+
+  private final ScheduleOverlapPolicy overlapPolicy;
+  private final ScheduleCatchUpPolicy catchUpPolicy;
+  private final Duration catchUpWindow;
+  private final boolean pauseOnFailure;
+  private final int bufferLimit;
+  private final int concurrencyLimit;
+
+  private SchedulePolicies(Builder b) {
+    this.overlapPolicy = b.overlapPolicy;
+    this.catchUpPolicy = b.catchUpPolicy;
+    this.catchUpWindow = b.catchUpWindow;
+    this.pauseOnFailure = b.pauseOnFailure;
+    this.bufferLimit = b.bufferLimit;
+    this.concurrencyLimit = b.concurrencyLimit;
+  }
+
+  /** What to do when a new run is scheduled while the previous is still running. */
+  public ScheduleOverlapPolicy getOverlapPolicy() {
+    return overlapPolicy;
+  }
+
+  /**
+   * How to handle missed runs on unpause or recovery. Defaults to server-configured behavior when
+   * {@code null}.
+   */
+  public ScheduleCatchUpPolicy getCatchUpPolicy() {
+    return catchUpPolicy;
+  }
+
+  /**
+   * Maximum look-back window for missed runs. Runs older than this are skipped even if the catch-up
+   * policy is {@link ScheduleCatchUpPolicy#ALL}. {@code null} defers to the server default
+   * (configurable via dynamic config).
+   */
+  public Duration getCatchUpWindow() {
+    return catchUpWindow;
+  }
+
+  /**
+   * Whether to automatically pause the schedule when a triggered workflow fails. Defaults to {@code
+   * false}.
+   */
+  public boolean isPauseOnFailure() {
+    return pauseOnFailure;
+  }
+
+  /**
+   * Maximum number of runs queued when {@link ScheduleOverlapPolicy#BUFFER} is active. {@code 0}
+   * means unlimited.
+   */
+  public int getBufferLimit() {
+    return bufferLimit;
+  }
+
+  /**
+   * Maximum number of concurrent runs when {@link ScheduleOverlapPolicy#CONCURRENT} is active.
+   * {@code 0} means unlimited.
+   */
+  public int getConcurrencyLimit() {
+    return concurrencyLimit;
+  }
+
+  /** Returns a new builder pre-populated with the values from this instance. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  /** Returns a new empty builder. */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof SchedulePolicies)) return false;
+    SchedulePolicies that = (SchedulePolicies) o;
+    return pauseOnFailure == that.pauseOnFailure
+        && bufferLimit == that.bufferLimit
+        && concurrencyLimit == that.concurrencyLimit
+        && overlapPolicy == that.overlapPolicy
+        && catchUpPolicy == that.catchUpPolicy
+        && Objects.equals(catchUpWindow, that.catchUpWindow);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        overlapPolicy, catchUpPolicy, catchUpWindow, pauseOnFailure, bufferLimit, concurrencyLimit);
+  }
+
+  @Override
+  public String toString() {
+    return "SchedulePolicies{"
+        + "overlapPolicy="
+        + overlapPolicy
+        + ", catchUpPolicy="
+        + catchUpPolicy
+        + ", catchUpWindow="
+        + catchUpWindow
+        + ", pauseOnFailure="
+        + pauseOnFailure
+        + ", bufferLimit="
+        + bufferLimit
+        + ", concurrencyLimit="
+        + concurrencyLimit
+        + '}';
+  }
+
+  public static final class Builder {
+
+    private ScheduleOverlapPolicy overlapPolicy;
+    private ScheduleCatchUpPolicy catchUpPolicy;
+    private Duration catchUpWindow;
+    private boolean pauseOnFailure;
+    private int bufferLimit;
+    private int concurrencyLimit;
+
+    private Builder() {}
+
+    private Builder(SchedulePolicies src) {
+      this.overlapPolicy = src.overlapPolicy;
+      this.catchUpPolicy = src.catchUpPolicy;
+      this.catchUpWindow = src.catchUpWindow;
+      this.pauseOnFailure = src.pauseOnFailure;
+      this.bufferLimit = src.bufferLimit;
+      this.concurrencyLimit = src.concurrencyLimit;
+    }
+
+    /** @see SchedulePolicies#getOverlapPolicy() */
+    public Builder setOverlapPolicy(ScheduleOverlapPolicy overlapPolicy) {
+      this.overlapPolicy = overlapPolicy;
+      return this;
+    }
+
+    /** @see SchedulePolicies#getCatchUpPolicy() */
+    public Builder setCatchUpPolicy(ScheduleCatchUpPolicy catchUpPolicy) {
+      this.catchUpPolicy = catchUpPolicy;
+      return this;
+    }
+
+    /** @see SchedulePolicies#getCatchUpWindow() */
+    public Builder setCatchUpWindow(Duration catchUpWindow) {
+      this.catchUpWindow = catchUpWindow;
+      return this;
+    }
+
+    /** @see SchedulePolicies#isPauseOnFailure() */
+    public Builder setPauseOnFailure(boolean pauseOnFailure) {
+      this.pauseOnFailure = pauseOnFailure;
+      return this;
+    }
+
+    /** @see SchedulePolicies#getBufferLimit() */
+    public Builder setBufferLimit(int bufferLimit) {
+      this.bufferLimit = bufferLimit;
+      return this;
+    }
+
+    /** @see SchedulePolicies#getConcurrencyLimit() */
+    public Builder setConcurrencyLimit(int concurrencyLimit) {
+      this.concurrencyLimit = concurrencyLimit;
+      return this;
+    }
+
+    public SchedulePolicies build() {
+      return new SchedulePolicies(this);
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleSpec.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleSpec.java
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Defines when a schedule fires.
+ *
+ * <p>Construct via {@link #newBuilder()}:
+ *
+ * <pre>{@code
+ * ScheduleSpec spec = ScheduleSpec.newBuilder()
+ *     .setCronExpression("0 6 * * *")        // daily at 06:00 UTC
+ *     .setStartTime(Instant.now())
+ *     .setJitter(Duration.ofMinutes(5))
+ *     .build();
+ * }</pre>
+ *
+ * <p>The cron timezone can be embedded with a {@code CRON_TZ=<tz>} prefix, e.g. {@code
+ * "CRON_TZ=America/Los_Angeles 0 6 * * *"}. If omitted, UTC is assumed.
+ */
+public final class ScheduleSpec {
+
+  private final String cronExpression;
+  private final Instant startTime;
+  private final Instant endTime;
+  private final Duration jitter;
+
+  private ScheduleSpec(Builder b) {
+    this.cronExpression = b.cronExpression;
+    this.startTime = b.startTime;
+    this.endTime = b.endTime;
+    this.jitter = b.jitter;
+  }
+
+  /**
+   * Standard cron expression, e.g. {@code "0 6 * * *"} (daily at 06:00 UTC).
+   *
+   * <p>Timezone prefix is supported: {@code "CRON_TZ=America/New_York 0 9 * * 1-5"}.
+   */
+  public String getCronExpression() {
+    return cronExpression;
+  }
+
+  /** Earliest time the schedule may fire. {@code null} means start immediately. */
+  public Instant getStartTime() {
+    return startTime;
+  }
+
+  /** Latest time the schedule may fire. {@code null} means run indefinitely. */
+  public Instant getEndTime() {
+    return endTime;
+  }
+
+  /**
+   * Random jitter added to each fire time to spread load. The actual fire time is offset by a
+   * random duration uniformly drawn from {@code [0, jitter)}. {@code null} means no jitter.
+   */
+  public Duration getJitter() {
+    return jitter;
+  }
+
+  /** Returns a new builder pre-populated with the values from this instance. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  /** Returns a new empty builder. */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ScheduleSpec)) return false;
+    ScheduleSpec that = (ScheduleSpec) o;
+    return Objects.equals(cronExpression, that.cronExpression)
+        && Objects.equals(startTime, that.startTime)
+        && Objects.equals(endTime, that.endTime)
+        && Objects.equals(jitter, that.jitter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(cronExpression, startTime, endTime, jitter);
+  }
+
+  @Override
+  public String toString() {
+    return "ScheduleSpec{"
+        + "cronExpression='"
+        + cronExpression
+        + "', startTime="
+        + startTime
+        + ", endTime="
+        + endTime
+        + ", jitter="
+        + jitter
+        + '}';
+  }
+
+  public static final class Builder {
+
+    private String cronExpression;
+    private Instant startTime;
+    private Instant endTime;
+    private Duration jitter;
+
+    private Builder() {}
+
+    private Builder(ScheduleSpec src) {
+      this.cronExpression = src.cronExpression;
+      this.startTime = src.startTime;
+      this.endTime = src.endTime;
+      this.jitter = src.jitter;
+    }
+
+    /** @see ScheduleSpec#getCronExpression() */
+    public Builder setCronExpression(String cronExpression) {
+      this.cronExpression = cronExpression;
+      return this;
+    }
+
+    /** @see ScheduleSpec#getStartTime() */
+    public Builder setStartTime(Instant startTime) {
+      this.startTime = startTime;
+      return this;
+    }
+
+    /** @see ScheduleSpec#getEndTime() */
+    public Builder setEndTime(Instant endTime) {
+      this.endTime = endTime;
+      return this;
+    }
+
+    /** @see ScheduleSpec#getJitter() */
+    public Builder setJitter(Duration jitter) {
+      this.jitter = jitter;
+      return this;
+    }
+
+    public ScheduleSpec build() {
+      return new ScheduleSpec(this);
+    }
+  }
+}

--- a/src/main/java/com/uber/cadence/client/schedule/ScheduleState.java
+++ b/src/main/java/com/uber/cadence/client/schedule/ScheduleState.java
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Immutable snapshot of a schedule's pause state returned by {@link
+ * com.uber.cadence.client.WorkflowClient#describeSchedule}.
+ */
+public final class ScheduleState {
+
+  private final boolean paused;
+  private final String pauseReason;
+  private final Instant pausedAt;
+  private final String pausedBy;
+
+  public ScheduleState(boolean paused, String pauseReason, Instant pausedAt, String pausedBy) {
+    this.paused = paused;
+    this.pauseReason = pauseReason;
+    this.pausedAt = pausedAt;
+    this.pausedBy = pausedBy;
+  }
+
+  /** Whether the schedule is currently paused. */
+  public boolean isPaused() {
+    return paused;
+  }
+
+  /**
+   * Human-readable reason the schedule was paused. Non-null only when {@link #isPaused()} is {@code
+   * true}.
+   */
+  public String getPauseReason() {
+    return pauseReason;
+  }
+
+  /** When the schedule was paused. {@code null} when not paused. */
+  public Instant getPausedAt() {
+    return pausedAt;
+  }
+
+  /** Identity of the actor that paused the schedule. {@code null} when not paused. */
+  public String getPausedBy() {
+    return pausedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ScheduleState)) return false;
+    ScheduleState that = (ScheduleState) o;
+    return paused == that.paused
+        && Objects.equals(pauseReason, that.pauseReason)
+        && Objects.equals(pausedAt, that.pausedAt)
+        && Objects.equals(pausedBy, that.pausedBy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(paused, pauseReason, pausedAt, pausedBy);
+  }
+
+  @Override
+  public String toString() {
+    return "ScheduleState{"
+        + "paused="
+        + paused
+        + ", pauseReason='"
+        + pauseReason
+        + "', pausedAt="
+        + pausedAt
+        + ", pausedBy='"
+        + pausedBy
+        + "'}";
+  }
+}

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/EnumMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/EnumMapper.java
@@ -613,4 +613,74 @@ public final class EnumMapper {
     }
     throw new IllegalArgumentException("unexpected enum value");
   }
+
+  public static ScheduleOverlapPolicy scheduleOverlapPolicy(
+      com.uber.cadence.client.schedule.ScheduleOverlapPolicy t) {
+    if (t == null) {
+      return ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_INVALID;
+    }
+    switch (t) {
+      case SKIP_NEW:
+        return ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_SKIP_NEW;
+      case BUFFER:
+        return ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER;
+      case CONCURRENT:
+        return ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT;
+      case CANCEL_PREVIOUS:
+        return ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CANCEL_PREVIOUS;
+      case TERMINATE_PREVIOUS:
+        return ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_TERMINATE_PREVIOUS;
+    }
+    throw new IllegalArgumentException("unexpected enum value");
+  }
+
+  public static com.uber.cadence.client.schedule.ScheduleOverlapPolicy scheduleOverlapPolicy(
+      ScheduleOverlapPolicy t) {
+    switch (t) {
+      case SCHEDULE_OVERLAP_POLICY_INVALID:
+        return null;
+      case SCHEDULE_OVERLAP_POLICY_SKIP_NEW:
+        return com.uber.cadence.client.schedule.ScheduleOverlapPolicy.SKIP_NEW;
+      case SCHEDULE_OVERLAP_POLICY_BUFFER:
+        return com.uber.cadence.client.schedule.ScheduleOverlapPolicy.BUFFER;
+      case SCHEDULE_OVERLAP_POLICY_CONCURRENT:
+        return com.uber.cadence.client.schedule.ScheduleOverlapPolicy.CONCURRENT;
+      case SCHEDULE_OVERLAP_POLICY_CANCEL_PREVIOUS:
+        return com.uber.cadence.client.schedule.ScheduleOverlapPolicy.CANCEL_PREVIOUS;
+      case SCHEDULE_OVERLAP_POLICY_TERMINATE_PREVIOUS:
+        return com.uber.cadence.client.schedule.ScheduleOverlapPolicy.TERMINATE_PREVIOUS;
+    }
+    throw new IllegalArgumentException("unexpected enum value");
+  }
+
+  public static ScheduleCatchUpPolicy scheduleCatchUpPolicy(
+      com.uber.cadence.client.schedule.ScheduleCatchUpPolicy t) {
+    if (t == null) {
+      return ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_INVALID;
+    }
+    switch (t) {
+      case SKIP:
+        return ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP;
+      case ONE:
+        return ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE;
+      case ALL:
+        return ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL;
+    }
+    throw new IllegalArgumentException("unexpected enum value");
+  }
+
+  public static com.uber.cadence.client.schedule.ScheduleCatchUpPolicy scheduleCatchUpPolicy(
+      ScheduleCatchUpPolicy t) {
+    switch (t) {
+      case SCHEDULE_CATCH_UP_POLICY_INVALID:
+        return null;
+      case SCHEDULE_CATCH_UP_POLICY_SKIP:
+        return com.uber.cadence.client.schedule.ScheduleCatchUpPolicy.SKIP;
+      case SCHEDULE_CATCH_UP_POLICY_ONE:
+        return com.uber.cadence.client.schedule.ScheduleCatchUpPolicy.ONE;
+      case SCHEDULE_CATCH_UP_POLICY_ALL:
+        return com.uber.cadence.client.schedule.ScheduleCatchUpPolicy.ALL;
+    }
+    throw new IllegalArgumentException("unexpected enum value");
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/Helpers.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/Helpers.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Int64Value;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -95,5 +96,33 @@ class Helpers {
       return null;
     }
     return t.toByteArray();
+  }
+
+  static Timestamp instantToTimestamp(Instant t) {
+    if (t == null) {
+      return null;
+    }
+    return Timestamp.newBuilder().setSeconds(t.getEpochSecond()).setNanos(t.getNano()).build();
+  }
+
+  static Instant timestampToInstant(Timestamp t) {
+    if (t == null || (t.getSeconds() == 0 && t.getNanos() == 0)) {
+      return null;
+    }
+    return Instant.ofEpochSecond(t.getSeconds(), t.getNanos());
+  }
+
+  static Duration javaDurationToProtoDuration(java.time.Duration d) {
+    if (d == null) {
+      return null;
+    }
+    return Duration.newBuilder().setSeconds(d.getSeconds()).setNanos(d.getNano()).build();
+  }
+
+  static java.time.Duration protoDurationToJavaDuration(Duration d) {
+    if (d == null || (d.getSeconds() == 0 && d.getNanos() == 0)) {
+      return null;
+    }
+    return java.time.Duration.ofSeconds(d.getSeconds(), d.getNanos());
   }
 }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/RequestMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/RequestMapper.java
@@ -53,9 +53,13 @@ import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.w
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.workflowType;
 import static com.uber.cadence.internal.compatibility.proto.mappers.TypeMapper.workflowTypeFilter;
 
+import com.uber.cadence.api.v1.BackfillScheduleRequest;
 import com.uber.cadence.api.v1.CountWorkflowExecutionsRequest;
+import com.uber.cadence.api.v1.CreateScheduleRequest;
+import com.uber.cadence.api.v1.DeleteScheduleRequest;
 import com.uber.cadence.api.v1.DeprecateDomainRequest;
 import com.uber.cadence.api.v1.DescribeDomainRequest;
+import com.uber.cadence.api.v1.DescribeScheduleRequest;
 import com.uber.cadence.api.v1.DescribeTaskListRequest;
 import com.uber.cadence.api.v1.DescribeWorkflowExecutionRequest;
 import com.uber.cadence.api.v1.GetTaskListsByDomainRequest;
@@ -64,8 +68,10 @@ import com.uber.cadence.api.v1.ListArchivedWorkflowExecutionsRequest;
 import com.uber.cadence.api.v1.ListClosedWorkflowExecutionsRequest;
 import com.uber.cadence.api.v1.ListDomainsRequest;
 import com.uber.cadence.api.v1.ListOpenWorkflowExecutionsRequest;
+import com.uber.cadence.api.v1.ListSchedulesRequest;
 import com.uber.cadence.api.v1.ListTaskListPartitionsRequest;
 import com.uber.cadence.api.v1.ListWorkflowExecutionsRequest;
+import com.uber.cadence.api.v1.PauseScheduleRequest;
 import com.uber.cadence.api.v1.PollForActivityTaskRequest;
 import com.uber.cadence.api.v1.PollForDecisionTaskRequest;
 import com.uber.cadence.api.v1.QueryWorkflowRequest;
@@ -93,8 +99,10 @@ import com.uber.cadence.api.v1.SignalWorkflowExecutionRequest;
 import com.uber.cadence.api.v1.StartWorkflowExecutionAsyncRequest;
 import com.uber.cadence.api.v1.StartWorkflowExecutionRequest;
 import com.uber.cadence.api.v1.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.api.v1.UnpauseScheduleRequest;
 import com.uber.cadence.api.v1.UpdateDomainRequest;
 import com.uber.cadence.api.v1.UpdateDomainRequest.Builder;
+import com.uber.cadence.api.v1.UpdateScheduleRequest;
 import com.uber.cadence.api.v1.WorkflowQueryResult;
 import java.util.ArrayList;
 import java.util.List;
@@ -1010,5 +1018,137 @@ public class RequestMapper {
     return RefreshWorkflowTasksRequest.newBuilder()
         .setDomain(request.getDomain() != null ? request.getDomain() : "")
         .build();
+  }
+
+  public static CreateScheduleRequest createScheduleRequest(
+      com.uber.cadence.CreateScheduleRequest t) {
+    if (t == null) {
+      return null;
+    }
+    CreateScheduleRequest.Builder b =
+        CreateScheduleRequest.newBuilder()
+            .setDomain(nullToEmpty(t.getDomain()))
+            .setScheduleId(nullToEmpty(t.getScheduleId()))
+            .setSpec(TypeMapper.scheduleSpec(t.getSpec()))
+            .setAction(TypeMapper.scheduleAction(t.getAction()))
+            .setPolicies(TypeMapper.schedulePolicies(t.getPolicies()));
+    if (t.getMemo() != null) {
+      b.setMemo(memo(t.getMemo()));
+    }
+    if (t.getSearchAttributes() != null) {
+      b.setSearchAttributes(searchAttributes(t.getSearchAttributes()));
+    }
+    return b.build();
+  }
+
+  public static DescribeScheduleRequest describeScheduleRequest(
+      com.uber.cadence.DescribeScheduleRequest t) {
+    if (t == null) {
+      return null;
+    }
+    return DescribeScheduleRequest.newBuilder()
+        .setDomain(nullToEmpty(t.getDomain()))
+        .setScheduleId(nullToEmpty(t.getScheduleId()))
+        .build();
+  }
+
+  public static UpdateScheduleRequest updateScheduleRequest(
+      com.uber.cadence.UpdateScheduleRequest t) {
+    if (t == null) {
+      return null;
+    }
+    UpdateScheduleRequest.Builder b =
+        UpdateScheduleRequest.newBuilder()
+            .setDomain(nullToEmpty(t.getDomain()))
+            .setScheduleId(nullToEmpty(t.getScheduleId()))
+            .setSpec(TypeMapper.scheduleSpec(t.getSpec()))
+            .setAction(TypeMapper.scheduleAction(t.getAction()))
+            .setPolicies(TypeMapper.schedulePolicies(t.getPolicies()));
+    if (t.getSearchAttributes() != null) {
+      b.setSearchAttributes(searchAttributes(t.getSearchAttributes()));
+    }
+    return b.build();
+  }
+
+  public static DeleteScheduleRequest deleteScheduleRequest(
+      com.uber.cadence.DeleteScheduleRequest t) {
+    if (t == null) {
+      return null;
+    }
+    return DeleteScheduleRequest.newBuilder()
+        .setDomain(nullToEmpty(t.getDomain()))
+        .setScheduleId(nullToEmpty(t.getScheduleId()))
+        .build();
+  }
+
+  public static PauseScheduleRequest pauseScheduleRequest(com.uber.cadence.PauseScheduleRequest t) {
+    if (t == null) {
+      return null;
+    }
+    PauseScheduleRequest.Builder b =
+        PauseScheduleRequest.newBuilder()
+            .setDomain(nullToEmpty(t.getDomain()))
+            .setScheduleId(nullToEmpty(t.getScheduleId()));
+    if (t.getReason() != null) {
+      b.setReason(t.getReason());
+    }
+    if (t.getIdentity() != null) {
+      b.setIdentity(t.getIdentity());
+    }
+    return b.build();
+  }
+
+  public static UnpauseScheduleRequest unpauseScheduleRequest(
+      com.uber.cadence.UnpauseScheduleRequest t) {
+    if (t == null) {
+      return null;
+    }
+    UnpauseScheduleRequest.Builder b =
+        UnpauseScheduleRequest.newBuilder()
+            .setDomain(nullToEmpty(t.getDomain()))
+            .setScheduleId(nullToEmpty(t.getScheduleId()));
+    if (t.getReason() != null) {
+      b.setReason(t.getReason());
+    }
+    if (t.getCatchUpPolicy() != null) {
+      b.setCatchUpPolicy(EnumMapper.scheduleCatchUpPolicy(t.getCatchUpPolicy()));
+    }
+    return b.build();
+  }
+
+  public static BackfillScheduleRequest backfillScheduleRequest(
+      com.uber.cadence.BackfillScheduleRequest t) {
+    if (t == null) {
+      return null;
+    }
+    BackfillScheduleRequest.Builder b =
+        BackfillScheduleRequest.newBuilder()
+            .setDomain(nullToEmpty(t.getDomain()))
+            .setScheduleId(nullToEmpty(t.getScheduleId()))
+            .setOverlapPolicy(EnumMapper.scheduleOverlapPolicy(t.getOverlapPolicy()));
+    if (t.getStartTime() != null) {
+      b.setStartTime(Helpers.instantToTimestamp(t.getStartTime()));
+    }
+    if (t.getEndTime() != null) {
+      b.setEndTime(Helpers.instantToTimestamp(t.getEndTime()));
+    }
+    if (t.getBackfillId() != null) {
+      b.setBackfillId(t.getBackfillId());
+    }
+    return b.build();
+  }
+
+  public static ListSchedulesRequest listSchedulesRequest(com.uber.cadence.ListSchedulesRequest t) {
+    if (t == null) {
+      return null;
+    }
+    ListSchedulesRequest.Builder b =
+        ListSchedulesRequest.newBuilder()
+            .setDomain(nullToEmpty(t.getDomain()))
+            .setPageSize(t.getPageSize());
+    if (t.getNextPageToken() != null) {
+      b.setNextPageToken(arrayToByteString(t.getNextPageToken()));
+    }
+    return b.build();
   }
 }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/ResponseMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/ResponseMapper.java
@@ -518,4 +518,35 @@ public class ResponseMapper {
                 Collectors.toMap(Map.Entry::getKey, e -> describeTaskListResponse(e.getValue()))));
     return res;
   }
+
+  public static com.uber.cadence.DescribeScheduleResponse describeScheduleResponse(
+      com.uber.cadence.api.v1.DescribeScheduleResponse t) {
+    if (t == null) {
+      return null;
+    }
+    return new com.uber.cadence.DescribeScheduleResponse()
+        .setSpec(TypeMapper.scheduleSpec(t.getSpec()))
+        .setAction(TypeMapper.scheduleAction(t.getAction()))
+        .setPolicies(TypeMapper.schedulePolicies(t.getPolicies()))
+        .setState(TypeMapper.scheduleState(t.getState()))
+        .setInfo(TypeMapper.scheduleInfo(t.getInfo()));
+  }
+
+  public static com.uber.cadence.ListSchedulesResponse listSchedulesResponse(
+      com.uber.cadence.api.v1.ListSchedulesResponse t) {
+    if (t == null) {
+      return null;
+    }
+    java.util.List<com.uber.cadence.client.schedule.ScheduleListEntry> entries =
+        new java.util.ArrayList<>();
+    for (com.uber.cadence.api.v1.ScheduleListEntry e : t.getSchedulesList()) {
+      com.uber.cadence.client.schedule.ScheduleListEntry entry = TypeMapper.scheduleListEntry(e);
+      if (entry != null) {
+        entries.add(entry);
+      }
+    }
+    return new com.uber.cadence.ListSchedulesResponse()
+        .setSchedules(entries)
+        .setNextPageToken(byteStringToArray(t.getNextPageToken()));
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/TypeMapper.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/mappers/TypeMapper.java
@@ -1088,4 +1088,235 @@ class TypeMapper {
     attr.setName(t.getName());
     return attr;
   }
+
+  // --- Schedule type helpers ---
+
+  static com.uber.cadence.api.v1.ScheduleSpec scheduleSpec(
+      com.uber.cadence.client.schedule.ScheduleSpec t) {
+    if (t == null) {
+      return com.uber.cadence.api.v1.ScheduleSpec.newBuilder().build();
+    }
+    com.uber.cadence.api.v1.ScheduleSpec.Builder b =
+        com.uber.cadence.api.v1.ScheduleSpec.newBuilder();
+    if (t.getCronExpression() != null) {
+      b.setCronExpression(t.getCronExpression());
+    }
+    if (t.getStartTime() != null) {
+      b.setStartTime(Helpers.instantToTimestamp(t.getStartTime()));
+    }
+    if (t.getEndTime() != null) {
+      b.setEndTime(Helpers.instantToTimestamp(t.getEndTime()));
+    }
+    if (t.getJitter() != null) {
+      b.setJitter(Helpers.javaDurationToProtoDuration(t.getJitter()));
+    }
+    return b.build();
+  }
+
+  static com.uber.cadence.client.schedule.ScheduleSpec scheduleSpec(
+      com.uber.cadence.api.v1.ScheduleSpec t) {
+    if (t == null) {
+      return null;
+    }
+    return com.uber.cadence.client.schedule.ScheduleSpec.newBuilder()
+        .setCronExpression(t.getCronExpression().isEmpty() ? null : t.getCronExpression())
+        .setStartTime(Helpers.timestampToInstant(t.getStartTime()))
+        .setEndTime(Helpers.timestampToInstant(t.getEndTime()))
+        .setJitter(Helpers.protoDurationToJavaDuration(t.getJitter()))
+        .build();
+  }
+
+  static com.uber.cadence.api.v1.ScheduleAction scheduleAction(
+      com.uber.cadence.client.schedule.ScheduleAction t) {
+    if (t == null) {
+      return com.uber.cadence.api.v1.ScheduleAction.newBuilder().build();
+    }
+    com.uber.cadence.api.v1.ScheduleAction.Builder b =
+        com.uber.cadence.api.v1.ScheduleAction.newBuilder();
+    if (t.getStartWorkflow() != null) {
+      b.setStartWorkflow(startWorkflowAction(t.getStartWorkflow()));
+    }
+    return b.build();
+  }
+
+  private static com.uber.cadence.api.v1.ScheduleAction.StartWorkflowAction startWorkflowAction(
+      com.uber.cadence.client.schedule.ScheduleAction.StartWorkflowAction t) {
+    com.uber.cadence.api.v1.ScheduleAction.StartWorkflowAction.Builder b =
+        com.uber.cadence.api.v1.ScheduleAction.StartWorkflowAction.newBuilder();
+    if (t.getWorkflowType() != null) {
+      b.setWorkflowType(WorkflowType.newBuilder().setName(t.getWorkflowType()).build());
+    }
+    if (t.getTaskList() != null) {
+      b.setTaskList(TaskList.newBuilder().setName(t.getTaskList()).build());
+    }
+    if (t.getInput() != null) {
+      b.setInput(
+          Payload.newBuilder()
+              .setData(com.google.protobuf.ByteString.copyFrom(t.getInput()))
+              .build());
+    }
+    if (t.getWorkflowIdPrefix() != null) {
+      b.setWorkflowIdPrefix(t.getWorkflowIdPrefix());
+    }
+    if (t.getExecutionStartToCloseTimeout() != null) {
+      b.setExecutionStartToCloseTimeout(
+          Helpers.javaDurationToProtoDuration(t.getExecutionStartToCloseTimeout()));
+    }
+    if (t.getTaskStartToCloseTimeout() != null) {
+      b.setTaskStartToCloseTimeout(
+          Helpers.javaDurationToProtoDuration(t.getTaskStartToCloseTimeout()));
+    }
+    if (t.getRetryOptions() != null) {
+      b.setRetryPolicy(retryPolicyFromOptions(t.getRetryOptions()));
+    }
+    return b.build();
+  }
+
+  private static RetryPolicy retryPolicyFromOptions(com.uber.cadence.common.RetryOptions t) {
+    RetryPolicy.Builder b = RetryPolicy.newBuilder();
+    if (t.getInitialInterval() != null) {
+      b.setInitialInterval(Helpers.javaDurationToProtoDuration(t.getInitialInterval()));
+    }
+    b.setBackoffCoefficient(t.getBackoffCoefficient());
+    if (t.getMaximumInterval() != null) {
+      b.setMaximumInterval(Helpers.javaDurationToProtoDuration(t.getMaximumInterval()));
+    }
+    b.setMaximumAttempts(t.getMaximumAttempts());
+    if (t.getExpiration() != null) {
+      b.setExpirationInterval(Helpers.javaDurationToProtoDuration(t.getExpiration()));
+    }
+    if (t.getDoNotRetry() != null) {
+      for (Class<? extends Throwable> c : t.getDoNotRetry()) {
+        b.addNonRetryableErrorReasons(c.getName());
+      }
+    }
+    return b.build();
+  }
+
+  static com.uber.cadence.client.schedule.ScheduleAction scheduleAction(
+      com.uber.cadence.api.v1.ScheduleAction t) {
+    if (t == null || !t.hasStartWorkflow()) {
+      return null;
+    }
+    return com.uber.cadence.client.schedule.ScheduleAction.newBuilder()
+        .setStartWorkflow(startWorkflowAction(t.getStartWorkflow()))
+        .build();
+  }
+
+  private static com.uber.cadence.client.schedule.ScheduleAction.StartWorkflowAction
+      startWorkflowAction(com.uber.cadence.api.v1.ScheduleAction.StartWorkflowAction t) {
+    com.uber.cadence.client.schedule.ScheduleAction.StartWorkflowAction.Builder b =
+        com.uber.cadence.client.schedule.ScheduleAction.StartWorkflowAction.newBuilder();
+    if (t.hasWorkflowType()) {
+      b.setWorkflowType(t.getWorkflowType().getName());
+    }
+    if (t.hasTaskList()) {
+      b.setTaskList(t.getTaskList().getName());
+    }
+    if (t.hasInput() && !t.getInput().getData().isEmpty()) {
+      b.setInput(t.getInput().getData().toByteArray());
+    }
+    if (!t.getWorkflowIdPrefix().isEmpty()) {
+      b.setWorkflowIdPrefix(t.getWorkflowIdPrefix());
+    }
+    if (t.hasExecutionStartToCloseTimeout()) {
+      b.setExecutionStartToCloseTimeout(
+          Helpers.protoDurationToJavaDuration(t.getExecutionStartToCloseTimeout()));
+    }
+    if (t.hasTaskStartToCloseTimeout()) {
+      b.setTaskStartToCloseTimeout(
+          Helpers.protoDurationToJavaDuration(t.getTaskStartToCloseTimeout()));
+    }
+    return b.build();
+  }
+
+  static com.uber.cadence.api.v1.SchedulePolicies schedulePolicies(
+      com.uber.cadence.client.schedule.SchedulePolicies t) {
+    if (t == null) {
+      return com.uber.cadence.api.v1.SchedulePolicies.newBuilder().build();
+    }
+    com.uber.cadence.api.v1.SchedulePolicies.Builder b =
+        com.uber.cadence.api.v1.SchedulePolicies.newBuilder()
+            .setOverlapPolicy(EnumMapper.scheduleOverlapPolicy(t.getOverlapPolicy()))
+            .setCatchUpPolicy(EnumMapper.scheduleCatchUpPolicy(t.getCatchUpPolicy()))
+            .setPauseOnFailure(t.isPauseOnFailure())
+            .setBufferLimit(t.getBufferLimit())
+            .setConcurrencyLimit(t.getConcurrencyLimit());
+    if (t.getCatchUpWindow() != null) {
+      b.setCatchUpWindow(Helpers.javaDurationToProtoDuration(t.getCatchUpWindow()));
+    }
+    return b.build();
+  }
+
+  static com.uber.cadence.client.schedule.SchedulePolicies schedulePolicies(
+      com.uber.cadence.api.v1.SchedulePolicies t) {
+    if (t == null) {
+      return null;
+    }
+    return com.uber.cadence.client.schedule.SchedulePolicies.newBuilder()
+        .setOverlapPolicy(EnumMapper.scheduleOverlapPolicy(t.getOverlapPolicy()))
+        .setCatchUpPolicy(EnumMapper.scheduleCatchUpPolicy(t.getCatchUpPolicy()))
+        .setCatchUpWindow(Helpers.protoDurationToJavaDuration(t.getCatchUpWindow()))
+        .setPauseOnFailure(t.getPauseOnFailure())
+        .setBufferLimit(t.getBufferLimit())
+        .setConcurrencyLimit(t.getConcurrencyLimit())
+        .build();
+  }
+
+  static com.uber.cadence.client.schedule.ScheduleState scheduleState(
+      com.uber.cadence.api.v1.ScheduleState t) {
+    if (t == null) {
+      return new com.uber.cadence.client.schedule.ScheduleState(false, null, null, null);
+    }
+    String pauseReason = null;
+    java.time.Instant pausedAt = null;
+    String pausedBy = null;
+    if (t.getPaused() && t.hasPauseInfo()) {
+      com.uber.cadence.api.v1.SchedulePauseInfo pi = t.getPauseInfo();
+      pauseReason = pi.getReason().isEmpty() ? null : pi.getReason();
+      pausedAt = Helpers.timestampToInstant(pi.getPausedAt());
+      pausedBy = pi.getPausedBy().isEmpty() ? null : pi.getPausedBy();
+    }
+    return new com.uber.cadence.client.schedule.ScheduleState(
+        t.getPaused(), pauseReason, pausedAt, pausedBy);
+  }
+
+  static com.uber.cadence.client.schedule.ScheduleInfo scheduleInfo(
+      com.uber.cadence.api.v1.ScheduleInfo t) {
+    if (t == null) {
+      return null;
+    }
+    java.util.List<com.uber.cadence.client.schedule.ScheduleInfo.BackfillInfo> backfills =
+        new java.util.ArrayList<>();
+    for (com.uber.cadence.api.v1.BackfillInfo bf : t.getOngoingBackfillsList()) {
+      backfills.add(
+          new com.uber.cadence.client.schedule.ScheduleInfo.BackfillInfo(
+              bf.getBackfillId().isEmpty() ? null : bf.getBackfillId(),
+              Helpers.timestampToInstant(bf.getStartTime()),
+              Helpers.timestampToInstant(bf.getEndTime()),
+              bf.getRunsCompleted(),
+              bf.getRunsTotal()));
+    }
+    return new com.uber.cadence.client.schedule.ScheduleInfo(
+        Helpers.timestampToInstant(t.getLastRunTime()),
+        Helpers.timestampToInstant(t.getNextRunTime()),
+        t.getTotalRuns(),
+        Helpers.timestampToInstant(t.getCreateTime()),
+        Helpers.timestampToInstant(t.getLastUpdateTime()),
+        backfills,
+        0,
+        0);
+  }
+
+  static com.uber.cadence.client.schedule.ScheduleListEntry scheduleListEntry(
+      com.uber.cadence.api.v1.ScheduleListEntry t) {
+    if (t == null) {
+      return null;
+    }
+    return new com.uber.cadence.client.schedule.ScheduleListEntry(
+        t.getScheduleId(),
+        t.hasWorkflowType() ? t.getWorkflowType().getName() : null,
+        scheduleState(t.hasState() ? t.getState() : null),
+        t.getCronExpression().isEmpty() ? null : t.getCronExpression());
+  }
 }

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
@@ -22,6 +22,7 @@ import com.uber.cadence.api.v1.DomainAPIGrpc;
 import com.uber.cadence.api.v1.MetaAPIGrpc;
 import com.uber.cadence.api.v1.MetaAPIGrpc.MetaAPIBlockingStub;
 import com.uber.cadence.api.v1.MetaAPIGrpc.MetaAPIFutureStub;
+import com.uber.cadence.api.v1.ScheduleAPIGrpc;
 import com.uber.cadence.api.v1.VisibilityAPIGrpc;
 import com.uber.cadence.api.v1.VisibilityAPIGrpc.VisibilityAPIBlockingStub;
 import com.uber.cadence.api.v1.VisibilityAPIGrpc.VisibilityAPIFutureStub;
@@ -93,6 +94,8 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
   private final WorkflowAPIGrpc.WorkflowAPIFutureStub workflowFutureStub;
   private final MetaAPIGrpc.MetaAPIBlockingStub metaBlockingStub;
   private final MetaAPIGrpc.MetaAPIFutureStub metaFutureStub;
+  private final ScheduleAPIGrpc.ScheduleAPIBlockingStub scheduleBlockingStub;
+  private final ScheduleAPIGrpc.ScheduleAPIFutureStub scheduleFutureStub;
 
   GrpcServiceStubs(ClientOptions options) {
     this.options = options;
@@ -146,6 +149,8 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
     this.workflowFutureStub = WorkflowAPIGrpc.newFutureStub(interceptedChannel);
     this.metaBlockingStub = MetaAPIGrpc.newBlockingStub(interceptedChannel);
     this.metaFutureStub = MetaAPIGrpc.newFutureStub(interceptedChannel);
+    this.scheduleBlockingStub = ScheduleAPIGrpc.newBlockingStub(interceptedChannel);
+    this.scheduleFutureStub = ScheduleAPIGrpc.newFutureStub(interceptedChannel);
   }
 
   private ClientInterceptor newAuthorizationInterceptor(IAuthorizationProvider provider) {
@@ -410,6 +415,16 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
   @Override
   public WorkflowAPIFutureStub workflowFutureStub() {
     return workflowFutureStub;
+  }
+
+  @Override
+  public ScheduleAPIGrpc.ScheduleAPIBlockingStub scheduleBlockingStub() {
+    return scheduleBlockingStub;
+  }
+
+  @Override
+  public ScheduleAPIGrpc.ScheduleAPIFutureStub scheduleFutureStub() {
+    return scheduleFutureStub;
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/IGrpcServiceStubs.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/IGrpcServiceStubs.java
@@ -18,6 +18,7 @@ package com.uber.cadence.internal.compatibility.proto.serviceclient;
 import com.uber.cadence.api.v1.DomainAPIGrpc;
 import com.uber.cadence.api.v1.MetaAPIGrpc.MetaAPIBlockingStub;
 import com.uber.cadence.api.v1.MetaAPIGrpc.MetaAPIFutureStub;
+import com.uber.cadence.api.v1.ScheduleAPIGrpc;
 import com.uber.cadence.api.v1.VisibilityAPIGrpc;
 import com.uber.cadence.api.v1.WorkerAPIGrpc;
 import com.uber.cadence.api.v1.WorkflowAPIGrpc;
@@ -70,6 +71,12 @@ public interface IGrpcServiceStubs {
 
   /** @return Future (asynchronous) stub to meta service. */
   MetaAPIBlockingStub metaBlockingStub();
+
+  /** @return Blocking (synchronous) stub to schedule service. */
+  ScheduleAPIGrpc.ScheduleAPIBlockingStub scheduleBlockingStub();
+
+  /** @return Future (asynchronous) stub to schedule service. */
+  ScheduleAPIGrpc.ScheduleAPIFutureStub scheduleFutureStub();
 
   void shutdown();
 

--- a/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestActivityEnvironmentInternal.java
@@ -583,10 +583,45 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     }
 
     @Override
-    public void RegisterDomain(
-        RegisterDomainRequest registerRequest, AsyncMethodCallback resultHandler)
+    public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
         throws CadenceError {
-      impl.RegisterDomain(registerRequest, resultHandler);
+      return impl.CreateSchedule(request);
+    }
+
+    @Override
+    public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+        throws CadenceError {
+      return impl.DescribeSchedule(request);
+    }
+
+    @Override
+    public void UpdateSchedule(UpdateScheduleRequest request) throws CadenceError {
+      impl.UpdateSchedule(request);
+    }
+
+    @Override
+    public void DeleteSchedule(DeleteScheduleRequest request) throws CadenceError {
+      impl.DeleteSchedule(request);
+    }
+
+    @Override
+    public void PauseSchedule(PauseScheduleRequest request) throws CadenceError {
+      impl.PauseSchedule(request);
+    }
+
+    @Override
+    public void UnpauseSchedule(UnpauseScheduleRequest request) throws CadenceError {
+      impl.UnpauseSchedule(request);
+    }
+
+    @Override
+    public void BackfillSchedule(BackfillScheduleRequest request) throws CadenceError {
+      impl.BackfillSchedule(request);
+    }
+
+    @Override
+    public ListSchedulesResponse ListSchedules(ListSchedulesRequest request) throws CadenceError {
+      return impl.ListSchedules(request);
     }
 
     @Override
@@ -925,6 +960,13 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     public void RegisterDomain(RegisterDomainRequest registerRequest)
         throws BadRequestError, InternalServiceError, DomainAlreadyExistsError, CadenceError {
       impl.RegisterDomain(registerRequest);
+    }
+
+    @Override
+    public void RegisterDomain(
+        RegisterDomainRequest registerRequest, AsyncMethodCallback resultHandler)
+        throws CadenceError {
+      impl.RegisterDomain(registerRequest, resultHandler);
     }
 
     @Override

--- a/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/TestWorkflowEnvironmentInternal.java
@@ -17,15 +17,21 @@
 
 package com.uber.cadence.internal.sync;
 
+import com.uber.cadence.BackfillScheduleRequest;
 import com.uber.cadence.BadRequestError;
 import com.uber.cadence.CadenceError;
 import com.uber.cadence.ClientVersionNotSupportedError;
 import com.uber.cadence.ClusterInfo;
 import com.uber.cadence.CountWorkflowExecutionsRequest;
 import com.uber.cadence.CountWorkflowExecutionsResponse;
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.CreateScheduleResponse;
+import com.uber.cadence.DeleteScheduleRequest;
 import com.uber.cadence.DeprecateDomainRequest;
 import com.uber.cadence.DescribeDomainRequest;
 import com.uber.cadence.DescribeDomainResponse;
+import com.uber.cadence.DescribeScheduleRequest;
+import com.uber.cadence.DescribeScheduleResponse;
 import com.uber.cadence.DescribeTaskListRequest;
 import com.uber.cadence.DescribeTaskListResponse;
 import com.uber.cadence.DescribeWorkflowExecutionRequest;
@@ -50,10 +56,13 @@ import com.uber.cadence.ListDomainsRequest;
 import com.uber.cadence.ListDomainsResponse;
 import com.uber.cadence.ListOpenWorkflowExecutionsRequest;
 import com.uber.cadence.ListOpenWorkflowExecutionsResponse;
+import com.uber.cadence.ListSchedulesRequest;
+import com.uber.cadence.ListSchedulesResponse;
 import com.uber.cadence.ListTaskListPartitionsRequest;
 import com.uber.cadence.ListTaskListPartitionsResponse;
 import com.uber.cadence.ListWorkflowExecutionsRequest;
 import com.uber.cadence.ListWorkflowExecutionsResponse;
+import com.uber.cadence.PauseScheduleRequest;
 import com.uber.cadence.PollForActivityTaskRequest;
 import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.PollForDecisionTaskRequest;
@@ -94,8 +103,10 @@ import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.StartWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.UnpauseScheduleRequest;
 import com.uber.cadence.UpdateDomainRequest;
 import com.uber.cadence.UpdateDomainResponse;
+import com.uber.cadence.UpdateScheduleRequest;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionAlreadyCompletedError;
 import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
@@ -462,6 +473,48 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
         throws BadRequestError, DomainNotActiveError, ServiceBusyError, EntityNotExistsError,
             CadenceError {
       impl.RefreshWorkflowTasks(request);
+    }
+
+    @Override
+    public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
+        throws CadenceError {
+      return impl.CreateSchedule(request);
+    }
+
+    @Override
+    public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+        throws CadenceError {
+      return impl.DescribeSchedule(request);
+    }
+
+    @Override
+    public void UpdateSchedule(UpdateScheduleRequest request) throws CadenceError {
+      impl.UpdateSchedule(request);
+    }
+
+    @Override
+    public void DeleteSchedule(DeleteScheduleRequest request) throws CadenceError {
+      impl.DeleteSchedule(request);
+    }
+
+    @Override
+    public void PauseSchedule(PauseScheduleRequest request) throws CadenceError {
+      impl.PauseSchedule(request);
+    }
+
+    @Override
+    public void UnpauseSchedule(UnpauseScheduleRequest request) throws CadenceError {
+      impl.UnpauseSchedule(request);
+    }
+
+    @Override
+    public void BackfillSchedule(BackfillScheduleRequest request) throws CadenceError {
+      impl.BackfillSchedule(request);
+    }
+
+    @Override
+    public ListSchedulesResponse ListSchedules(ListSchedulesRequest request) throws CadenceError {
+      return impl.ListSchedules(request);
     }
 
     @Override

--- a/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
+++ b/src/main/java/com/uber/cadence/internal/sync/WorkflowClientInternal.java
@@ -19,8 +19,18 @@ package com.uber.cadence.internal.sync;
 
 import com.google.common.base.Strings;
 import com.google.common.reflect.TypeToken;
+import com.uber.cadence.BackfillScheduleRequest;
 import com.uber.cadence.CadenceError;
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.DeleteScheduleRequest;
+import com.uber.cadence.DescribeScheduleRequest;
+import com.uber.cadence.DescribeScheduleResponse;
+import com.uber.cadence.ListSchedulesRequest;
+import com.uber.cadence.ListSchedulesResponse;
+import com.uber.cadence.PauseScheduleRequest;
 import com.uber.cadence.RefreshWorkflowTasksRequest;
+import com.uber.cadence.UnpauseScheduleRequest;
+import com.uber.cadence.UpdateScheduleRequest;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.client.ActivityCompletionClient;
 import com.uber.cadence.client.BatchRequest;
@@ -29,6 +39,14 @@ import com.uber.cadence.client.WorkflowClientInterceptor;
 import com.uber.cadence.client.WorkflowClientOptions;
 import com.uber.cadence.client.WorkflowOptions;
 import com.uber.cadence.client.WorkflowStub;
+import com.uber.cadence.client.schedule.ListSchedulesResult;
+import com.uber.cadence.client.schedule.ScheduleAction;
+import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
+import com.uber.cadence.client.schedule.ScheduleDescription;
+import com.uber.cadence.client.schedule.ScheduleOverlapPolicy;
+import com.uber.cadence.client.schedule.SchedulePolicies;
+import com.uber.cadence.client.schedule.ScheduleSpec;
+import com.uber.cadence.client.schedule.ScheduleState;
 import com.uber.cadence.internal.external.GenericWorkflowClientExternalImpl;
 import com.uber.cadence.internal.external.ManualActivityCompletionClientFactory;
 import com.uber.cadence.internal.external.ManualActivityCompletionClientFactoryImpl;
@@ -41,12 +59,15 @@ import com.uber.cadence.workflow.WorkflowMethod;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 public final class WorkflowClientInternal implements WorkflowClient {
 
@@ -222,6 +243,115 @@ public final class WorkflowClientInternal implements WorkflowClient {
   public void refreshWorkflowTasks(RefreshWorkflowTasksRequest refreshWorkflowTasksRequest)
       throws CadenceError {
     workflowService.RefreshWorkflowTasks(refreshWorkflowTasksRequest);
+  }
+
+  @Override
+  public void createSchedule(
+      String scheduleId,
+      ScheduleSpec spec,
+      ScheduleAction action,
+      SchedulePolicies policies,
+      ScheduleState state,
+      Map<String, Object> memo)
+      throws CadenceError {
+    String domain = clientOptions.getDomain();
+    CreateScheduleRequest req =
+        new CreateScheduleRequest()
+            .setDomain(domain)
+            .setScheduleId(scheduleId)
+            .setSpec(spec)
+            .setAction(action)
+            .setPolicies(policies);
+    workflowService.CreateSchedule(req);
+  }
+
+  @Override
+  public ScheduleDescription describeSchedule(String scheduleId) throws CadenceError {
+    String domain = clientOptions.getDomain();
+    DescribeScheduleResponse resp =
+        workflowService.DescribeSchedule(
+            new DescribeScheduleRequest().setDomain(domain).setScheduleId(scheduleId));
+    return new ScheduleDescription(
+        resp.getSpec(),
+        resp.getAction(),
+        resp.getPolicies(),
+        resp.getState(),
+        resp.getInfo(),
+        null,
+        null);
+  }
+
+  @Override
+  public void updateSchedule(
+      String scheduleId, Function<ScheduleDescription, ScheduleDescription> updater)
+      throws CadenceError {
+    ScheduleDescription current = describeSchedule(scheduleId);
+    ScheduleDescription updated = updater.apply(current);
+    String domain = clientOptions.getDomain();
+    workflowService.UpdateSchedule(
+        new UpdateScheduleRequest()
+            .setDomain(domain)
+            .setScheduleId(scheduleId)
+            .setSpec(updated.getSpec())
+            .setAction(updated.getAction())
+            .setPolicies(updated.getPolicies()));
+  }
+
+  @Override
+  public void deleteSchedule(String scheduleId) throws CadenceError {
+    String domain = clientOptions.getDomain();
+    workflowService.DeleteSchedule(
+        new DeleteScheduleRequest().setDomain(domain).setScheduleId(scheduleId));
+  }
+
+  @Override
+  public void pauseSchedule(String scheduleId, String reason) throws CadenceError {
+    String domain = clientOptions.getDomain();
+    workflowService.PauseSchedule(
+        new PauseScheduleRequest().setDomain(domain).setScheduleId(scheduleId).setReason(reason));
+  }
+
+  @Override
+  public void unpauseSchedule(String scheduleId, String reason) throws CadenceError {
+    unpauseSchedule(scheduleId, reason, null);
+  }
+
+  @Override
+  public void unpauseSchedule(String scheduleId, String reason, ScheduleCatchUpPolicy catchUpPolicy)
+      throws CadenceError {
+    String domain = clientOptions.getDomain();
+    workflowService.UnpauseSchedule(
+        new UnpauseScheduleRequest()
+            .setDomain(domain)
+            .setScheduleId(scheduleId)
+            .setReason(reason)
+            .setCatchUpPolicy(catchUpPolicy));
+  }
+
+  @Override
+  public void backfillSchedule(
+      String scheduleId, Instant startTime, Instant endTime, ScheduleOverlapPolicy overlapPolicy)
+      throws CadenceError {
+    String domain = clientOptions.getDomain();
+    workflowService.BackfillSchedule(
+        new BackfillScheduleRequest()
+            .setDomain(domain)
+            .setScheduleId(scheduleId)
+            .setStartTime(startTime)
+            .setEndTime(endTime)
+            .setOverlapPolicy(overlapPolicy));
+  }
+
+  @Override
+  public ListSchedulesResult listSchedules(int pageSize, byte[] nextPageToken) throws CadenceError {
+    String domain = clientOptions.getDomain();
+    ListSchedulesResponse resp =
+        workflowService.ListSchedules(
+            new ListSchedulesRequest()
+                .setDomain(domain)
+                .setPageSize(pageSize)
+                .setNextPageToken(nextPageToken));
+    return new ListSchedulesResult(resp.getSchedules(), resp.getNextPageToken());
   }
 
   public static WorkflowExecution start(Functions.Proc workflow) {

--- a/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
+++ b/src/main/java/com/uber/cadence/internal/testservice/TestWorkflowService.java
@@ -17,15 +17,21 @@
 
 package com.uber.cadence.internal.testservice;
 
+import com.uber.cadence.BackfillScheduleRequest;
 import com.uber.cadence.BadRequestError;
 import com.uber.cadence.CadenceError;
 import com.uber.cadence.ClientVersionNotSupportedError;
 import com.uber.cadence.ClusterInfo;
 import com.uber.cadence.CountWorkflowExecutionsRequest;
 import com.uber.cadence.CountWorkflowExecutionsResponse;
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.CreateScheduleResponse;
+import com.uber.cadence.DeleteScheduleRequest;
 import com.uber.cadence.DeprecateDomainRequest;
 import com.uber.cadence.DescribeDomainRequest;
 import com.uber.cadence.DescribeDomainResponse;
+import com.uber.cadence.DescribeScheduleRequest;
+import com.uber.cadence.DescribeScheduleResponse;
 import com.uber.cadence.DescribeTaskListRequest;
 import com.uber.cadence.DescribeTaskListResponse;
 import com.uber.cadence.DescribeWorkflowExecutionRequest;
@@ -50,10 +56,13 @@ import com.uber.cadence.ListDomainsRequest;
 import com.uber.cadence.ListDomainsResponse;
 import com.uber.cadence.ListOpenWorkflowExecutionsRequest;
 import com.uber.cadence.ListOpenWorkflowExecutionsResponse;
+import com.uber.cadence.ListSchedulesRequest;
+import com.uber.cadence.ListSchedulesResponse;
 import com.uber.cadence.ListTaskListPartitionsRequest;
 import com.uber.cadence.ListTaskListPartitionsResponse;
 import com.uber.cadence.ListWorkflowExecutionsRequest;
 import com.uber.cadence.ListWorkflowExecutionsResponse;
+import com.uber.cadence.PauseScheduleRequest;
 import com.uber.cadence.PollForActivityTaskRequest;
 import com.uber.cadence.PollForActivityTaskResponse;
 import com.uber.cadence.PollForDecisionTaskRequest;
@@ -96,8 +105,10 @@ import com.uber.cadence.StartWorkflowExecutionAsyncResponse;
 import com.uber.cadence.StartWorkflowExecutionRequest;
 import com.uber.cadence.StartWorkflowExecutionResponse;
 import com.uber.cadence.TerminateWorkflowExecutionRequest;
+import com.uber.cadence.UnpauseScheduleRequest;
 import com.uber.cadence.UpdateDomainRequest;
 import com.uber.cadence.UpdateDomainResponse;
+import com.uber.cadence.UpdateScheduleRequest;
 import com.uber.cadence.WorkflowExecution;
 import com.uber.cadence.WorkflowExecutionAlreadyCompletedError;
 import com.uber.cadence.WorkflowExecutionAlreadyStartedError;
@@ -867,6 +878,47 @@ public final class TestWorkflowService implements IWorkflowService {
   public void RefreshWorkflowTasks(RefreshWorkflowTasksRequest request)
       throws BadRequestError, DomainNotActiveError, ServiceBusyError, EntityNotExistsError,
           CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+      throws CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void UpdateSchedule(UpdateScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void DeleteSchedule(DeleteScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void PauseSchedule(PauseScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void UnpauseSchedule(UnpauseScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public void BackfillSchedule(BackfillScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public ListSchedulesResponse ListSchedules(ListSchedulesRequest request) throws CadenceError {
     throw new UnsupportedOperationException("not implemented");
   }
 

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowService.java
@@ -816,4 +816,92 @@ public interface IWorkflowService {
   void RefreshWorkflowTasks(
       RefreshWorkflowTasksRequest request, AsyncMethodCallback<Void> resultHandler)
       throws CadenceError;
+
+  // ---- Schedule API ----
+
+  /**
+   * Creates a new schedule in the domain.
+   *
+   * @throws BadRequestError if the schedule spec is invalid (e.g. bad cron expression)
+   * @throws WorkflowExecutionAlreadyStartedError if a schedule with the same ID already exists
+   * @throws EntityNotExistsError if the domain does not exist
+   * @throws CadenceError on other server errors
+   */
+  CreateScheduleResponse CreateSchedule(CreateScheduleRequest request)
+      throws BadRequestError, WorkflowExecutionAlreadyStartedError, EntityNotExistsError,
+          ServiceBusyError, DomainNotActiveError, LimitExceededError, CadenceError;
+
+  /**
+   * Returns the full configuration and runtime state of a schedule.
+   *
+   * @throws EntityNotExistsError if the schedule does not exist
+   * @throws CadenceError on other server errors
+   */
+  DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, CadenceError;
+
+  /**
+   * Replaces the spec, action, and policies of an existing schedule.
+   *
+   * <p>The server replaces the entire schedule configuration. Any field not included in the request
+   * is zeroed out — always use describe-first (read-modify-write) pattern via {@link
+   * com.uber.cadence.client.WorkflowClient#updateSchedule}.
+   *
+   * @throws EntityNotExistsError if the schedule does not exist
+   * @throws CadenceError on other server errors
+   */
+  void UpdateSchedule(UpdateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, CadenceError;
+
+  /**
+   * Permanently deletes a schedule. Running workflows triggered by this schedule are not affected.
+   *
+   * @throws EntityNotExistsError if the schedule does not exist
+   * @throws CadenceError on other server errors
+   */
+  void DeleteSchedule(DeleteScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          CadenceError;
+
+  /**
+   * Pauses a schedule. No new runs will be triggered while the schedule is paused.
+   *
+   * @throws EntityNotExistsError if the schedule does not exist
+   * @throws CadenceError on other server errors
+   */
+  void PauseSchedule(PauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          CadenceError;
+
+  /**
+   * Resumes a paused schedule. Optionally overrides the catch-up policy for the immediate catch-up
+   * pass on resume.
+   *
+   * @throws EntityNotExistsError if the schedule does not exist
+   * @throws CadenceError on other server errors
+   */
+  void UnpauseSchedule(UnpauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          CadenceError;
+
+  /**
+   * Triggers runs for all scheduled times within a historical time range. Backfill runs are subject
+   * to the configured overlap policy; excess runs may be dropped.
+   *
+   * @throws EntityNotExistsError if the schedule does not exist
+   * @throws CadenceError on other server errors
+   */
+  void BackfillSchedule(BackfillScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, CadenceError;
+
+  /**
+   * Lists schedules in a domain, paginated.
+   *
+   * @throws EntityNotExistsError if the domain does not exist
+   * @throws CadenceError on other server errors
+   */
+  ListSchedulesResponse ListSchedules(ListSchedulesRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, CadenceError;
 }

--- a/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
+++ b/src/main/java/com/uber/cadence/serviceclient/IWorkflowServiceBase.java
@@ -722,4 +722,45 @@ public class IWorkflowServiceBase implements IWorkflowService {
   public CompletableFuture<Boolean> isHealthy() {
     throw new UnsupportedOperationException("unimplemented");
   }
+
+  @Override
+  public CreateScheduleResponse CreateSchedule(CreateScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public DescribeScheduleResponse DescribeSchedule(DescribeScheduleRequest request)
+      throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void UpdateSchedule(UpdateScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void DeleteSchedule(DeleteScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void PauseSchedule(PauseScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void UnpauseSchedule(UnpauseScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public void BackfillSchedule(BackfillScheduleRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
+
+  @Override
+  public ListSchedulesResponse ListSchedules(ListSchedulesRequest request) throws CadenceError {
+    throw new UnsupportedOperationException("unimplemented");
+  }
 }

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceGrpc.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceGrpc.java
@@ -1392,4 +1392,117 @@ public class WorkflowServiceGrpc implements IWorkflowService {
       throws CadenceError {
     throw new UnsupportedOperationException("Unimplemented method 'DiagnoseWorkflowExecution'");
   }
+
+  // ---- Schedule API ----
+
+  @Override
+  public com.uber.cadence.CreateScheduleResponse CreateSchedule(
+      com.uber.cadence.CreateScheduleRequest request)
+      throws BadRequestError, WorkflowExecutionAlreadyStartedError, EntityNotExistsError,
+          ServiceBusyError, DomainNotActiveError, LimitExceededError, CadenceError {
+    try {
+      com.uber.cadence.api.v1.CreateScheduleResponse resp =
+          grpcServiceStubs
+              .scheduleBlockingStub()
+              .createSchedule(RequestMapper.createScheduleRequest(request));
+      return new com.uber.cadence.CreateScheduleResponse().setScheduleId(resp.getScheduleId());
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
+
+  @Override
+  public com.uber.cadence.DescribeScheduleResponse DescribeSchedule(
+      com.uber.cadence.DescribeScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, CadenceError {
+    try {
+      com.uber.cadence.api.v1.DescribeScheduleResponse resp =
+          grpcServiceStubs
+              .scheduleBlockingStub()
+              .describeSchedule(RequestMapper.describeScheduleRequest(request));
+      return ResponseMapper.describeScheduleResponse(resp);
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
+
+  @Override
+  public void UpdateSchedule(com.uber.cadence.UpdateScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, CadenceError {
+    try {
+      grpcServiceStubs
+          .scheduleBlockingStub()
+          .updateSchedule(RequestMapper.updateScheduleRequest(request));
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
+
+  @Override
+  public void DeleteSchedule(com.uber.cadence.DeleteScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          CadenceError {
+    try {
+      grpcServiceStubs
+          .scheduleBlockingStub()
+          .deleteSchedule(RequestMapper.deleteScheduleRequest(request));
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
+
+  @Override
+  public void PauseSchedule(com.uber.cadence.PauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          CadenceError {
+    try {
+      grpcServiceStubs
+          .scheduleBlockingStub()
+          .pauseSchedule(RequestMapper.pauseScheduleRequest(request));
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
+
+  @Override
+  public void UnpauseSchedule(com.uber.cadence.UnpauseScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          CadenceError {
+    try {
+      grpcServiceStubs
+          .scheduleBlockingStub()
+          .unpauseSchedule(RequestMapper.unpauseScheduleRequest(request));
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
+
+  @Override
+  public void BackfillSchedule(com.uber.cadence.BackfillScheduleRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, DomainNotActiveError,
+          LimitExceededError, CadenceError {
+    try {
+      grpcServiceStubs
+          .scheduleBlockingStub()
+          .backfillSchedule(RequestMapper.backfillScheduleRequest(request));
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
+
+  @Override
+  public com.uber.cadence.ListSchedulesResponse ListSchedules(
+      com.uber.cadence.ListSchedulesRequest request)
+      throws BadRequestError, EntityNotExistsError, ServiceBusyError, CadenceError {
+    try {
+      com.uber.cadence.api.v1.ListSchedulesResponse resp =
+          grpcServiceStubs
+              .scheduleBlockingStub()
+              .listSchedules(RequestMapper.listSchedulesRequest(request));
+      return ResponseMapper.listSchedulesResponse(resp);
+    } catch (Exception e) {
+      throw toServiceClientException(e);
+    }
+  }
 }

--- a/src/test/java/com/uber/cadence/client/schedule/WorkflowClientScheduleTest.java
+++ b/src/test/java/com/uber/cadence/client/schedule/WorkflowClientScheduleTest.java
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+package com.uber.cadence.client.schedule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.uber.cadence.BackfillScheduleRequest;
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.DeleteScheduleRequest;
+import com.uber.cadence.DescribeScheduleRequest;
+import com.uber.cadence.DescribeScheduleResponse;
+import com.uber.cadence.ListSchedulesRequest;
+import com.uber.cadence.ListSchedulesResponse;
+import com.uber.cadence.PauseScheduleRequest;
+import com.uber.cadence.UnpauseScheduleRequest;
+import com.uber.cadence.UpdateScheduleRequest;
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.internal.sync.WorkflowClientInternal;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import java.time.Instant;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class WorkflowClientScheduleTest {
+
+  private static final String DOMAIN = "test-domain";
+  private static final String SCHEDULE_ID = "my-schedule";
+
+  private IWorkflowService service;
+  private WorkflowClient client;
+
+  @Before
+  public void setUp() throws Exception {
+    service = mock(IWorkflowService.class);
+    WorkflowClientOptions options = WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build();
+    client = WorkflowClientInternal.newInstance(service, options);
+  }
+
+  // --- createSchedule ---
+
+  @Test
+  public void createSchedule_sendsCorrectRequest() throws Exception {
+    ScheduleSpec spec = ScheduleSpec.newBuilder().setCronExpression("0 6 * * *").build();
+    ScheduleAction action =
+        ScheduleAction.newBuilder()
+            .setStartWorkflow(
+                ScheduleAction.StartWorkflowAction.newBuilder()
+                    .setWorkflowType("MyWorkflow")
+                    .setTaskList("tl")
+                    .build())
+            .build();
+    SchedulePolicies policies =
+        SchedulePolicies.newBuilder().setOverlapPolicy(ScheduleOverlapPolicy.SKIP_NEW).build();
+    ScheduleState state = new ScheduleState(false, null, null, null);
+
+    when(service.CreateSchedule(any())).thenReturn(new com.uber.cadence.CreateScheduleResponse());
+
+    client.createSchedule(SCHEDULE_ID, spec, action, policies, state, null);
+
+    ArgumentCaptor<CreateScheduleRequest> captor =
+        ArgumentCaptor.forClass(CreateScheduleRequest.class);
+    verify(service).CreateSchedule(captor.capture());
+    CreateScheduleRequest req = captor.getValue();
+    assertEquals(DOMAIN, req.getDomain());
+    assertEquals(SCHEDULE_ID, req.getScheduleId());
+    assertEquals(spec, req.getSpec());
+    assertEquals(action, req.getAction());
+    assertEquals(policies, req.getPolicies());
+  }
+
+  // --- describeSchedule ---
+
+  @Test
+  public void describeSchedule_mapsResponseFields() throws Exception {
+    ScheduleSpec spec = ScheduleSpec.newBuilder().setCronExpression("0 6 * * *").build();
+    ScheduleAction action =
+        ScheduleAction.newBuilder()
+            .setStartWorkflow(
+                ScheduleAction.StartWorkflowAction.newBuilder()
+                    .setWorkflowType("MyWorkflow")
+                    .setTaskList("tl")
+                    .build())
+            .build();
+    SchedulePolicies policies =
+        SchedulePolicies.newBuilder().setOverlapPolicy(ScheduleOverlapPolicy.SKIP_NEW).build();
+    ScheduleState state = new ScheduleState(false, null, null, null);
+    ScheduleInfo info = new ScheduleInfo(null, null, 5, null, null, Collections.emptyList(), 0, 0);
+
+    DescribeScheduleResponse resp = new DescribeScheduleResponse();
+    resp.setSpec(spec);
+    resp.setAction(action);
+    resp.setPolicies(policies);
+    resp.setState(state);
+    resp.setInfo(info);
+    when(service.DescribeSchedule(any())).thenReturn(resp);
+
+    ScheduleDescription desc = client.describeSchedule(SCHEDULE_ID);
+
+    ArgumentCaptor<DescribeScheduleRequest> captor =
+        ArgumentCaptor.forClass(DescribeScheduleRequest.class);
+    verify(service).DescribeSchedule(captor.capture());
+    assertEquals(DOMAIN, captor.getValue().getDomain());
+    assertEquals(SCHEDULE_ID, captor.getValue().getScheduleId());
+
+    assertEquals(spec, desc.getSpec());
+    assertEquals(action, desc.getAction());
+    assertEquals(policies, desc.getPolicies());
+    assertEquals(5L, desc.getInfo().getTotalRuns());
+  }
+
+  // --- updateSchedule: describe-first read-modify-write ---
+
+  @Test
+  public void updateSchedule_callsDescribeFirstThenUpdate() throws Exception {
+    ScheduleSpec original = ScheduleSpec.newBuilder().setCronExpression("0 6 * * *").build();
+    ScheduleSpec updated = ScheduleSpec.newBuilder().setCronExpression("0 12 * * *").build();
+    ScheduleAction action =
+        ScheduleAction.newBuilder()
+            .setStartWorkflow(
+                ScheduleAction.StartWorkflowAction.newBuilder()
+                    .setWorkflowType("MyWorkflow")
+                    .setTaskList("tl")
+                    .build())
+            .build();
+    SchedulePolicies policies = SchedulePolicies.newBuilder().build();
+    ScheduleState state = new ScheduleState(false, null, null, null);
+    ScheduleInfo info = new ScheduleInfo(null, null, 0, null, null, Collections.emptyList(), 0, 0);
+
+    DescribeScheduleResponse resp = new DescribeScheduleResponse();
+    resp.setSpec(original);
+    resp.setAction(action);
+    resp.setPolicies(policies);
+    resp.setState(state);
+    resp.setInfo(info);
+    when(service.DescribeSchedule(any())).thenReturn(resp);
+
+    client.updateSchedule(SCHEDULE_ID, desc -> desc.setSpec(updated));
+
+    // Verify describe was called first
+    verify(service).DescribeSchedule(any());
+
+    // Verify update was called with the mutated spec
+    ArgumentCaptor<UpdateScheduleRequest> captor =
+        ArgumentCaptor.forClass(UpdateScheduleRequest.class);
+    verify(service).UpdateSchedule(captor.capture());
+    UpdateScheduleRequest req = captor.getValue();
+    assertEquals(DOMAIN, req.getDomain());
+    assertEquals(SCHEDULE_ID, req.getScheduleId());
+    assertEquals(updated, req.getSpec());
+    assertEquals(action, req.getAction());
+    assertEquals(policies, req.getPolicies());
+  }
+
+  @Test
+  public void updateSchedule_doesNotUpdateWhenUpdaterReturnsUnchanged() throws Exception {
+    ScheduleSpec spec = ScheduleSpec.newBuilder().setCronExpression("0 6 * * *").build();
+    ScheduleAction action =
+        ScheduleAction.newBuilder()
+            .setStartWorkflow(
+                ScheduleAction.StartWorkflowAction.newBuilder()
+                    .setWorkflowType("MyWorkflow")
+                    .setTaskList("tl")
+                    .build())
+            .build();
+    SchedulePolicies policies = SchedulePolicies.newBuilder().build();
+    ScheduleState state = new ScheduleState(false, null, null, null);
+    ScheduleInfo info = new ScheduleInfo(null, null, 0, null, null, Collections.emptyList(), 0, 0);
+
+    DescribeScheduleResponse resp = new DescribeScheduleResponse();
+    resp.setSpec(spec);
+    resp.setAction(action);
+    resp.setPolicies(policies);
+    resp.setState(state);
+    resp.setInfo(info);
+    when(service.DescribeSchedule(any())).thenReturn(resp);
+
+    // Updater returns the same description unchanged
+    client.updateSchedule(SCHEDULE_ID, desc -> desc);
+
+    verify(service).DescribeSchedule(any());
+    // UpdateSchedule should still be called (server decides idempotency)
+    verify(service).UpdateSchedule(any());
+  }
+
+  // --- deleteSchedule ---
+
+  @Test
+  public void deleteSchedule_sendsCorrectRequest() throws Exception {
+    client.deleteSchedule(SCHEDULE_ID);
+
+    ArgumentCaptor<DeleteScheduleRequest> captor =
+        ArgumentCaptor.forClass(DeleteScheduleRequest.class);
+    verify(service).DeleteSchedule(captor.capture());
+    assertEquals(DOMAIN, captor.getValue().getDomain());
+    assertEquals(SCHEDULE_ID, captor.getValue().getScheduleId());
+  }
+
+  // --- pauseSchedule ---
+
+  @Test
+  public void pauseSchedule_sendsReasonInRequest() throws Exception {
+    client.pauseSchedule(SCHEDULE_ID, "maintenance");
+
+    ArgumentCaptor<PauseScheduleRequest> captor =
+        ArgumentCaptor.forClass(PauseScheduleRequest.class);
+    verify(service).PauseSchedule(captor.capture());
+    assertEquals(DOMAIN, captor.getValue().getDomain());
+    assertEquals(SCHEDULE_ID, captor.getValue().getScheduleId());
+    assertEquals("maintenance", captor.getValue().getReason());
+  }
+
+  // --- unpauseSchedule ---
+
+  @Test
+  public void unpauseSchedule_withoutPolicySendsNullCatchUp() throws Exception {
+    client.unpauseSchedule(SCHEDULE_ID, "done");
+
+    ArgumentCaptor<UnpauseScheduleRequest> captor =
+        ArgumentCaptor.forClass(UnpauseScheduleRequest.class);
+    verify(service).UnpauseSchedule(captor.capture());
+    assertEquals(DOMAIN, captor.getValue().getDomain());
+    assertEquals("done", captor.getValue().getReason());
+    assertEquals(null, captor.getValue().getCatchUpPolicy());
+  }
+
+  @Test
+  public void unpauseSchedule_withCatchUpPolicy() throws Exception {
+    client.unpauseSchedule(SCHEDULE_ID, "done", ScheduleCatchUpPolicy.SKIP);
+
+    ArgumentCaptor<UnpauseScheduleRequest> captor =
+        ArgumentCaptor.forClass(UnpauseScheduleRequest.class);
+    verify(service).UnpauseSchedule(captor.capture());
+    assertEquals(ScheduleCatchUpPolicy.SKIP, captor.getValue().getCatchUpPolicy());
+  }
+
+  // --- backfillSchedule ---
+
+  @Test
+  public void backfillSchedule_sendsCorrectTimeRange() throws Exception {
+    Instant start = Instant.ofEpochSecond(1000);
+    Instant end = Instant.ofEpochSecond(2000);
+
+    client.backfillSchedule(SCHEDULE_ID, start, end, ScheduleOverlapPolicy.BUFFER);
+
+    ArgumentCaptor<BackfillScheduleRequest> captor =
+        ArgumentCaptor.forClass(BackfillScheduleRequest.class);
+    verify(service).BackfillSchedule(captor.capture());
+    BackfillScheduleRequest req = captor.getValue();
+    assertEquals(DOMAIN, req.getDomain());
+    assertEquals(SCHEDULE_ID, req.getScheduleId());
+    assertEquals(start, req.getStartTime());
+    assertEquals(end, req.getEndTime());
+    assertEquals(ScheduleOverlapPolicy.BUFFER, req.getOverlapPolicy());
+  }
+
+  // --- listSchedules ---
+
+  @Test
+  public void listSchedules_returnsEntriesFromResponse() throws Exception {
+    ScheduleState state = new ScheduleState(false, null, null, null);
+    ScheduleListEntry entry = new ScheduleListEntry("s1", "MyWorkflow", state, "0 6 * * *");
+    ListSchedulesResponse resp = new ListSchedulesResponse();
+    resp.setSchedules(Collections.singletonList(entry));
+    resp.setNextPageToken("tok".getBytes());
+    when(service.ListSchedules(any())).thenReturn(resp);
+
+    ListSchedulesResult result = client.listSchedules(10, null);
+
+    ArgumentCaptor<ListSchedulesRequest> captor =
+        ArgumentCaptor.forClass(ListSchedulesRequest.class);
+    verify(service).ListSchedules(captor.capture());
+    assertEquals(DOMAIN, captor.getValue().getDomain());
+    assertEquals(10, captor.getValue().getPageSize());
+
+    assertEquals(1, result.getSchedules().size());
+    assertEquals("s1", result.getSchedules().get(0).getScheduleId());
+    assertNotNull(result.getNextPageToken());
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/compatibility/ClientObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ClientObjects.java
@@ -1198,6 +1198,90 @@ public class ClientObjects {
           .setFailoverVersion(1)
           .setGlobalDomain(true);
 
+  // --- Schedule fixtures ---
+
+  private static final com.uber.cadence.client.schedule.ScheduleSpec SCHEDULE_SPEC =
+      com.uber.cadence.client.schedule.ScheduleSpec.newBuilder()
+          .setCronExpression("0 6 * * *")
+          .setStartTime(java.time.Instant.ofEpochSecond(1000))
+          .setEndTime(java.time.Instant.ofEpochSecond(2000))
+          .setJitter(java.time.Duration.ofSeconds(60))
+          .build();
+
+  private static final com.uber.cadence.client.schedule.ScheduleAction SCHEDULE_ACTION =
+      com.uber.cadence.client.schedule.ScheduleAction.newBuilder()
+          .setStartWorkflow(
+              com.uber.cadence.client.schedule.ScheduleAction.StartWorkflowAction.newBuilder()
+                  .setWorkflowType("workflowType")
+                  .setTaskList("schedule-tl")
+                  .setWorkflowIdPrefix("sched-")
+                  .setExecutionStartToCloseTimeout(java.time.Duration.ofSeconds(60))
+                  .setTaskStartToCloseTimeout(java.time.Duration.ofSeconds(10))
+                  .build())
+          .build();
+
+  private static final com.uber.cadence.client.schedule.SchedulePolicies SCHEDULE_POLICIES =
+      com.uber.cadence.client.schedule.SchedulePolicies.newBuilder()
+          .setOverlapPolicy(com.uber.cadence.client.schedule.ScheduleOverlapPolicy.SKIP_NEW)
+          .setCatchUpPolicy(com.uber.cadence.client.schedule.ScheduleCatchUpPolicy.SKIP)
+          .setCatchUpWindow(java.time.Duration.ofSeconds(3600))
+          .setPauseOnFailure(true)
+          .setBufferLimit(5)
+          .setConcurrencyLimit(2)
+          .build();
+
+  public static final com.uber.cadence.CreateScheduleRequest CREATE_SCHEDULE_REQUEST =
+      new com.uber.cadence.CreateScheduleRequest()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setSpec(SCHEDULE_SPEC)
+          .setAction(SCHEDULE_ACTION)
+          .setPolicies(SCHEDULE_POLICIES);
+
+  public static final com.uber.cadence.DescribeScheduleRequest DESCRIBE_SCHEDULE_REQUEST =
+      new com.uber.cadence.DescribeScheduleRequest()
+          .setDomain("domain")
+          .setScheduleId("schedule-id");
+
+  public static final com.uber.cadence.UpdateScheduleRequest UPDATE_SCHEDULE_REQUEST =
+      new com.uber.cadence.UpdateScheduleRequest()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setSpec(SCHEDULE_SPEC)
+          .setAction(SCHEDULE_ACTION)
+          .setPolicies(SCHEDULE_POLICIES);
+
+  public static final com.uber.cadence.DeleteScheduleRequest DELETE_SCHEDULE_REQUEST =
+      new com.uber.cadence.DeleteScheduleRequest().setDomain("domain").setScheduleId("schedule-id");
+
+  public static final com.uber.cadence.PauseScheduleRequest PAUSE_SCHEDULE_REQUEST =
+      new com.uber.cadence.PauseScheduleRequest()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setReason("pausing");
+
+  public static final com.uber.cadence.UnpauseScheduleRequest UNPAUSE_SCHEDULE_REQUEST =
+      new com.uber.cadence.UnpauseScheduleRequest()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setReason("resuming")
+          .setCatchUpPolicy(com.uber.cadence.client.schedule.ScheduleCatchUpPolicy.SKIP);
+
+  public static final com.uber.cadence.BackfillScheduleRequest BACKFILL_SCHEDULE_REQUEST =
+      new com.uber.cadence.BackfillScheduleRequest()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setOverlapPolicy(com.uber.cadence.client.schedule.ScheduleOverlapPolicy.BUFFER)
+          .setStartTime(java.time.Instant.ofEpochSecond(1000))
+          .setEndTime(java.time.Instant.ofEpochSecond(2000))
+          .setBackfillId("bf-1");
+
+  public static final com.uber.cadence.ListSchedulesRequest LIST_SCHEDULES_REQUEST =
+      new com.uber.cadence.ListSchedulesRequest()
+          .setDomain("domain")
+          .setPageSize(50)
+          .setNextPageToken(utf8("token"));
+
   private ClientObjects() {}
 
   public static byte[] utf8(String value) {

--- a/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/ProtoObjects.java
@@ -1463,6 +1463,147 @@ public final class ProtoObjects {
   public static final RefreshWorkflowTasksResponse REFRESH_WORKFLOW_TASKS_RESPONSE =
       RefreshWorkflowTasksResponse.getDefaultInstance();
 
+  // --- Schedule fixtures ---
+
+  public static final Timestamp SCHEDULE_TIMESTAMP =
+      Timestamp.newBuilder().setSeconds(1000).build();
+  public static final Duration SCHEDULE_DURATION = Duration.newBuilder().setSeconds(60).build();
+
+  public static final ScheduleSpec SCHEDULE_SPEC =
+      ScheduleSpec.newBuilder()
+          .setCronExpression("0 6 * * *")
+          .setStartTime(SCHEDULE_TIMESTAMP)
+          .setEndTime(Timestamp.newBuilder().setSeconds(2000).build())
+          .setJitter(SCHEDULE_DURATION)
+          .build();
+
+  public static final ScheduleAction SCHEDULE_ACTION =
+      ScheduleAction.newBuilder()
+          .setStartWorkflow(
+              ScheduleAction.StartWorkflowAction.newBuilder()
+                  .setWorkflowType(WORKFLOW_TYPE)
+                  .setTaskList(TaskList.newBuilder().setName("schedule-tl").build())
+                  .setWorkflowIdPrefix("sched-")
+                  .setExecutionStartToCloseTimeout(SCHEDULE_DURATION)
+                  .setTaskStartToCloseTimeout(Duration.newBuilder().setSeconds(10).build())
+                  .build())
+          .build();
+
+  public static final SchedulePolicies SCHEDULE_POLICIES =
+      SchedulePolicies.newBuilder()
+          .setOverlapPolicy(ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_SKIP_NEW)
+          .setCatchUpPolicy(ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP)
+          .setCatchUpWindow(Duration.newBuilder().setSeconds(3600).build())
+          .setPauseOnFailure(true)
+          .setBufferLimit(5)
+          .setConcurrencyLimit(2)
+          .build();
+
+  public static final ScheduleState SCHEDULE_STATE =
+      ScheduleState.newBuilder()
+          .setPaused(true)
+          .setPauseInfo(
+              SchedulePauseInfo.newBuilder()
+                  .setReason("testing")
+                  .setPausedAt(SCHEDULE_TIMESTAMP)
+                  .setPausedBy("test-user")
+                  .build())
+          .build();
+
+  public static final ScheduleInfo SCHEDULE_INFO =
+      ScheduleInfo.newBuilder()
+          .setLastRunTime(SCHEDULE_TIMESTAMP)
+          .setNextRunTime(Timestamp.newBuilder().setSeconds(1060).build())
+          .setTotalRuns(42)
+          .setCreateTime(Timestamp.newBuilder().setSeconds(500).build())
+          .setLastUpdateTime(Timestamp.newBuilder().setSeconds(900).build())
+          .build();
+
+  public static final com.uber.cadence.api.v1.CreateScheduleRequest CREATE_SCHEDULE_REQUEST =
+      com.uber.cadence.api.v1.CreateScheduleRequest.newBuilder()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setSpec(SCHEDULE_SPEC)
+          .setAction(SCHEDULE_ACTION)
+          .setPolicies(SCHEDULE_POLICIES)
+          .build();
+
+  public static final com.uber.cadence.api.v1.DescribeScheduleRequest DESCRIBE_SCHEDULE_REQUEST =
+      com.uber.cadence.api.v1.DescribeScheduleRequest.newBuilder()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .build();
+
+  public static final com.uber.cadence.api.v1.UpdateScheduleRequest UPDATE_SCHEDULE_REQUEST =
+      com.uber.cadence.api.v1.UpdateScheduleRequest.newBuilder()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setSpec(SCHEDULE_SPEC)
+          .setAction(SCHEDULE_ACTION)
+          .setPolicies(SCHEDULE_POLICIES)
+          .build();
+
+  public static final com.uber.cadence.api.v1.DeleteScheduleRequest DELETE_SCHEDULE_REQUEST =
+      com.uber.cadence.api.v1.DeleteScheduleRequest.newBuilder()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .build();
+
+  public static final com.uber.cadence.api.v1.PauseScheduleRequest PAUSE_SCHEDULE_REQUEST =
+      com.uber.cadence.api.v1.PauseScheduleRequest.newBuilder()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setReason("pausing")
+          .build();
+
+  public static final com.uber.cadence.api.v1.UnpauseScheduleRequest UNPAUSE_SCHEDULE_REQUEST =
+      com.uber.cadence.api.v1.UnpauseScheduleRequest.newBuilder()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setReason("resuming")
+          .setCatchUpPolicy(ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP)
+          .build();
+
+  public static final com.uber.cadence.api.v1.BackfillScheduleRequest BACKFILL_SCHEDULE_REQUEST =
+      com.uber.cadence.api.v1.BackfillScheduleRequest.newBuilder()
+          .setDomain("domain")
+          .setScheduleId("schedule-id")
+          .setOverlapPolicy(ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER)
+          .setStartTime(SCHEDULE_TIMESTAMP)
+          .setEndTime(Timestamp.newBuilder().setSeconds(2000).build())
+          .setBackfillId("bf-1")
+          .build();
+
+  public static final com.uber.cadence.api.v1.ListSchedulesRequest LIST_SCHEDULES_REQUEST =
+      com.uber.cadence.api.v1.ListSchedulesRequest.newBuilder()
+          .setDomain("domain")
+          .setPageSize(50)
+          .setNextPageToken(utf8("token"))
+          .build();
+
+  public static final com.uber.cadence.api.v1.DescribeScheduleResponse DESCRIBE_SCHEDULE_RESPONSE =
+      com.uber.cadence.api.v1.DescribeScheduleResponse.newBuilder()
+          .setSpec(SCHEDULE_SPEC)
+          .setAction(SCHEDULE_ACTION)
+          .setPolicies(SCHEDULE_POLICIES)
+          .setState(SCHEDULE_STATE)
+          .setInfo(SCHEDULE_INFO)
+          .build();
+
+  public static final ScheduleListEntry SCHEDULE_LIST_ENTRY =
+      ScheduleListEntry.newBuilder()
+          .setScheduleId("schedule-id")
+          .setWorkflowType(WORKFLOW_TYPE)
+          .setState(ScheduleState.newBuilder().setPaused(false).build())
+          .setCronExpression("0 6 * * *")
+          .build();
+
+  public static final com.uber.cadence.api.v1.ListSchedulesResponse LIST_SCHEDULES_RESPONSE =
+      com.uber.cadence.api.v1.ListSchedulesResponse.newBuilder()
+          .addSchedules(SCHEDULE_LIST_ENTRY)
+          .setNextPageToken(utf8("token"))
+          .build();
+
   private ProtoObjects() {}
 
   public static Payload payload(String value) {

--- a/src/test/java/com/uber/cadence/internal/compatibility/proto/mappers/RequestMapperTest.java
+++ b/src/test/java/com/uber/cadence/internal/compatibility/proto/mappers/RequestMapperTest.java
@@ -278,7 +278,44 @@ public class RequestMapperTest<T, P extends Message> {
         testCase(
             ClientObjects.LIST_WORKFLOW_EXECUTIONS_REQUEST,
             ProtoObjects.LIST_WORKFLOW_EXECUTIONS_REQUEST,
-            RequestMapper::listWorkflowExecutionsRequest));
+            RequestMapper::listWorkflowExecutionsRequest),
+        // Schedule API
+        testCase(
+            ClientObjects.CREATE_SCHEDULE_REQUEST,
+            ProtoObjects.CREATE_SCHEDULE_REQUEST,
+            RequestMapper::createScheduleRequest,
+            "memo", // not mapped yet
+            "searchAttributes"), // not mapped yet
+        testCase(
+            ClientObjects.DESCRIBE_SCHEDULE_REQUEST,
+            ProtoObjects.DESCRIBE_SCHEDULE_REQUEST,
+            RequestMapper::describeScheduleRequest),
+        testCase(
+            ClientObjects.UPDATE_SCHEDULE_REQUEST,
+            ProtoObjects.UPDATE_SCHEDULE_REQUEST,
+            RequestMapper::updateScheduleRequest,
+            "searchAttributes"), // not mapped yet
+        testCase(
+            ClientObjects.DELETE_SCHEDULE_REQUEST,
+            ProtoObjects.DELETE_SCHEDULE_REQUEST,
+            RequestMapper::deleteScheduleRequest),
+        testCase(
+            ClientObjects.PAUSE_SCHEDULE_REQUEST,
+            ProtoObjects.PAUSE_SCHEDULE_REQUEST,
+            RequestMapper::pauseScheduleRequest,
+            "identity"), // optional field
+        testCase(
+            ClientObjects.UNPAUSE_SCHEDULE_REQUEST,
+            ProtoObjects.UNPAUSE_SCHEDULE_REQUEST,
+            RequestMapper::unpauseScheduleRequest),
+        testCase(
+            ClientObjects.BACKFILL_SCHEDULE_REQUEST,
+            ProtoObjects.BACKFILL_SCHEDULE_REQUEST,
+            RequestMapper::backfillScheduleRequest),
+        testCase(
+            ClientObjects.LIST_SCHEDULES_REQUEST,
+            ProtoObjects.LIST_SCHEDULES_REQUEST,
+            RequestMapper::listSchedulesRequest));
   }
 
   private static <T, P> Object[] testCase(


### PR DESCRIPTION
## What changed

Adds the full Cadence Schedules API to the Java SDK, bringing it on par with the Go and Python client.

### Public API (`WorkflowClient`)

| Method | Description |
|---|---|
| `createSchedule` | Create a recurring schedule |
| `describeSchedule` | Read spec, action, policies, state and runtime info |
| `updateSchedule` | Describe-first read-modify-write via `Function<ScheduleDescription, ScheduleDescription>` |
| `deleteSchedule` | Permanently remove a schedule |
| `pauseSchedule` | Stop firing, with a reason |
| `unpauseSchedule` | Resume firing with optional catch-up policy |
| `backfillSchedule` | Trigger historical firings for a closed time range |
| `listSchedules` | Paginated listing of all schedules in a domain |

### New types (`com.uber.cadence.client.schedule`)

`ScheduleSpec`, `ScheduleAction`, `SchedulePolicies`, `ScheduleState`, `ScheduleInfo`, `ScheduleDescription`, `ScheduleListEntry`, `ScheduleOverlapPolicy`, `ScheduleCatchUpPolicy`, `ListSchedulesResult`

### Plumbing

- `IGrpcServiceStubs` / `GrpcServiceStubs` – `scheduleBlockingStub` / `scheduleFutureStub`
- `WorkflowServiceGrpc` – all 8 methods via `ScheduleAPIGrpc`
- `IWorkflowService` / `IWorkflowServiceBase` – service contract
- `RequestMapper` (8), `ResponseMapper` (2), `TypeMapper` (6), `EnumMapper` (4) – full proto↔internal conversion
- 11 Thrift gen types in `src/gen/java/com/uber/cadence/`
- `TestWorkflowService` – stubs all 8 methods

## Tests

- `WorkflowClientScheduleTest` – 10 unit tests covering all 8 methods; describe-first update verified with `ArgumentCaptor`
- `RequestMapperTest` – 24 new parameterized cases (8 requests × null-safety / round-trip / field coverage)
- Full test suite: `BUILD SUCCESSFUL`

## Notes

- `updateSchedule` follows the describe-first pattern (mirrors Go/Python SDK)
- `unpauseSchedule(id, reason)` delegates to the overload with `null` catch-up policy (server default = SKIP)
- `memo` / `searchAttributes` on create/update and `identity` on pause are not yet mapped (fields exist in proto but have no Java SDK representation today; declared as `missingFields` in mapper tests)