### PR TITLE
fix: switch metrics default emit mode to histogram only (#1061)

### DIFF
--- a/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
+++ b/src/main/java/com/uber/cadence/internal/metrics/MetricsEmit.java
@@ -25,13 +25,9 @@ import com.uber.m3.util.Duration;
 /**
  * Helper utilities for dual-emitting metrics during timer to histogram migration.
  *
- * <p>This class provides utilities to support gradual migration from timer metrics to histogram
- * metrics. By default, both timer and histogram metrics are emitted to support gradual
- * dashboard/alert migration without requiring a flag day.
- *
- * <p>Migration path: 1. Use these helpers to emit both timers and histograms (default behavior) 2.
- * Update dashboards/alerts to use histogram metrics 3. In a future release, remove timer emission
- * and use histograms exclusively
+ * <p>This class provides utilities to support the timer to histogram migration. The default is now
+ * histogram-only emission. Users who still need timers can opt in via {@link
+ * MetricEmitMode#EMIT_TIMERS_ONLY} or {@link MetricEmitMode#EMIT_BOTH}.
  *
  * <p>Example usage:
  *
@@ -49,8 +45,8 @@ import com.uber.m3.util.Duration;
  * // ... do work ...
  * sw.stop();
  *
- * // Configure emission mode (optional, typically done at application startup)
- * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
+ * // Configure emission mode (optional, default is EMIT_HISTOGRAMS_ONLY)
+ * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
  * }</pre>
  */
 public final class MetricsEmit {
@@ -59,18 +55,18 @@ public final class MetricsEmit {
   public enum MetricEmitMode {
     /** Emit only timer metrics (legacy OSS behavior) */
     EMIT_TIMERS_ONLY,
-    /** Emit both timer and histogram metrics (default for migration) */
+    /** Emit both timer and histogram metrics (for migration) */
     EMIT_BOTH,
-    /** Emit only histogram metrics (post-migration) */
+    /** Emit only histogram metrics (default, post-migration) */
     EMIT_HISTOGRAMS_ONLY
   }
 
   /**
-   * Current emission mode. Default is EMIT_BOTH for migration. This should be set during
-   * application initialization (e.g., in static initializer or before starting workers). It should
-   * NOT be changed dynamically after workers have started.
+   * Current emission mode. Default is EMIT_HISTOGRAMS_ONLY (post-migration). This should be set
+   * during application initialization (e.g., in static initializer or before starting workers). It
+   * should NOT be changed dynamically after workers have started.
    */
-  private static volatile MetricEmitMode currentEmitMode = MetricEmitMode.EMIT_BOTH;
+  private static volatile MetricEmitMode currentEmitMode = MetricEmitMode.EMIT_HISTOGRAMS_ONLY;
 
   /**
    * Configures the metric emission strategy. This should be called during application
@@ -82,10 +78,10 @@ public final class MetricsEmit {
    * // To use only timers (legacy behavior)
    * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_TIMERS_ONLY);
    *
-   * // To use both (default, for migration)
+   * // To use both (for migration)
    * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
    *
-   * // To use only histograms (post-migration)
+   * // To use only histograms (default, no need to set)
    * MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
    * }</pre>
    */

--- a/src/main/java/com/uber/cadence/reporter/CadenceClientStatsReporter.java
+++ b/src/main/java/com/uber/cadence/reporter/CadenceClientStatsReporter.java
@@ -96,7 +96,7 @@ public class CadenceClientStatsReporter implements StatsReporter {
       Duration bucketLowerBound,
       Duration bucketUpperBound,
       long samples) {
-    // NOOP
+    // NOOP: histogram data is consumed via tally's native reporters, not the Micrometer bridge
   }
 
   private Iterable<Tag> getTags(Map<String, String> tags) {

--- a/src/test/java/com/uber/cadence/internal/metrics/MetricsEmitTest.java
+++ b/src/test/java/com/uber/cadence/internal/metrics/MetricsEmitTest.java
@@ -46,7 +46,7 @@ public class MetricsEmitTest {
     // Save original mode to restore after each test
     originalMode = MetricsEmit.getEmitMode();
     // Reset to default mode for each test
-    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_HISTOGRAMS_ONLY);
   }
 
   @After
@@ -57,6 +57,8 @@ public class MetricsEmitTest {
 
   @Test
   public void testEmitLatency_DualEmit() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
+
     when(mockScope.timer("test-metric")).thenReturn(mockTimer);
     when(mockScope.histogram(eq("test-metric_ns"), any())).thenReturn(mockHistogram);
 
@@ -70,6 +72,8 @@ public class MetricsEmitTest {
 
   @Test
   public void testStartLatency_DualEmit() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
+
     Stopwatch mockTimerSW = mock(Stopwatch.class);
     Stopwatch mockHistogramSW = mock(Stopwatch.class);
 
@@ -91,6 +95,8 @@ public class MetricsEmitTest {
 
   @Test
   public void testStartLatency_StopNotCalledTwice() {
+    MetricsEmit.setEmitMode(MetricEmitMode.EMIT_BOTH);
+
     Stopwatch mockTimerSW = mock(Stopwatch.class);
     Stopwatch mockHistogramSW = mock(Stopwatch.class);
 
@@ -135,8 +141,8 @@ public class MetricsEmitTest {
 
   @Test
   public void testEmitMode_Default() {
-    // Default mode should be EMIT_BOTH
-    assertEquals(MetricEmitMode.EMIT_BOTH, MetricsEmit.getEmitMode());
+    // Default mode should be EMIT_HISTOGRAMS_ONLY
+    assertEquals(MetricEmitMode.EMIT_HISTOGRAMS_ONLY, MetricsEmit.getEmitMode());
   }
 
   @Test

--- a/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/ActivityPollTaskTest.java
@@ -33,7 +33,6 @@ import com.uber.m3.tally.Counter;
 import com.uber.m3.tally.Histogram;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
-import com.uber.m3.tally.Timer;
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,13 +48,7 @@ public class ActivityPollTaskTest {
     mockService = mock(IWorkflowService.class);
     Scope metricsScope = mock(Scope.class); // Mock Scope to avoid NoopScope
 
-    // Mock the Timer and Stopwatch
-    Timer timer = mock(Timer.class);
-    Stopwatch stopwatch = mock(Stopwatch.class);
-    when(metricsScope.timer(MetricsType.ACTIVITY_POLL_LATENCY)).thenReturn(timer);
-    when(timer.start()).thenReturn(stopwatch);
-
-    // Mock the Histogram and its Stopwatch (for dual-emit)
+    // Mock the Histogram and its Stopwatch (histogram-only by default)
     Histogram histogram = mock(Histogram.class);
     Stopwatch histogramStopwatch = mock(Stopwatch.class);
     when(metricsScope.histogram(
@@ -92,17 +85,13 @@ public class ActivityPollTaskTest {
     when(mockService.PollForActivityTask(any(PollForActivityTaskRequest.class)))
         .thenReturn(response);
 
-    // Mock the timer and histogram behavior
+    // Mock the histogram behavior (default mode is EMIT_HISTOGRAMS_ONLY)
     Scope metricsScope = options.getMetricsScope();
-    Timer timer = mock(Timer.class);
     Histogram histogram = mock(Histogram.class);
-    when(metricsScope.timer(MetricsType.ACTIVITY_POLL_LATENCY)).thenReturn(timer);
     when(metricsScope.histogram(
             eq(MetricsType.ACTIVITY_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(histogram);
-    Stopwatch timerSw = mock(Stopwatch.class);
     Stopwatch histogramSw = mock(Stopwatch.class);
-    when(timer.start()).thenReturn(timerSw);
     when(histogram.start()).thenReturn(histogramSw);
 
     PollForActivityTaskResponse result = pollTask.pollTask();
@@ -110,11 +99,9 @@ public class ActivityPollTaskTest {
     assertNotNull(result);
     assertArrayEquals("testToken".getBytes(), result.getTaskToken());
 
-    // Verify the counters and the timer/histogram behavior (dual-emit)
+    // Verify the counters and the histogram behavior (histogram-only by default)
     verify(metricsScope.counter(MetricsType.ACTIVITY_POLL_COUNTER), times(1)).inc(1);
-    verify(timer, times(1)).start();
     verify(histogram, times(1)).start();
-    verify(timerSw, times(1)).stop();
     verify(histogramSw, times(1)).stop();
   }
 

--- a/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
+++ b/src/test/java/com/uber/cadence/internal/worker/WorkflowPollTaskTest.java
@@ -29,7 +29,6 @@ import com.uber.m3.tally.Counter;
 import com.uber.m3.tally.Histogram;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
-import com.uber.m3.tally.Timer;
 import com.uber.m3.util.Duration;
 import org.apache.thrift.TException;
 import org.junit.Before;
@@ -46,15 +45,11 @@ public class WorkflowPollTaskTest {
     mockService = mock(IWorkflowService.class);
     mockMetricScope = mock(Scope.class);
 
-    // Mock the Timer and Histogram for poll latency (dual-emit)
-    Timer pollLatencyTimer = mock(Timer.class);
+    // Mock the Histogram for poll latency (histogram-only by default)
     Histogram pollLatencyHistogram = mock(Histogram.class);
-    Stopwatch timerSw = mock(Stopwatch.class);
     Stopwatch histogramSw = mock(Stopwatch.class);
 
-    // Ensure timers and stopwatch are not null and return expected values
-    when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
-    when(pollLatencyTimer.start()).thenReturn(timerSw);
+    // Ensure histogram and stopwatch are not null and return expected values
     when(mockMetricScope.histogram(
             eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(pollLatencyHistogram);
@@ -104,13 +99,9 @@ public class WorkflowPollTaskTest {
     when(mockService.PollForDecisionTask(any(PollForDecisionTaskRequest.class)))
         .thenReturn(response);
 
-    // Mock the timer and histogram behavior (dual-emit)
-    Timer pollLatencyTimer = mock(Timer.class);
+    // Mock the histogram behavior (default mode is EMIT_HISTOGRAMS_ONLY)
     Histogram pollLatencyHistogram = mock(Histogram.class);
-    Stopwatch timerSw = mock(Stopwatch.class);
     Stopwatch histogramSw = mock(Stopwatch.class);
-    when(mockMetricScope.timer(MetricsType.DECISION_POLL_LATENCY)).thenReturn(pollLatencyTimer);
-    when(pollLatencyTimer.start()).thenReturn(timerSw);
     when(mockMetricScope.histogram(
             eq(MetricsType.DECISION_POLL_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX), any()))
         .thenReturn(pollLatencyHistogram);
@@ -121,16 +112,12 @@ public class WorkflowPollTaskTest {
     when(mockMetricScope.tagged(ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, "testWorkflowType")))
         .thenReturn(taggedScope);
 
-    // Mock scheduled-to-start latency timer and histogram (dual-emit)
-    Timer scheduledToStartLatencyTimer = mock(Timer.class);
+    // Mock scheduled-to-start latency histogram (histogram-only by default)
     Histogram scheduledToStartLatencyHistogram = mock(Histogram.class);
-    when(taggedScope.timer(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY))
-        .thenReturn(scheduledToStartLatencyTimer);
     when(taggedScope.histogram(
             eq(MetricsType.DECISION_SCHEDULED_TO_START_LATENCY + MetricsEmit.HISTOGRAM_SUFFIX),
             any()))
         .thenReturn(scheduledToStartLatencyHistogram);
-    doNothing().when(scheduledToStartLatencyTimer).record(any(Duration.class));
     doNothing().when(scheduledToStartLatencyHistogram).recordDuration(any(Duration.class));
 
     // Mock counters for DECISION_POLL_COUNTER and DECISION_POLL_SUCCEED_COUNTER
@@ -145,18 +132,16 @@ public class WorkflowPollTaskTest {
     assertNotNull(result);
     assertArrayEquals("testToken".getBytes(), result.getTaskToken());
 
-    // Verify counter and timer/histogram behavior (dual-emit)
+    // Verify counter and histogram behavior (histogram-only by default)
     verify(pollCounter, times(1)).inc(1);
     verify(succeedCounter, times(1)).inc(1);
-    verify(pollLatencyTimer, times(1)).start();
     verify(pollLatencyHistogram, times(1)).start();
-    verify(timerSw, times(1)).stop();
     verify(histogramSw, times(1)).stop();
 
-    // Verify that record() on scheduledToStartLatency metrics was called with correct duration
+    // Verify that recordDuration() on scheduledToStartLatency histogram was called with correct
+    // duration
     Duration expectedDuration =
         Duration.ofNanos(response.getStartedTimestamp() - response.getScheduledTimestamp());
-    verify(scheduledToStartLatencyTimer, times(1)).record(eq(expectedDuration));
     verify(scheduledToStartLatencyHistogram, times(1)).recordDuration(eq(expectedDuration));
   }
 

--- a/src/test/java/com/uber/cadence/reporter/CadenceClientStatsReporterTest.java
+++ b/src/test/java/com/uber/cadence/reporter/CadenceClientStatsReporterTest.java
@@ -97,6 +97,15 @@ public class CadenceClientStatsReporterTest {
     assertEquals(1.0, Metrics.globalRegistry.get(DEFAULT_REPORT_NAME).gauge().value(), 0);
   }
 
+  @Test
+  public void testHistogramDurationSamplesShouldBeNoop() {
+    cadenceClientStatsReporter.reportHistogramDurationSamples(
+        DEFAULT_REPORT_NAME, DEFAULT_REPORT_TAGS, null, Duration.ofSeconds(5), DEFAULT_DURATION, 3);
+
+    // Histogram duration samples are a NOOP - no metrics should be registered
+    assertEquals(0, Metrics.globalRegistry.getMeters().size());
+  }
+
   private void callDefaultCounter() {
     cadenceClientStatsReporter.reportCounter(
         DEFAULT_REPORT_NAME, DEFAULT_REPORT_TAGS, DEFAULT_COUNT);


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Cherry pick https://github.com/cadence-workflow/cadence-java-client/pull/1061 into release branch

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/cadence-workflow/cadence/issues/7741

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
./gradlew test --tests "com.uber.cadence.internal.metrics.MetricsEmitTest" --tests "com.uber.cadence.reporter.CadenceClientStatsReporterTest"

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
