### PR TITLE
chore(test): fix flaky tests on TChannel span assertion

### DIFF
--- a/src/test/java/com/uber/cadence/FakeWorkflowServiceRule.java
+++ b/src/test/java/com/uber/cadence/FakeWorkflowServiceRule.java
@@ -8,8 +8,12 @@ import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.api.handlers.ThriftRequestHandler;
 import com.uber.tchannel.messages.ThriftRequest;
 import com.uber.tchannel.messages.ThriftResponse;
+import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,6 +26,8 @@ import org.junit.rules.ExternalResource;
  * particularly with TChannel being difficult to mock.
  */
 public class FakeWorkflowServiceRule extends ExternalResource {
+
+  private static final Duration SPAN_TIMEOUT = Duration.ofSeconds(5);
 
   private final Map<String, StubbedEndpoint> stubbedEndpoints = new ConcurrentHashMap<>();
   private final MockTracer tracer = new MockTracer();
@@ -87,6 +93,32 @@ public class FakeWorkflowServiceRule extends ExternalResource {
 
   public MockTracer getTracer() {
     return tracer;
+  }
+
+  /**
+   * Returns the first finished span with the given operation name, waiting for it to appear.
+   * TChannel finishes its client span from a response callback which may run after the calling
+   * thread has been unblocked, so spans are not guaranteed to be visible once the call returns.
+   */
+  public MockSpan awaitSpan(String operationName) {
+    long deadline = System.nanoTime() + SPAN_TIMEOUT.toNanos();
+    while (true) {
+      List<MockSpan> spans = tracer.finishedSpans();
+      Optional<MockSpan> span =
+          spans.stream().filter(s -> operationName.equals(s.operationName())).findFirst();
+      if (span.isPresent()) {
+        return span.get();
+      }
+      if (System.nanoTime() - deadline >= 0) {
+        throw new AssertionError("No span found for " + operationName + ", got: " + spans);
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted waiting for span " + operationName, e);
+      }
+    }
   }
 
   public <V> CompletableFuture<V> stubSuccess(

--- a/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
@@ -116,18 +116,9 @@ public class WorkflowClientInternalTest {
     stub.enqueueStart("input");
 
     StartWorkflowExecutionAsyncRequest request = requestFuture.getNow(null).getStartRequest();
-    MockSpan mockSpan =
-        fakeService
-            .getTracer()
-            .finishedSpans()
-            .stream()
-            .filter(span -> "cadence-StartWorkflowExecutionAsync".equals(span.operationName()))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new AssertionError(
-                        "No span found for StartWorkflowExecutionAsync:"
-                            + fakeService.getTracer().finishedSpans()));
+    // TChannel emits its own client span for the RPC in addition to the one the client creates
+    fakeService.awaitSpan("WorkflowService::StartWorkflowExecutionAsync");
+    MockSpan mockSpan = fakeService.awaitSpan("cadence-StartWorkflowExecutionAsync");
     assertEquals(
         mockSpan.context().toTraceId(),
         Charsets.UTF_8
@@ -279,21 +270,9 @@ public class WorkflowClientInternalTest {
 
     SignalWithStartWorkflowExecutionRequest request =
         requestFuture.getNow(null).getSignalWithStartRequest().getRequest();
-    assertEquals(2, fakeService.getTracer().finishedSpans().size());
-    MockSpan mockSpan =
-        fakeService
-            .getTracer()
-            .finishedSpans()
-            .stream()
-            .filter(
-                span ->
-                    "cadence-SignalWithStartWorkflowExecutionAsync".equals(span.operationName()))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new AssertionError(
-                        "No span found for SignalWithStartWorkflowExecutionAsync:"
-                            + fakeService.getTracer().finishedSpans()));
+    // TChannel emits its own client span for the RPC in addition to the one the client creates
+    fakeService.awaitSpan("WorkflowService::SignalWithStartWorkflowExecutionAsync");
+    MockSpan mockSpan = fakeService.awaitSpan("cadence-SignalWithStartWorkflowExecutionAsync");
     assertEquals(
         mockSpan.context().toTraceId(),
         Charsets.UTF_8.decode(request.getHeader().getFields().get("traceid")).toString());

--- a/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
@@ -143,6 +143,7 @@ public class StartWorkflowTest {
   private static final Logger logger = LoggerFactory.getLogger(StartWorkflowTest.class);
   private static final String DOMAIN = "test-domain";
   private static final String TASK_LIST = "test-tasklist";
+  private static final Duration SPAN_TIMEOUT = Duration.ofSeconds(30);
 
   @Test
   public void testStartWorkflowTchannel() {
@@ -195,9 +196,10 @@ public class StartWorkflowTest {
     worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class, DoubleWorkflowImpl.class);
     workerFactory.start();
 
+    int workflowCount = 100;
     List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < workflowCount; i++) {
       int finalI = i;
       futures.add(
           CompletableFuture.runAsync(
@@ -217,7 +219,12 @@ public class StartWorkflowTest {
       // test debug log
       StringBuilder sb = new StringBuilder();
 
-      List<MockSpan> spans = mockTracer.finishedSpans();
+      Map<String, Long> expectedSpans = new HashMap<>();
+      // each workflow runs an activity plus a child workflow which runs a local activity
+      expectedSpans.put("cadence-ExecuteWorkflow", 2L * workflowCount);
+      expectedSpans.put("cadence-ExecuteActivity", (long) workflowCount);
+      expectedSpans.put("cadence-ExecuteLocalActivity", (long) workflowCount);
+      List<MockSpan> spans = awaitSpans(mockTracer, expectedSpans);
       spans.forEach(
           span -> {
             sb.append(span.toString()).append("\n");
@@ -337,7 +344,16 @@ public class StartWorkflowTest {
       throw new AssertionError("workflow failure", e);
     } finally {
       rootSpan.finish();
-      List<MockSpan> spans = mockTracer.finishedSpans();
+      List<MockSpan> spans =
+          shouldPropagate
+              ? awaitSpans(
+                  mockTracer,
+                  "cadence-StartWorkflowExecution",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteActivity",
+                  "cadence-ExecuteLocalActivity")
+              : mockTracer.finishedSpans();
       spans.sort(
           (o1, o2) -> {
             if (o1.startMicros() < o2.startMicros()) {
@@ -431,7 +447,16 @@ public class StartWorkflowTest {
       throw new AssertionError("Workflow failure", e);
     } finally {
       rootSpan.finish();
-      List<MockSpan> spans = mockTracer.finishedSpans();
+      List<MockSpan> spans =
+          shouldPropagate
+              ? awaitSpans(
+                  mockTracer,
+                  "cadence-SignalWithStartWorkflowExecution",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteActivity",
+                  "cadence-ExecuteLocalActivity")
+              : mockTracer.finishedSpans();
       spans.sort(
           (o1, o2) -> {
             if (o1.startMicros() < o2.startMicros()) {
@@ -479,6 +504,49 @@ public class StartWorkflowTest {
         assertSpanReferences(spanExecuteLocalActivity, "follows_from", spanExecuteChildWF);
       }
       workerFactory.shutdown();
+    }
+  }
+
+  /**
+   * Returns the finished spans once every expected operation name is present, a repeated name
+   * requiring that many spans. Worker side spans are finished on worker threads after the client
+   * has already received the workflow result, so they aren't guaranteed to be visible as soon as
+   * the call returns.
+   */
+  private List<MockSpan> awaitSpans(MockTracer tracer, String... expectedOperationNames) {
+    return awaitSpans(
+        tracer,
+        Arrays.stream(expectedOperationNames)
+            .collect(Collectors.groupingBy(name -> name, Collectors.counting())));
+  }
+
+  private List<MockSpan> awaitSpans(MockTracer tracer, Map<String, Long> expectedOperationCounts) {
+    long deadline = System.nanoTime() + SPAN_TIMEOUT.toNanos();
+    while (true) {
+      List<MockSpan> spans = tracer.finishedSpans();
+      Map<String, Long> actual =
+          spans
+              .stream()
+              .collect(Collectors.groupingBy(span -> span.operationName(), Collectors.counting()));
+      boolean complete =
+          expectedOperationCounts
+              .entrySet()
+              .stream()
+              .allMatch(
+                  expected -> actual.getOrDefault(expected.getKey(), 0L) >= expected.getValue());
+      if (complete) {
+        return spans;
+      }
+      if (System.nanoTime() - deadline >= 0) {
+        throw new AssertionError(
+            "Timed out waiting for spans " + expectedOperationCounts + ", got: " + actual);
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted waiting for spans " + expectedOperationCounts, e);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* Add awaitSpan helper method
* fixed StartWorkflowTest and WorkflowClientInternalTest


<!-- Tell your future self why have you made these changes -->
**Why?**

TChannel can activate span but has race conditions on the callback. This would cause span assertions assuming it's synchronos. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**
no, it's pure test changes

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
