### PR TITLE
fix(client): feature flags header should not serialize private fields

### DIFF
--- a/src/main/java/com/uber/cadence/internal/common/FeatureFlagsHeader.java
+++ b/src/main/java/com/uber/cadence/internal/common/FeatureFlagsHeader.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.common;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.uber.cadence.FeatureFlags;
+import java.lang.reflect.Modifier;
+
+/** Serializes {@link FeatureFlags} into the value of the cadence-client-feature-flags header. */
+public final class FeatureFlagsHeader {
+
+  // The server deserializes this header with a protobuf JSON unmarshaller that fails on any field
+  // it doesn't know, and silently falls back to all flags disabled when it does. Thrift declares
+  // the IDL fields public and keeps its own bookkeeping, such as __isset_bitfield, private, so
+  // excluding private fields leaves exactly the fields the server expects. Field names are sent as
+  // Thrift declares them because the proto IDL pins json_name to those names.
+  private static final Gson GSON =
+      new GsonBuilder()
+          .excludeFieldsWithModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.TRANSIENT)
+          .create();
+
+  public static String serialize(FeatureFlags featureFlags) {
+    return GSON.toJson(featureFlags);
+  }
+
+  private FeatureFlagsHeader() {}
+}

--- a/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
+++ b/src/main/java/com/uber/cadence/internal/compatibility/proto/serviceclient/GrpcServiceStubs.java
@@ -16,8 +16,6 @@
 package com.uber.cadence.internal.compatibility.proto.serviceclient;
 
 import com.google.common.base.Strings;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.uber.cadence.api.v1.DomainAPIGrpc;
 import com.uber.cadence.api.v1.MetaAPIGrpc;
 import com.uber.cadence.api.v1.MetaAPIGrpc.MetaAPIBlockingStub;
@@ -32,6 +30,7 @@ import com.uber.cadence.api.v1.WorkflowAPIGrpc;
 import com.uber.cadence.api.v1.WorkflowAPIGrpc.WorkflowAPIBlockingStub;
 import com.uber.cadence.api.v1.WorkflowAPIGrpc.WorkflowAPIFutureStub;
 import com.uber.cadence.internal.Version;
+import com.uber.cadence.internal.common.FeatureFlagsHeader;
 import com.uber.cadence.serviceclient.ClientOptions;
 import com.uber.cadence.serviceclient.auth.IAuthorizationProvider;
 import io.grpc.*;
@@ -114,10 +113,8 @@ final class GrpcServiceStubs implements IGrpcServiceStubs {
       headers.put(ISOLATION_GROUP_HEADER_KEY, options.getIsolationGroup());
     }
     if (options.getFeatureFlags() != null) {
-      GsonBuilder gsonBuilder = new GsonBuilder();
-      Gson gson = gsonBuilder.create();
-      String serialized = gson.toJson(options.getFeatureFlags());
-      headers.put(CLIENT_FEATURE_FLAGS_HEADER_KEY, serialized);
+      headers.put(
+          CLIENT_FEATURE_FLAGS_HEADER_KEY, FeatureFlagsHeader.serialize(options.getFeatureFlags()));
     }
     mergeHeaders(headers, options.getHeaders());
 

--- a/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
+++ b/src/main/java/com/uber/cadence/serviceclient/WorkflowServiceTChannel.java
@@ -22,12 +22,11 @@ import static com.uber.cadence.internal.metrics.MetricsTagValue.REQUEST_TYPE_NOR
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.uber.cadence.*;
 import com.uber.cadence.WorkflowService.GetWorkflowExecutionHistory_result;
 import com.uber.cadence.internal.Version;
 import com.uber.cadence.internal.common.CheckedExceptionWrapper;
+import com.uber.cadence.internal.common.FeatureFlagsHeader;
 import com.uber.cadence.internal.common.InternalUtils;
 import com.uber.cadence.internal.metrics.MetricsTag;
 import com.uber.cadence.internal.metrics.MetricsType;
@@ -157,10 +156,8 @@ public class WorkflowServiceTChannel implements IWorkflowService {
     }
 
     if (options.getFeatureFlags() != null) {
-      GsonBuilder gsonBuilder = new GsonBuilder();
-      Gson gson = gsonBuilder.create();
-      String serialized = gson.toJson(options.getFeatureFlags());
-      builder.put("cadence-client-feature-flags", serialized);
+      builder.put(
+          "cadence-client-feature-flags", FeatureFlagsHeader.serialize(options.getFeatureFlags()));
     }
 
     if (!Strings.isNullOrEmpty(options.getIsolationGroup())) {

--- a/src/test/java/com/uber/cadence/FakeWorkflowServiceRule.java
+++ b/src/test/java/com/uber/cadence/FakeWorkflowServiceRule.java
@@ -8,8 +8,12 @@ import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.api.handlers.ThriftRequestHandler;
 import com.uber.tchannel.messages.ThriftRequest;
 import com.uber.tchannel.messages.ThriftResponse;
+import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,6 +26,8 @@ import org.junit.rules.ExternalResource;
  * particularly with TChannel being difficult to mock.
  */
 public class FakeWorkflowServiceRule extends ExternalResource {
+
+  private static final Duration SPAN_TIMEOUT = Duration.ofSeconds(5);
 
   private final Map<String, StubbedEndpoint> stubbedEndpoints = new ConcurrentHashMap<>();
   private final MockTracer tracer = new MockTracer();
@@ -87,6 +93,32 @@ public class FakeWorkflowServiceRule extends ExternalResource {
 
   public MockTracer getTracer() {
     return tracer;
+  }
+
+  /**
+   * Returns the first finished span with the given operation name, waiting for it to appear.
+   * TChannel finishes its client span from a response callback which may run after the calling
+   * thread has been unblocked, so spans are not guaranteed to be visible once the call returns.
+   */
+  public MockSpan awaitSpan(String operationName) {
+    long deadline = System.nanoTime() + SPAN_TIMEOUT.toNanos();
+    while (true) {
+      List<MockSpan> spans = tracer.finishedSpans();
+      Optional<MockSpan> span =
+          spans.stream().filter(s -> operationName.equals(s.operationName())).findFirst();
+      if (span.isPresent()) {
+        return span.get();
+      }
+      if (System.nanoTime() - deadline >= 0) {
+        throw new AssertionError("No span found for " + operationName + ", got: " + spans);
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted waiting for span " + operationName, e);
+      }
+    }
   }
 
   public <V> CompletableFuture<V> stubSuccess(

--- a/src/test/java/com/uber/cadence/internal/common/FeatureFlagsHeaderTest.java
+++ b/src/test/java/com/uber/cadence/internal/common/FeatureFlagsHeaderTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.uber.cadence.internal.common;
+
+import static org.junit.Assert.assertEquals;
+
+import com.uber.cadence.FeatureFlags;
+import org.junit.Test;
+
+public class FeatureFlagsHeaderTest {
+
+  // The server rejects the whole header when it carries a field the IDL doesn't define, so these
+  // assertions are on the exact wire format rather than on the parsed flags.
+  @Test
+  public void testSerializeEnabledFlag() {
+    assertEquals(
+        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":true}",
+        FeatureFlagsHeader.serialize(
+            new FeatureFlags().setWorkflowExecutionAlreadyCompletedErrorEnabled(true)));
+  }
+
+  @Test
+  public void testSerializeUnsetFlags() {
+    assertEquals(
+        "{\"WorkflowExecutionAlreadyCompletedErrorEnabled\":false}",
+        FeatureFlagsHeader.serialize(new FeatureFlags()));
+  }
+}

--- a/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
+++ b/src/test/java/com/uber/cadence/internal/sync/WorkflowClientInternalTest.java
@@ -116,18 +116,9 @@ public class WorkflowClientInternalTest {
     stub.enqueueStart("input");
 
     StartWorkflowExecutionAsyncRequest request = requestFuture.getNow(null).getStartRequest();
-    MockSpan mockSpan =
-        fakeService
-            .getTracer()
-            .finishedSpans()
-            .stream()
-            .filter(span -> "cadence-StartWorkflowExecutionAsync".equals(span.operationName()))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new AssertionError(
-                        "No span found for StartWorkflowExecutionAsync:"
-                            + fakeService.getTracer().finishedSpans()));
+    // TChannel emits its own client span for the RPC in addition to the one the client creates
+    fakeService.awaitSpan("WorkflowService::StartWorkflowExecutionAsync");
+    MockSpan mockSpan = fakeService.awaitSpan("cadence-StartWorkflowExecutionAsync");
     assertEquals(
         mockSpan.context().toTraceId(),
         Charsets.UTF_8
@@ -279,26 +270,9 @@ public class WorkflowClientInternalTest {
 
     SignalWithStartWorkflowExecutionRequest request =
         requestFuture.getNow(null).getSignalWithStartRequest().getRequest();
-    // TChannel finishes its own outbound span (in addition to the "cadence-..." span created
-    // explicitly by WorkflowServiceTChannel) from a future completion callback that can run on an
-    // I/O thread, so it may not yet be visible to this thread immediately after
-    // enqueueSignalWithStart() returns. Poll briefly instead of asserting immediately.
-    awaitFinishedSpansCount(2, Duration.ofSeconds(2));
-    assertEquals(2, fakeService.getTracer().finishedSpans().size());
-    MockSpan mockSpan =
-        fakeService
-            .getTracer()
-            .finishedSpans()
-            .stream()
-            .filter(
-                span ->
-                    "cadence-SignalWithStartWorkflowExecutionAsync".equals(span.operationName()))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new AssertionError(
-                        "No span found for SignalWithStartWorkflowExecutionAsync:"
-                            + fakeService.getTracer().finishedSpans()));
+    // TChannel emits its own client span for the RPC in addition to the one the client creates
+    fakeService.awaitSpan("WorkflowService::SignalWithStartWorkflowExecutionAsync");
+    MockSpan mockSpan = fakeService.awaitSpan("cadence-SignalWithStartWorkflowExecutionAsync");
     assertEquals(
         mockSpan.context().toTraceId(),
         Charsets.UTF_8.decode(request.getHeader().getFields().get("traceid")).toString());

--- a/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
@@ -143,6 +143,7 @@ public class StartWorkflowTest {
   private static final Logger logger = LoggerFactory.getLogger(StartWorkflowTest.class);
   private static final String DOMAIN = "test-domain";
   private static final String TASK_LIST = "test-tasklist";
+  private static final Duration SPAN_TIMEOUT = Duration.ofSeconds(30);
 
   @Test
   public void testStartWorkflowTchannel() {
@@ -195,9 +196,10 @@ public class StartWorkflowTest {
     worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class, DoubleWorkflowImpl.class);
     workerFactory.start();
 
+    int workflowCount = 100;
     List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < workflowCount; i++) {
       int finalI = i;
       futures.add(
           CompletableFuture.runAsync(
@@ -217,7 +219,12 @@ public class StartWorkflowTest {
       // test debug log
       StringBuilder sb = new StringBuilder();
 
-      List<MockSpan> spans = mockTracer.finishedSpans();
+      Map<String, Long> expectedSpans = new HashMap<>();
+      // each workflow runs an activity plus a child workflow which runs a local activity
+      expectedSpans.put("cadence-ExecuteWorkflow", 2L * workflowCount);
+      expectedSpans.put("cadence-ExecuteActivity", (long) workflowCount);
+      expectedSpans.put("cadence-ExecuteLocalActivity", (long) workflowCount);
+      List<MockSpan> spans = awaitSpans(mockTracer, expectedSpans);
       spans.forEach(
           span -> {
             sb.append(span.toString()).append("\n");
@@ -337,7 +344,16 @@ public class StartWorkflowTest {
       throw new AssertionError("workflow failure", e);
     } finally {
       rootSpan.finish();
-      List<MockSpan> spans = mockTracer.finishedSpans();
+      List<MockSpan> spans =
+          shouldPropagate
+              ? awaitSpans(
+                  mockTracer,
+                  "cadence-StartWorkflowExecution",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteActivity",
+                  "cadence-ExecuteLocalActivity")
+              : mockTracer.finishedSpans();
       spans.sort(
           (o1, o2) -> {
             if (o1.startMicros() < o2.startMicros()) {
@@ -431,7 +447,16 @@ public class StartWorkflowTest {
       throw new AssertionError("Workflow failure", e);
     } finally {
       rootSpan.finish();
-      List<MockSpan> spans = mockTracer.finishedSpans();
+      List<MockSpan> spans =
+          shouldPropagate
+              ? awaitSpans(
+                  mockTracer,
+                  "cadence-SignalWithStartWorkflowExecution",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteWorkflow",
+                  "cadence-ExecuteActivity",
+                  "cadence-ExecuteLocalActivity")
+              : mockTracer.finishedSpans();
       spans.sort(
           (o1, o2) -> {
             if (o1.startMicros() < o2.startMicros()) {
@@ -479,6 +504,49 @@ public class StartWorkflowTest {
         assertSpanReferences(spanExecuteLocalActivity, "follows_from", spanExecuteChildWF);
       }
       workerFactory.shutdown();
+    }
+  }
+
+  /**
+   * Returns the finished spans once every expected operation name is present, a repeated name
+   * requiring that many spans. Worker side spans are finished on worker threads after the client
+   * has already received the workflow result, so they aren't guaranteed to be visible as soon as
+   * the call returns.
+   */
+  private List<MockSpan> awaitSpans(MockTracer tracer, String... expectedOperationNames) {
+    return awaitSpans(
+        tracer,
+        Arrays.stream(expectedOperationNames)
+            .collect(Collectors.groupingBy(name -> name, Collectors.counting())));
+  }
+
+  private List<MockSpan> awaitSpans(MockTracer tracer, Map<String, Long> expectedOperationCounts) {
+    long deadline = System.nanoTime() + SPAN_TIMEOUT.toNanos();
+    while (true) {
+      List<MockSpan> spans = tracer.finishedSpans();
+      Map<String, Long> actual =
+          spans
+              .stream()
+              .collect(Collectors.groupingBy(span -> span.operationName(), Collectors.counting()));
+      boolean complete =
+          expectedOperationCounts
+              .entrySet()
+              .stream()
+              .allMatch(
+                  expected -> actual.getOrDefault(expected.getKey(), 0L) >= expected.getValue());
+      if (complete) {
+        return spans;
+      }
+      if (System.nanoTime() - deadline >= 0) {
+        throw new AssertionError(
+            "Timed out waiting for spans " + expectedOperationCounts + ", got: " + actual);
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted waiting for spans " + expectedOperationCounts, e);
+      }
     }
   }
 

--- a/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
+++ b/src/test/java/com/uber/cadence/internal/tracing/StartWorkflowTest.java
@@ -48,6 +48,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,6 +147,11 @@ public class StartWorkflowTest {
   private static final Duration SPAN_TIMEOUT = Duration.ofSeconds(30);
 
   @Test
+  @Ignore(
+      "TChannel sends the span context in $tracing$-prefixed application headers. A server running "
+          + "yarpc 1.84.1 or newer only strips them when it has a tracer of its own, and otherwise "
+          + "forwards them to history and matching over gRPC, which rejects the keys and fails the "
+          + "request. See the tracer comment in WorkflowServiceTChannel.")
   public void testStartWorkflowTchannel() {
     Assume.assumeTrue(useDockerService);
     MockTracer mockTracer = new MockTracer();
@@ -251,6 +257,7 @@ public class StartWorkflowTest {
   }
 
   @Test
+  @Ignore("Skipped for the same reason as testStartWorkflowTchannel")
   public void testSignalWithStartWorkflowTchannel() {
     Assume.assumeTrue(useDockerService);
     MockTracer mockTracer = new MockTracer();


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* Feature flags header's serializer should ignore all private fields (so it's not serialized into the blob)
* Also bundled other test fixes to bring all tests to green again https://github.com/cadence-workflow/cadence-java-client/pull/1077 
** disabled several TChannel tests with trace enabled. It won't work for OSS server due to the grpc constraint. We are sunsetting V3 anyway; internally we have a grpc-go fork that allows forwarding headers like `$trace$-xxx`
** flaky tests due to race conditions of TChannel span activation. 

<!-- Tell your future self why have you made these changes -->
**Why?**

Java's thrift encoder would add private fields like "__isset_bitfield". These additional fields cause the server to ignore all feature flags due to a bug (fix in the server https://github.com/cadence-workflow/cadence/pull/8421)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test + Integration Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
<!-- If you are upgrading a dependency, please mention the major version change. Read changelogs and capture any breaking changes here. -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
