### PR TITLE
feat(schedule): add clean-type overloads for createSchedule and updateSchedule

### DIFF
--- a/src/main/java/com/uber/cadence/client/ScheduleClient.java
+++ b/src/main/java/com/uber/cadence/client/ScheduleClient.java
@@ -27,6 +27,7 @@ import com.uber.cadence.UnpauseScheduleResponse;
 import com.uber.cadence.UpdateScheduleRequest;
 import com.uber.cadence.UpdateScheduleResponse;
 import com.uber.cadence.client.schedule.ScheduleAction;
+import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
 import com.uber.cadence.client.schedule.ScheduleDescription;
 import com.uber.cadence.client.schedule.SchedulePolicies;
 import com.uber.cadence.client.schedule.ScheduleSpec;
@@ -128,6 +129,18 @@ public interface ScheduleClient {
    * @param reason stored as the unpause note, visible in {@link #describeSchedule}
    */
   CompletableFuture<UnpauseScheduleResponse> unpauseSchedule(String scheduleId, String reason);
+
+  /**
+   * Resumes a paused schedule, overriding the catch-up policy for this unpause only. Use this when
+   * you want different catch-up behavior than the schedule's configured default, e.g. skipping all
+   * missed firings after a long pause.
+   *
+   * @param scheduleId the schedule identifier
+   * @param reason stored as the unpause note, visible in {@link #describeSchedule}
+   * @param catchUpPolicy catch-up policy to apply for missed firings on this unpause
+   */
+  CompletableFuture<UnpauseScheduleResponse> unpauseSchedule(
+      String scheduleId, String reason, ScheduleCatchUpPolicy catchUpPolicy);
 
   /**
    * Triggers runs for all times in the given historical ranges. One service call is made per entry.

--- a/src/main/java/com/uber/cadence/client/ScheduleClient.java
+++ b/src/main/java/com/uber/cadence/client/ScheduleClient.java
@@ -26,7 +26,10 @@ import com.uber.cadence.PauseScheduleResponse;
 import com.uber.cadence.UnpauseScheduleResponse;
 import com.uber.cadence.UpdateScheduleRequest;
 import com.uber.cadence.UpdateScheduleResponse;
+import com.uber.cadence.client.schedule.ScheduleAction;
 import com.uber.cadence.client.schedule.ScheduleDescription;
+import com.uber.cadence.client.schedule.SchedulePolicies;
+import com.uber.cadence.client.schedule.ScheduleSpec;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -57,6 +60,20 @@ public interface ScheduleClient {
       String scheduleId, CreateScheduleRequest request);
 
   /**
+   * Creates a new schedule using clean client types. Equivalent to constructing a {@link
+   * com.uber.cadence.CreateScheduleRequest} manually and calling {@link #createSchedule(String,
+   * com.uber.cadence.CreateScheduleRequest)}. Use the raw-request overload if you need to set memo
+   * or search attributes.
+   *
+   * @param scheduleId unique identifier for the schedule within the domain
+   * @param spec when and how often the schedule fires
+   * @param action what to do on each firing (start a workflow)
+   * @param policies overlap, catch-up, and failure-handling policies
+   */
+  CompletableFuture<CreateScheduleResponse> createSchedule(
+      String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies);
+
+  /**
    * Returns the current configuration and runtime state of a schedule.
    *
    * @param scheduleId the schedule identifier
@@ -73,6 +90,20 @@ public interface ScheduleClient {
    */
   CompletableFuture<UpdateScheduleResponse> updateSchedule(
       String scheduleId, UpdateScheduleRequest request);
+
+  /**
+   * Replaces the configuration of an existing schedule using clean client types. Equivalent to
+   * constructing an {@link com.uber.cadence.UpdateScheduleRequest} manually and calling {@link
+   * #updateSchedule(String, com.uber.cadence.UpdateScheduleRequest)}. Any field not included is
+   * cleared by the server; call {@link #describeSchedule} first to avoid losing existing settings.
+   *
+   * @param scheduleId the schedule identifier
+   * @param spec new schedule spec
+   * @param action new workflow action
+   * @param policies new overlap/catch-up/failure policies
+   */
+  CompletableFuture<UpdateScheduleResponse> updateSchedule(
+      String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies);
 
   /**
    * Permanently deletes a schedule. In-flight workflow runs triggered by this schedule are not

--- a/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
@@ -131,8 +131,17 @@ final class ScheduleClientImpl implements ScheduleClient {
   @Override
   public CompletableFuture<UnpauseScheduleResponse> unpauseSchedule(
       String scheduleId, String reason) {
+    return unpauseSchedule(scheduleId, reason, null);
+  }
+
+  @Override
+  public CompletableFuture<UnpauseScheduleResponse> unpauseSchedule(
+      String scheduleId, String reason, ScheduleCatchUpPolicy catchUpPolicy) {
     UnpauseScheduleRequest request =
         new UnpauseScheduleRequest().setDomain(domain).setScheduleId(scheduleId).setReason(reason);
+    if (catchUpPolicy != null) {
+      request.setCatchUpPolicy(toThriftCatchUpPolicy(catchUpPolicy));
+    }
     return service.UnpauseSchedule(request);
   }
 

--- a/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
@@ -80,12 +80,18 @@ final class ScheduleClientImpl implements ScheduleClient {
   @Override
   public CompletableFuture<CreateScheduleResponse> createSchedule(
       String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies) {
-    CreateScheduleRequest request =
-        new CreateScheduleRequest()
-            .setSpec(toThriftSpec(spec))
-            .setAction(toThriftAction(action))
-            .setPolicies(toThriftPolicies(policies));
-    return createSchedule(scheduleId, request);
+    try {
+      CreateScheduleRequest request =
+          new CreateScheduleRequest()
+              .setSpec(toThriftSpec(spec))
+              .setAction(toThriftAction(action))
+              .setPolicies(toThriftPolicies(policies));
+      return createSchedule(scheduleId, request);
+    } catch (Exception e) {
+      CompletableFuture<CreateScheduleResponse> f = new CompletableFuture<>();
+      f.completeExceptionally(e);
+      return f;
+    }
   }
 
   @Override
@@ -106,12 +112,18 @@ final class ScheduleClientImpl implements ScheduleClient {
   @Override
   public CompletableFuture<UpdateScheduleResponse> updateSchedule(
       String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies) {
-    UpdateScheduleRequest request =
-        new UpdateScheduleRequest()
-            .setSpec(toThriftSpec(spec))
-            .setAction(toThriftAction(action))
-            .setPolicies(toThriftPolicies(policies));
-    return updateSchedule(scheduleId, request);
+    try {
+      UpdateScheduleRequest request =
+          new UpdateScheduleRequest()
+              .setSpec(toThriftSpec(spec))
+              .setAction(toThriftAction(action))
+              .setPolicies(toThriftPolicies(policies));
+      return updateSchedule(scheduleId, request);
+    } catch (Exception e) {
+      CompletableFuture<UpdateScheduleResponse> f = new CompletableFuture<>();
+      f.completeExceptionally(e);
+      return f;
+    }
   }
 
   @Override

--- a/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
@@ -160,6 +160,8 @@ final class ScheduleClientImpl implements ScheduleClient {
   @Override
   public CompletableFuture<List<BackfillScheduleResponse>> backfillSchedule(
       String scheduleId, List<ScheduleBackfill> backfills) {
+    // Requests are dispatched concurrently; the server handles ordering and overlap-policy
+    // per-backfill. Results are collected in submission order.
     List<CompletableFuture<BackfillScheduleResponse>> futures = new ArrayList<>();
     for (ScheduleBackfill bf : backfills) {
       BackfillScheduleRequest request =

--- a/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
@@ -179,10 +179,12 @@ final class ScheduleClientImpl implements ScheduleClient {
     com.uber.cadence.ScheduleSpec t =
         new com.uber.cadence.ScheduleSpec().setCronExpression(s.getCronExpression());
     if (s.getStartTime() != null) {
-      t.setStartTimeNano(s.getStartTime().toEpochMilli() * 1_000_000L);
+      Instant si = s.getStartTime();
+      t.setStartTimeNano(si.getEpochSecond() * 1_000_000_000L + si.getNano());
     }
     if (s.getEndTime() != null) {
-      t.setEndTimeNano(s.getEndTime().toEpochMilli() * 1_000_000L);
+      Instant ei = s.getEndTime();
+      t.setEndTimeNano(ei.getEpochSecond() * 1_000_000_000L + ei.getNano());
     }
     if (s.getJitter() != null) {
       t.setJitterInSeconds((int) s.getJitter().getSeconds());
@@ -220,12 +222,34 @@ final class ScheduleClientImpl implements ScheduleClient {
     }
     if (sw.getMemo() != null && !sw.getMemo().isEmpty()) {
       Map<String, byte[]> fields = new HashMap<>();
-      sw.getMemo().forEach((k, v) -> fields.put(k, (byte[]) v));
+      sw.getMemo()
+          .forEach(
+              (k, v) -> {
+                if (!(v instanceof byte[])) {
+                  throw new IllegalArgumentException(
+                      "memo value for key '"
+                          + k
+                          + "' must be byte[], got "
+                          + (v == null ? "null" : v.getClass().getName()));
+                }
+                fields.put(k, (byte[]) v);
+              });
       t.setMemo(new Memo().setFields(fields));
     }
     if (sw.getSearchAttributes() != null && !sw.getSearchAttributes().isEmpty()) {
       Map<String, byte[]> indexedFields = new HashMap<>();
-      sw.getSearchAttributes().forEach((k, v) -> indexedFields.put(k, (byte[]) v));
+      sw.getSearchAttributes()
+          .forEach(
+              (k, v) -> {
+                if (!(v instanceof byte[])) {
+                  throw new IllegalArgumentException(
+                      "searchAttributes value for key '"
+                          + k
+                          + "' must be byte[], got "
+                          + (v == null ? "null" : v.getClass().getName()));
+                }
+                indexedFields.put(k, (byte[]) v);
+              });
       t.setSearchAttributes(new SearchAttributes().setIndexedFields(indexedFields));
     }
     return t;

--- a/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
+++ b/src/main/java/com/uber/cadence/internal/sync/ScheduleClientImpl.java
@@ -27,12 +27,18 @@ import com.uber.cadence.DescribeScheduleRequest;
 import com.uber.cadence.DescribeScheduleResponse;
 import com.uber.cadence.ListSchedulesRequest;
 import com.uber.cadence.ListSchedulesResponse;
+import com.uber.cadence.Memo;
 import com.uber.cadence.PauseScheduleRequest;
 import com.uber.cadence.PauseScheduleResponse;
+import com.uber.cadence.RetryPolicy;
+import com.uber.cadence.ScheduleStartWorkflowAction;
+import com.uber.cadence.SearchAttributes;
+import com.uber.cadence.TaskList;
 import com.uber.cadence.UnpauseScheduleRequest;
 import com.uber.cadence.UnpauseScheduleResponse;
 import com.uber.cadence.UpdateScheduleRequest;
 import com.uber.cadence.UpdateScheduleResponse;
+import com.uber.cadence.WorkflowType;
 import com.uber.cadence.client.ScheduleBackfill;
 import com.uber.cadence.client.ScheduleClient;
 import com.uber.cadence.client.schedule.ScheduleAction;
@@ -72,6 +78,17 @@ final class ScheduleClientImpl implements ScheduleClient {
   }
 
   @Override
+  public CompletableFuture<CreateScheduleResponse> createSchedule(
+      String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies) {
+    CreateScheduleRequest request =
+        new CreateScheduleRequest()
+            .setSpec(toThriftSpec(spec))
+            .setAction(toThriftAction(action))
+            .setPolicies(toThriftPolicies(policies));
+    return createSchedule(scheduleId, request);
+  }
+
+  @Override
   public CompletableFuture<ScheduleDescription> describeSchedule(String scheduleId) {
     DescribeScheduleRequest request =
         new DescribeScheduleRequest().setDomain(domain).setScheduleId(scheduleId);
@@ -84,6 +101,17 @@ final class ScheduleClientImpl implements ScheduleClient {
     request.setDomain(domain);
     request.setScheduleId(scheduleId);
     return service.UpdateSchedule(request);
+  }
+
+  @Override
+  public CompletableFuture<UpdateScheduleResponse> updateSchedule(
+      String scheduleId, ScheduleSpec spec, ScheduleAction action, SchedulePolicies policies) {
+    UpdateScheduleRequest request =
+        new UpdateScheduleRequest()
+            .setSpec(toThriftSpec(spec))
+            .setAction(toThriftAction(action))
+            .setPolicies(toThriftPolicies(policies));
+    return updateSchedule(scheduleId, request);
   }
 
   @Override
@@ -144,6 +172,111 @@ final class ScheduleClientImpl implements ScheduleClient {
             .setPageSize(pageSize)
             .setNextPageToken(nextPageToken);
     return service.ListSchedules(request);
+  }
+
+  private static com.uber.cadence.ScheduleSpec toThriftSpec(ScheduleSpec s) {
+    if (s == null) return null;
+    com.uber.cadence.ScheduleSpec t =
+        new com.uber.cadence.ScheduleSpec().setCronExpression(s.getCronExpression());
+    if (s.getStartTime() != null) {
+      t.setStartTimeNano(s.getStartTime().toEpochMilli() * 1_000_000L);
+    }
+    if (s.getEndTime() != null) {
+      t.setEndTimeNano(s.getEndTime().toEpochMilli() * 1_000_000L);
+    }
+    if (s.getJitter() != null) {
+      t.setJitterInSeconds((int) s.getJitter().getSeconds());
+    }
+    return t;
+  }
+
+  private static com.uber.cadence.ScheduleAction toThriftAction(ScheduleAction a) {
+    if (a == null) return null;
+    return new com.uber.cadence.ScheduleAction()
+        .setStartWorkflow(toThriftStartWorkflow(a.getStartWorkflow()));
+  }
+
+  private static ScheduleStartWorkflowAction toThriftStartWorkflow(
+      ScheduleAction.StartWorkflowAction sw) {
+    if (sw == null) return null;
+    ScheduleStartWorkflowAction t = new ScheduleStartWorkflowAction();
+    if (sw.getWorkflowType() != null) {
+      t.setWorkflowType(new WorkflowType().setName(sw.getWorkflowType()));
+    }
+    if (sw.getTaskList() != null) {
+      t.setTaskList(new TaskList().setName(sw.getTaskList()));
+    }
+    t.setInput(sw.getInput());
+    t.setWorkflowIdPrefix(sw.getWorkflowIdPrefix());
+    if (sw.getExecutionStartToCloseTimeout() != null) {
+      t.setExecutionStartToCloseTimeoutSeconds(
+          (int) sw.getExecutionStartToCloseTimeout().getSeconds());
+    }
+    if (sw.getTaskStartToCloseTimeout() != null) {
+      t.setTaskStartToCloseTimeoutSeconds((int) sw.getTaskStartToCloseTimeout().getSeconds());
+    }
+    if (sw.getRetryOptions() != null) {
+      t.setRetryPolicy(toThriftRetryPolicy(sw.getRetryOptions()));
+    }
+    if (sw.getMemo() != null && !sw.getMemo().isEmpty()) {
+      Map<String, byte[]> fields = new HashMap<>();
+      sw.getMemo().forEach((k, v) -> fields.put(k, (byte[]) v));
+      t.setMemo(new Memo().setFields(fields));
+    }
+    if (sw.getSearchAttributes() != null && !sw.getSearchAttributes().isEmpty()) {
+      Map<String, byte[]> indexedFields = new HashMap<>();
+      sw.getSearchAttributes().forEach((k, v) -> indexedFields.put(k, (byte[]) v));
+      t.setSearchAttributes(new SearchAttributes().setIndexedFields(indexedFields));
+    }
+    return t;
+  }
+
+  private static com.uber.cadence.SchedulePolicies toThriftPolicies(SchedulePolicies p) {
+    if (p == null) return null;
+    com.uber.cadence.SchedulePolicies t =
+        new com.uber.cadence.SchedulePolicies()
+            .setPauseOnFailure(p.isPauseOnFailure())
+            .setBufferLimit(p.getBufferLimit())
+            .setConcurrencyLimit(p.getConcurrencyLimit());
+    if (p.getOverlapPolicy() != null) {
+      t.setOverlapPolicy(toThriftOverlapPolicy(p.getOverlapPolicy()));
+    }
+    if (p.getCatchUpPolicy() != null) {
+      t.setCatchUpPolicy(toThriftCatchUpPolicy(p.getCatchUpPolicy()));
+    }
+    if (p.getCatchUpWindow() != null) {
+      t.setCatchUpWindowInSeconds((int) p.getCatchUpWindow().getSeconds());
+    }
+    return t;
+  }
+
+  private static com.uber.cadence.ScheduleCatchUpPolicy toThriftCatchUpPolicy(
+      ScheduleCatchUpPolicy p) {
+    switch (p) {
+      case SKIP:
+        return com.uber.cadence.ScheduleCatchUpPolicy.SKIP;
+      case ONE:
+        return com.uber.cadence.ScheduleCatchUpPolicy.ONE;
+      case ALL:
+        return com.uber.cadence.ScheduleCatchUpPolicy.ALL;
+      default:
+        throw new IllegalArgumentException("unknown ScheduleCatchUpPolicy: " + p);
+    }
+  }
+
+  private static RetryPolicy toThriftRetryPolicy(RetryOptions r) {
+    RetryPolicy t = new RetryPolicy().setBackoffCoefficient(r.getBackoffCoefficient());
+    if (r.getInitialInterval() != null) {
+      t.setInitialIntervalInSeconds((int) r.getInitialInterval().getSeconds());
+    }
+    if (r.getMaximumInterval() != null) {
+      t.setMaximumIntervalInSeconds((int) r.getMaximumInterval().getSeconds());
+    }
+    if (r.getExpiration() != null) {
+      t.setExpirationIntervalInSeconds((int) r.getExpiration().getSeconds());
+    }
+    t.setMaximumAttempts(r.getMaximumAttempts());
+    return t;
   }
 
   private static ScheduleDescription toScheduleDescription(DescribeScheduleResponse r) {

--- a/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
@@ -1,0 +1,357 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * <p>Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ * <p>http://aws.amazon.com/apache2.0
+ *
+ * <p>or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.uber.cadence.internal.sync;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.uber.cadence.CreateScheduleRequest;
+import com.uber.cadence.CreateScheduleResponse;
+import com.uber.cadence.UpdateScheduleRequest;
+import com.uber.cadence.UpdateScheduleResponse;
+import com.uber.cadence.client.schedule.ScheduleAction;
+import com.uber.cadence.client.schedule.ScheduleCatchUpPolicy;
+import com.uber.cadence.client.schedule.ScheduleOverlapPolicy;
+import com.uber.cadence.client.schedule.SchedulePolicies;
+import com.uber.cadence.client.schedule.ScheduleSpec;
+import com.uber.cadence.common.RetryOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class ScheduleClientImplTest {
+
+  private static final String DOMAIN = "test-domain";
+  private static final String SCHEDULE_ID = "test-schedule";
+
+  private IWorkflowService service;
+  private ScheduleClientImpl client;
+
+  @Before
+  public void setUp() throws Exception {
+    service = mock(IWorkflowService.class);
+    when(service.CreateSchedule(any())).thenReturn(new CreateScheduleResponse());
+    when(service.UpdateSchedule(any())).thenReturn(new UpdateScheduleResponse());
+    client = new ScheduleClientImpl(service, DOMAIN);
+  }
+
+  // --- toThriftSpec ---
+
+  @Test
+  public void createSchedule_spec_cronExpression() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().setCronExpression("* * * * *").build(),
+            minimalAction(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    assertEquals("* * * * *", captor.getValue().getSpec().getCronExpression());
+  }
+
+  @Test
+  public void createSchedule_spec_startEndTime_fullNanoPrecision() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    Instant start = Instant.ofEpochSecond(1_700_000_000L, 123_456_789L);
+    Instant end = Instant.ofEpochSecond(1_800_000_000L, 987_654_321L);
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().setStartTime(start).setEndTime(end).build(),
+            minimalAction(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    com.uber.cadence.ScheduleSpec spec = captor.getValue().getSpec();
+    assertEquals(
+        start.getEpochSecond() * 1_000_000_000L + start.getNano(), spec.getStartTimeNano());
+    assertEquals(end.getEpochSecond() * 1_000_000_000L + end.getNano(), spec.getEndTimeNano());
+  }
+
+  @Test
+  public void createSchedule_spec_nullStartEnd_leaveZero() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().setCronExpression("0 * * * *").build(),
+            minimalAction(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    com.uber.cadence.ScheduleSpec spec = captor.getValue().getSpec();
+    assertEquals(0L, spec.getStartTimeNano());
+    assertEquals(0L, spec.getEndTimeNano());
+  }
+
+  @Test
+  public void createSchedule_spec_jitter() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().setJitter(Duration.ofSeconds(30)).build(),
+            minimalAction(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    assertEquals(30, captor.getValue().getSpec().getJitterInSeconds());
+  }
+
+  // --- toThriftAction / toThriftStartWorkflow ---
+
+  @Test
+  public void createSchedule_action_workflowTypeAndTaskList() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().build(),
+            ScheduleAction.newBuilder()
+                .setStartWorkflow(
+                    ScheduleAction.StartWorkflowAction.newBuilder()
+                        .setWorkflowType("MyWorkflow")
+                        .setTaskList("my-tl")
+                        .build())
+                .build(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    com.uber.cadence.ScheduleStartWorkflowAction sw =
+        captor.getValue().getAction().getStartWorkflow();
+    assertEquals("MyWorkflow", sw.getWorkflowType().getName());
+    assertEquals("my-tl", sw.getTaskList().getName());
+  }
+
+  @Test
+  public void createSchedule_action_timeouts() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().build(),
+            ScheduleAction.newBuilder()
+                .setStartWorkflow(
+                    ScheduleAction.StartWorkflowAction.newBuilder()
+                        .setWorkflowType("wf")
+                        .setTaskList("tl")
+                        .setExecutionStartToCloseTimeout(Duration.ofSeconds(120))
+                        .setTaskStartToCloseTimeout(Duration.ofSeconds(10))
+                        .build())
+                .build(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    com.uber.cadence.ScheduleStartWorkflowAction sw =
+        captor.getValue().getAction().getStartWorkflow();
+    assertEquals(120, sw.getExecutionStartToCloseTimeoutSeconds());
+    assertEquals(10, sw.getTaskStartToCloseTimeoutSeconds());
+  }
+
+  @Test
+  public void createSchedule_action_retryPolicy() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    RetryOptions retry =
+        new RetryOptions.Builder()
+            .setInitialInterval(Duration.ofSeconds(1))
+            .setMaximumInterval(Duration.ofSeconds(60))
+            .setBackoffCoefficient(2.0)
+            .setMaximumAttempts(5)
+            .setExpiration(Duration.ofMinutes(10))
+            .build();
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().build(),
+            ScheduleAction.newBuilder()
+                .setStartWorkflow(
+                    ScheduleAction.StartWorkflowAction.newBuilder()
+                        .setWorkflowType("wf")
+                        .setTaskList("tl")
+                        .setRetryOptions(retry)
+                        .build())
+                .build(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    com.uber.cadence.RetryPolicy rp =
+        captor.getValue().getAction().getStartWorkflow().getRetryPolicy();
+    assertNotNull(rp);
+    assertEquals(1, rp.getInitialIntervalInSeconds());
+    assertEquals(60, rp.getMaximumIntervalInSeconds());
+    assertEquals(2.0, rp.getBackoffCoefficient(), 0.0);
+    assertEquals(5, rp.getMaximumAttempts());
+    assertEquals(600, rp.getExpirationIntervalInSeconds());
+  }
+
+  @Test
+  public void createSchedule_action_memo() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    byte[] value = "hello".getBytes();
+    Map<String, Object> memo = new HashMap<>();
+    memo.put("key", value);
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().build(),
+            ScheduleAction.newBuilder()
+                .setStartWorkflow(
+                    ScheduleAction.StartWorkflowAction.newBuilder()
+                        .setWorkflowType("wf")
+                        .setTaskList("tl")
+                        .setMemo(memo)
+                        .build())
+                .build(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+
+    assertArrayEquals(
+        value, captor.getValue().getAction().getStartWorkflow().getMemo().getFields().get("key"));
+  }
+
+  @Test(expected = java.util.concurrent.CompletionException.class)
+  public void createSchedule_action_memo_nonByteArrayValueThrows() {
+    Map<String, Object> memo = new HashMap<>();
+    memo.put("key", "not-a-byte-array");
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().build(),
+            ScheduleAction.newBuilder()
+                .setStartWorkflow(
+                    ScheduleAction.StartWorkflowAction.newBuilder()
+                        .setWorkflowType("wf")
+                        .setTaskList("tl")
+                        .setMemo(memo)
+                        .build())
+                .build(),
+            SchedulePolicies.newBuilder().build())
+        .join();
+  }
+
+  // --- toThriftPolicies ---
+
+  @Test
+  public void createSchedule_policies_overlapAndCatchUp() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    client
+        .createSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().build(),
+            minimalAction(),
+            SchedulePolicies.newBuilder()
+                .setOverlapPolicy(ScheduleOverlapPolicy.SKIP_NEW)
+                .setCatchUpPolicy(ScheduleCatchUpPolicy.ONE)
+                .setCatchUpWindow(Duration.ofMinutes(5))
+                .setPauseOnFailure(true)
+                .setBufferLimit(3)
+                .setConcurrencyLimit(2)
+                .build())
+        .join();
+
+    com.uber.cadence.SchedulePolicies p = captor.getValue().getPolicies();
+    assertEquals(com.uber.cadence.ScheduleOverlapPolicy.SKIP_NEW, p.getOverlapPolicy());
+    assertEquals(com.uber.cadence.ScheduleCatchUpPolicy.ONE, p.getCatchUpPolicy());
+    assertEquals(300, p.getCatchUpWindowInSeconds());
+    assertEquals(true, p.isPauseOnFailure());
+    assertEquals(3, p.getBufferLimit());
+    assertEquals(2, p.getConcurrencyLimit());
+  }
+
+  // --- updateSchedule overload ---
+
+  @Test
+  public void updateSchedule_cleanTypeOverload_setsFields() throws Exception {
+    ArgumentCaptor<UpdateScheduleRequest> captor = forClass(UpdateScheduleRequest.class);
+    when(service.UpdateSchedule(captor.capture())).thenReturn(new UpdateScheduleResponse());
+
+    client
+        .updateSchedule(
+            SCHEDULE_ID,
+            ScheduleSpec.newBuilder().setCronExpression("0 * * * *").build(),
+            minimalAction(),
+            SchedulePolicies.newBuilder()
+                .setOverlapPolicy(ScheduleOverlapPolicy.CONCURRENT)
+                .build())
+        .join();
+
+    UpdateScheduleRequest req = captor.getValue();
+    assertEquals(DOMAIN, req.getDomain());
+    assertEquals(SCHEDULE_ID, req.getScheduleId());
+    assertEquals("0 * * * *", req.getSpec().getCronExpression());
+    assertEquals(
+        com.uber.cadence.ScheduleOverlapPolicy.CONCURRENT, req.getPolicies().getOverlapPolicy());
+  }
+
+  // --- null handling ---
+
+  @Test
+  public void createSchedule_nullSpec_sendsNullSpec() throws Exception {
+    ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
+    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+
+    client.createSchedule(SCHEDULE_ID, null, minimalAction(), null).join();
+
+    assertNull(captor.getValue().getSpec());
+    assertNull(captor.getValue().getPolicies());
+  }
+
+  // --- helpers ---
+
+  private static ScheduleAction minimalAction() {
+    return ScheduleAction.newBuilder()
+        .setStartWorkflow(
+            ScheduleAction.StartWorkflowAction.newBuilder()
+                .setWorkflowType("wf")
+                .setTaskList("tl")
+                .build())
+        .build();
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/ScheduleClientImplTest.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -53,8 +54,10 @@ public class ScheduleClientImplTest {
   @Before
   public void setUp() throws Exception {
     service = mock(IWorkflowService.class);
-    when(service.CreateSchedule(any())).thenReturn(new CreateScheduleResponse());
-    when(service.UpdateSchedule(any())).thenReturn(new UpdateScheduleResponse());
+    when(service.CreateSchedule(any()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
+    when(service.UpdateSchedule(any()))
+        .thenReturn(CompletableFuture.completedFuture(new UpdateScheduleResponse()));
     client = new ScheduleClientImpl(service, DOMAIN);
   }
 
@@ -63,7 +66,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_spec_cronExpression() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     client
         .createSchedule(
@@ -79,7 +83,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_spec_startEndTime_fullNanoPrecision() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     Instant start = Instant.ofEpochSecond(1_700_000_000L, 123_456_789L);
     Instant end = Instant.ofEpochSecond(1_800_000_000L, 987_654_321L);
@@ -101,7 +106,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_spec_nullStartEnd_leaveZero() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     client
         .createSchedule(
@@ -119,7 +125,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_spec_jitter() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     client
         .createSchedule(
@@ -137,7 +144,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_action_workflowTypeAndTaskList() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     client
         .createSchedule(
@@ -162,7 +170,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_action_timeouts() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     client
         .createSchedule(
@@ -189,7 +198,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_action_retryPolicy() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     RetryOptions retry =
         new RetryOptions.Builder()
@@ -228,7 +238,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_action_memo() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     byte[] value = "hello".getBytes();
     Map<String, Object> memo = new HashMap<>();
@@ -279,7 +290,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_policies_overlapAndCatchUp() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     client
         .createSchedule(
@@ -310,7 +322,8 @@ public class ScheduleClientImplTest {
   @Test
   public void updateSchedule_cleanTypeOverload_setsFields() throws Exception {
     ArgumentCaptor<UpdateScheduleRequest> captor = forClass(UpdateScheduleRequest.class);
-    when(service.UpdateSchedule(captor.capture())).thenReturn(new UpdateScheduleResponse());
+    when(service.UpdateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new UpdateScheduleResponse()));
 
     client
         .updateSchedule(
@@ -335,7 +348,8 @@ public class ScheduleClientImplTest {
   @Test
   public void createSchedule_nullSpec_sendsNullSpec() throws Exception {
     ArgumentCaptor<CreateScheduleRequest> captor = forClass(CreateScheduleRequest.class);
-    when(service.CreateSchedule(captor.capture())).thenReturn(new CreateScheduleResponse());
+    when(service.CreateSchedule(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new CreateScheduleResponse()));
 
     client.createSchedule(SCHEDULE_ID, null, minimalAction(), null).join();
 


### PR DESCRIPTION
## What changed

Adds convenience overloads to `ScheduleClient` and `ScheduleClientImpl` so callers can use clean client types instead of raw Thrift gen types.

**Before:**
```java
ScheduleClient sc = workflowClient.scheduleClient();
CreateScheduleRequest request = new CreateScheduleRequest()
    .setSpec(new com.uber.cadence.ScheduleSpec().setCronExpression("* * * * *"))
    .setAction(new com.uber.cadence.ScheduleAction().setStartWorkflow(...))
    .setPolicies(new com.uber.cadence.SchedulePolicies()...);
sc.createSchedule("my-schedule", request).join();
```

**After:**
```java
sc.createSchedule(
    "my-schedule",
    ScheduleSpec.newBuilder().setCronExpression("* * * * *").build(),
    ScheduleAction.newBuilder().setStartWorkflow(
        StartWorkflowAction.newBuilder()
            .setWorkflowType("MyWorkflow")
            .setTaskList("my-tl")
            .build()).build(),
    SchedulePolicies.newBuilder().setOverlapPolicy(ScheduleOverlapPolicy.SKIP_NEW).build()
).join();
```

The raw-request overloads remain for callers that need to set memo or search attributes (which require Thrift gen types).

New private helpers in `ScheduleClientImpl`: `toThriftSpec`, `toThriftAction`, `toThriftStartWorkflow`, `toThriftPolicies`, `toThriftCatchUpPolicy`, `toThriftRetryPolicy`.

## Why

Makes the API surface usable without knowledge of generated Thrift types. Enables clean samples in `cadence-java-samples`.

## How it was tested

- `./gradlew compileJava -x generateProto` — clean build

## Dependencies

Stacked on `feat/schedule-impl` (#1069). Merge #1067 and #1069 first.